### PR TITLE
update Dockerfile for the user command to be simpler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,5 @@ RUN mkdir /root/Mergen/build
 WORKDIR /root/Mergen/build
 RUN cmake .. && cmake --build . -j $(nproc)
 
-ENTRYPOINT [ "/root/Mergen/build/lifter" ]
+WORKDIR /data
+ENTRYPOINT ["/bin/sh", "-c", "/root/Mergen/build/lifter \"$1\" \"$2\" ", "--"]

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -18,8 +18,19 @@ docker build . -t mergen
 
 ## Run
 
+Place target binary in the Mergen's root dir, then run following command.
+
+Note that you have to replace target.exe with your binary and 0x123456789 with your obfuscated function address.
+
 ```bash
-docker run -it --rm mergen
+# Powershell
+docker run --rm -v ${PWD}:/data mergen target.exe 0x123456789
+
+# command prompt
+docker run --rm -v %cd%:/data mergen target.exe 0x123456789
+
+# bash
+docker run --rm -v $PWD:/data mergen target.exe 0x123456789
 ```
 
 


### PR DESCRIPTION
The new command is in README.md

Now docker will spit out whatever file that lifter write down to host directory.

U can see `output.ll` and `output_finalnoopt.ll` after running the container!