### PR TITLE
Made docker utilizes cache mechanism. also change entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ RUN ln -s /usr/bin/clang-18 /usr/bin/clang \
     && ln -s /usr/bin/clang-cpp-18 /usr/bin/clang-cpp \
     && ln -s /usr/bin/clang-cpp-18 /usr/bin/clang++
 
-ENV CC /usr/bin/clang
-ENV CXX /usr/bin/clang++
+ENV CC=/usr/bin/clang
+ENV CXX=/usr/bin/clang++
 
 RUN mkdir /root/Mergen/build
 WORKDIR /root/Mergen/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     software-properties-common \
     gnupg \
     cmake \
-    git \
-    curl
+    git
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     wget https://apt.llvm.org/llvm.sh \


### PR DESCRIPTION
Hi, I found that docker build takes really long with current Dockerfile and I thought I can help u with it.

This PR significantly decreases build time. More specifically, when u change source files, because it's nothing to do with dependency list, u can completely skip dependency install step which is huge.

 so I made following changes:

- execute all dependency install first. because COPY all the source code before dependency install typically makes docker confuse and end up not caching.
- added `--mount=type=cache` to utilize cache type mount which persists between build layers.
- changed ENTRYPOINT from `/bin/bash` to `/root/Mergen/build/lifter` so that u can directly do `docker run -it --rm mergen FILEPATH ADDRESS`. Cuz I didnt see the benefit of going into bash. **If there's any benefit of run bash than directly lifter bin, tell me**

## speed in action in my env

These are the build logs for 

- subtle .cpp file change
- dependency change

When I make small change to cpp files it took 2.6 seconds to build. became way faster
![image](https://github.com/user-attachments/assets/e5c9a2c4-ba8f-4961-ba76-735f7b61b7e3)

When I add curl to dependency list, it takes 366 seconds to build which is ok cuz it's dependency build. maybe i can make it faster tho but it's out of scope for now. 
![image](https://github.com/user-attachments/assets/03042b8d-6dc2-4a86-8e06-f6b42ff2670d)

Also since i changed the entrypoint, u have to mount the directory into container like this `docker run --rm -v /Users/vxcall/Downloads:/root/Mergen/data mergen /root/Mergen/data/devirtualizeme.exe 0xADDRESS`