### PR TITLE
Experimental pattern matching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ FetchContent_MakeAvailable(Zydis)
 
 # Target: lifter
 set(lifter_SOURCES
+	"lifter/FunctionSignatures.cpp"
 	"lifter/GEPTracker.cpp"
 	"lifter/OperandUtils.cpp"
 	"lifter/PathSolver.cpp"
@@ -66,6 +67,7 @@ set(lifter_SOURCES
 	"lifter/lifter.cpp"
 	"lifter/utils.cpp"
 	"lifter/CustomPasses.hpp"
+	"lifter/FunctionSignatures.h"
 	"lifter/GEPTracker.h"
 	"lifter/OperandUtils.h"
 	"lifter/PathSolver.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ set(lifter_SOURCES
 	"lifter/PathSolver.h"
 	"lifter/Semantics.h"
 	"lifter/includes.h"
+	"lifter/lifterClass.h"
 	"lifter/utils.h"
 	cmake.toml
 )

--- a/lifter/CustomPasses.hpp
+++ b/lifter/CustomPasses.hpp
@@ -210,71 +210,80 @@ public:
 class ResizeAllocatedStackPass
     : public llvm::PassInfoMixin<ResizeAllocatedStackPass> {
 public:
+  bool chainEnd(Instruction* inst) {
+    return isa<CallInst>(inst) || isa<LoadInst>(inst) || isa<StoreInst>(inst);
+  }
+  void chainLook(llvm::Module& M, Instruction* GEP,
+                 uint64_t& smallest_val_of_chain) {
+    for (auto user : GEP->users()) {
+      auto inst = cast<Instruction>(user);
+      auto offset = GEP->getOperand(1);
+      auto offsetKB = computeKnownBits(offset, M.getDataLayout());
+      smallest_val_of_chain += offsetKB.getMinValue().getZExtValue();
+      if (chainEnd(inst)) {
+        return;
+      }
+      chainLook(M, inst, smallest_val_of_chain);
+    }
+  }
   llvm::PreservedAnalyses run(llvm::Module& M, llvm::ModuleAnalysisManager&) {
-
     std::vector<llvm::Instruction*> toResize;
-
-    uint64_t smallest = -1;
+    uint64_t smallest = std::numeric_limits<uint64_t>::max();
     bool hasChanged = false;
 
     for (auto& F : M) {
       if (F.isDeclaration())
         continue;
-      Instruction* Allocated = &(F.getEntryBlock().front());
 
+      Instruction* Allocated = &(F.getEntryBlock().front());
       if (!isa<AllocaInst>(Allocated))
         continue;
+
       for (auto& BB : F) {
         for (auto& I : BB) {
           if (auto* GEP = llvm::dyn_cast<llvm::GetElementPtrInst>(&I)) {
             if (GEP->getOperand(0) == Allocated) {
-              auto offset = GEP->getOperand(1);
+              uint64_t smallest_val_of_chain = 0;
+              chainLook(M, GEP, smallest_val_of_chain);
+              smallest = std::min(smallest_val_of_chain, smallest);
               toResize.push_back(GEP);
-              // early continue if offset is a constant
-              if (ConstantInt* offsetCI = dyn_cast<ConstantInt>(offset)) {
-                smallest = std::min(offsetCI->getZExtValue(), smallest);
-                continue;
-              }
-              // if offsetCI is not a constant
-              auto offsetKB = computeKnownBits(offset, M.getDataLayout());
-              auto StackSize = APInt(64, STACKP_VALUE);
-              auto SSKB = KnownBits::makeConstant(StackSize);
-              if (KnownBits::ult(offsetKB, SSKB)) {
-                // minimum of offsetKB
-                smallest =
-                    std::min(offsetKB.getMinValue().getZExtValue(), smallest);
-              }
-              // endif
             }
           }
         }
       }
-      IRBuilder<> builder(M.getContext());
-      auto allocainst = cast<AllocaInst>(Allocated);
-      auto allocaType = allocainst->getAllocatedType();
 
-      auto allocationSize = M.getDataLayout().getTypeAllocSize(allocaType) / 16;
-      // / 16 because i128 is (i) 8 x 16
-      auto newSize = allocationSize - smallest;
+      if (smallest != std::numeric_limits<uint64_t>::max()) {
+        IRBuilder<> builder(M.getContext());
+        auto allocainst = cast<AllocaInst>(Allocated);
+        auto allocaType = allocainst->getAllocatedType();
 
-      Type* newType =
-          ArrayType::get(Type::getInt8Ty(allocainst->getContext()), newSize);
+        auto allocationSize =
+            M.getDataLayout().getTypeAllocSize(allocaType) / 16;
+        // / 16 because i128 is (i) 8 x 16
+        auto newSize = allocationSize - smallest;
+        Type* newType =
+            ArrayType::get(Type::getInt8Ty(allocainst->getContext()), newSize);
 
-      builder.SetInsertPoint(allocainst);
-      AllocaInst* newAlloca = builder.CreateAlloca(
-          newType, nullptr, allocainst->getName() + ".resized");
+        builder.SetInsertPoint(allocainst);
+        AllocaInst* newAlloca = builder.CreateAlloca(
+            newType, nullptr, allocainst->getName() + ".resized");
 
-      allocainst->replaceAllUsesWith(newAlloca);
-      allocainst->eraseFromParent();
+        allocainst->replaceAllUsesWith(newAlloca);
+        allocainst->eraseFromParent();
 
-      for (llvm::Instruction* GEPInst : toResize) {
-        builder.SetInsertPoint(GEPInst->getPrevNode());
-        auto val = GEPInst->getOperand(1);
-        Value* newval = builder.CreateSub(val, builder.getInt64(smallest));
-        val->replaceAllUsesWith(newval);
+        for (llvm::Instruction* GEPInst : toResize) {
+
+          builder.SetInsertPoint(GEPInst);
+
+          auto val = GEPInst->getOperand(1);
+
+          Value* newval = builder.CreateSub(val, builder.getInt64(smallest));
+          GEPInst->setOperand(1, newval);
+        }
+
+        toResize.clear();
+        hasChanged = true;
       }
-
-      toResize.clear();
     }
     return hasChanged ? llvm::PreservedAnalyses::none()
                       : llvm::PreservedAnalyses::all();

--- a/lifter/FunctionSignatures.h
+++ b/lifter/FunctionSignatures.h
@@ -31,7 +31,6 @@ namespace funcsignatures {
     functioninfo(const std::string& Name, const std::vector<funcArgInfo> Args,
                  const std::vector<unsigned char> Bytes)
         : name(Name), args(Args), bytes(Bytes) {}
-    std::vector<unsigned char> bytes;
     std::string name;
     //
     funcArgInfos args = {funcArgInfo(ZYDIS_REGISTER_RAX, I64, 0),
@@ -52,6 +51,7 @@ namespace funcsignatures {
                          funcArgInfo(ZYDIS_REGISTER_R15, I64, 0),
                          funcArgInfo(ZYDIS_REGISTER_DS, I64, 1)};
 
+    std::vector<unsigned char> bytes;
     // DS represents memory
     // (yeah i hate it aswell)
     // so the default is

--- a/lifter/GEPTracker.cpp
+++ b/lifter/GEPTracker.cpp
@@ -111,7 +111,7 @@ Value* lifterMemoryBuffer::retrieveCombinedValue(IRBuilder<>& builder,
     return nullptr;
   }
 
-  bool contiguous = true;
+  // bool contiguous = true;
 
   vector<ValueByteReferenceRange> values; // we can just create an array here
   for (uint64_t i = 0; i < byteCount; ++i) {
@@ -119,7 +119,7 @@ Value* lifterMemoryBuffer::retrieveCombinedValue(IRBuilder<>& builder,
     if (buffer[currentAddress] == nullptr ||
         buffer[currentAddress]->value != buffer[startAddress]->value ||
         buffer[currentAddress]->byteOffset != i) {
-      contiguous = false; // non-contiguous value
+      // contiguous = false; // non-contiguous value
     }
 
     // push if

--- a/lifter/GEPTracker.h
+++ b/lifter/GEPTracker.h
@@ -25,13 +25,13 @@ public:
     val(uint64_t addr) : memoryAddress(addr) {}
 
   } valinfo;
-  bool isRef;
 
   // size info, we can make this smaller because they can only be 0-8 range
   // (maybe higher for avx)
   uint8_t start;
   uint8_t end;
 
+  bool isRef;
   ValueByteReferenceRange(ValueByteReference* vref, uint8_t startv,
                           uint8_t endv)
       : valinfo(vref), start(startv), end(endv), isRef(true) {}

--- a/lifter/GEPTracker.h
+++ b/lifter/GEPTracker.h
@@ -43,7 +43,7 @@ public:
 
 class lifterMemoryBuffer {
 public:
-  std::unordered_map<uint64_t, ValueByteReference*> buffer;
+  DenseMap<uint64_t, ValueByteReference*> buffer;
   void addValueReference(Instruction* inst, Value* value, uint64_t address);
   Value* retrieveCombinedValue(IRBuilder<>& builder, uint64_t startAddress,
                                uint64_t byteCount, Value* orgLoad);
@@ -88,7 +88,7 @@ namespace GEPStoreTracker {
 
   void loadMemoryOp(LoadInst* inst);
 
-  Value* solveLoad(LoadInst* inst, bool buildTime = 1);
+  Value* solveLoad(LoadInst* inst);
 
 }; // namespace GEPStoreTracker
 

--- a/lifter/GEPTracker.h
+++ b/lifter/GEPTracker.h
@@ -77,6 +77,12 @@ namespace GEPStoreTracker {
   DominatorTree* getDomTree();
 
   void updateDomTree(Function& F);
+  struct APIntComparator {
+    bool operator()(const APInt& lhs, const APInt& rhs) const {
+      return lhs.ult(rhs); // unsigned less-than comparison
+    }
+  };
+  set<APInt, APIntComparator> computePossibleValues(Value* V);
 
   void updateMemoryOp(StoreInst* inst);
 

--- a/lifter/OperandUtils.cpp
+++ b/lifter/OperandUtils.cpp
@@ -9,6 +9,7 @@
 #include <llvm/Analysis/ValueTracking.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/PatternMatch.h>
 
 #ifndef TESTFOLDER
 #define TESTFOLDER
@@ -35,7 +36,7 @@ static void findAffectedValues(Value* Cond, SmallVectorImpl<Value*>& Affected) {
 
       Value* Op;
       if (match(I, m_PtrToInt(m_Value(Op)))) {
-        if (isa<Instruction>(Op) || isa<Argument>(Op))
+        if (isa<Instruction>(Op) || isa<Argument>(Op) && Op->hasNUsesOrMore(1))
           Affected.push_back(Op);
       }
     }
@@ -61,7 +62,8 @@ static void findAffectedValues(Value* Cond, SmallVectorImpl<Value*>& Affected) {
     }
   }
 }
-
+DomConditionCache* DC;
+unsigned long BIlistsize = 0;
 namespace GetSimplifyQuery {
 
   vector<BranchInst*> BIlist;
@@ -69,7 +71,8 @@ namespace GetSimplifyQuery {
     //
     BIlist.push_back(BI);
   }
-
+  unsigned int instct = 0;
+  SimplifyQuery* cachedquery;
   SimplifyQuery createSimplifyQuery(Function* fnc, Instruction* Inst) {
     AssumptionCache AC(*fnc);
     GEPStoreTracker::updateDomTree(*fnc);
@@ -78,16 +81,18 @@ namespace GetSimplifyQuery {
     static TargetLibraryInfoImpl TLIImpl(
         Triple(fnc->getParent()->getTargetTriple()));
     static TargetLibraryInfo TLI(TLIImpl);
+    if (BIlist.size() != BIlistsize) {
+      BIlistsize = BIlist.size();
+      DC = new DomConditionCache();
 
-    DomConditionCache* DC = new DomConditionCache();
+      for (auto BI : BIlist) {
 
-    for (auto BI : BIlist) {
-
-      DC->registerBranch(BI);
-      SmallVector<Value*, 16> Affected;
-      findAffectedValues(BI->getCondition(), Affected);
-      for (auto affectedvalues : Affected) {
-        printvalue(affectedvalues);
+        DC->registerBranch(BI);
+        SmallVector<Value*, 16> Affected;
+        findAffectedValues(BI->getCondition(), Affected);
+        for (auto affectedvalues : Affected) {
+          printvalue(affectedvalues);
+        }
       }
     }
 
@@ -116,7 +121,42 @@ using namespace llvm::PatternMatch;
 
 Value* doPatternMatching(Instruction::BinaryOps I, Value* op0, Value* op1) {
   Value* X = nullptr;
+  Value* Y = nullptr;
+  Value* Z = nullptr;
+
   switch (I) {
+  case Instruction::Add:
+  case Instruction::Or: {
+    Value *Z = nullptr, *A = nullptr, *B = nullptr, *C = nullptr;
+
+    // Match (~A & B) | (A & C)
+    if ((match(op0, m_And(m_Not(m_Value(X)), m_Value(B))) &&
+         match(op1, m_And(m_Value(X), m_Value(C)))) ||
+        (match(op1, m_And(m_Not(m_Value(X)), m_Value(B))) &&
+         match(op0, m_And(m_Value(X), m_Value(C))))) {
+      // This matches (~A & B) | (A & C)
+      // Simplify to A ? C : B
+
+      // X is ( max(v) - v)
+      printvalue(X);
+      printvalue(B);
+      printvalue(C);
+      if (auto X_inst = dyn_cast<Instruction>(X)) {
+        auto pv = GEPStoreTracker::computePossibleValues(X_inst);
+        if (pv.size() == 2) {
+          // check if pv is 0, -1
+
+          IRBuilder<> builder(cast<Instruction>(op0));
+          return createSelectFolder(builder, X, C, B, "selectEZ");
+        }
+      }
+
+      // printvalue2(tryCompute.getMinValue()); if 0
+      // printvalue2(tryCompute.getMaxValue()); if -1
+      // do the simplfiication
+    }
+    break;
+  }
   case Instruction::And: {
     // X & ~X
     // how the hell we remove this zext and truncs it looks horrible
@@ -165,8 +205,81 @@ Value* doPatternMatching(Instruction::BinaryOps I, Value* op0, Value* op1) {
       printvalue(possibleSimplify);
       return possibleSimplify;
     }
+    Value* A = nullptr;
+    Value* B = nullptr;
+    Value* C = nullptr;
+    Value* D = nullptr;
+    // not
+    if (match(op1, m_SpecificInt(-1)) &&
+        match(op0, m_Or(m_Value(A), m_Value(B)))) {
+      IRBuilder<> builder(cast<Instruction>(op0));
+      Constant* constant_v = nullptr;
+      if (match(A, m_Not(m_Value(C))) && match(B, m_Constant(constant_v))) {
+        // ~(~a | b)
+        // simplify to
+        // a & ~b
+        printvalue(C);
+        return createAndFolder(
+            builder, C,
+            createXorFolder(builder, constant_v,
+                            Constant::getAllOnesValue(constant_v->getType())),
+            "not-PConst-");
+      }
+
+      if (match(A, m_Value(C)) && match(B, m_Constant(constant_v))) {
+        // ~(a | b(ci))
+        // simplify to
+        // ~a & ~b
+        printvalue(C);
+        return createAndFolder(
+            builder,
+            createXorFolder(builder, C, Constant::getAllOnesValue(C->getType()),
+                            "not_v"),
+            createXorFolder(builder, constant_v,
+                            Constant::getAllOnesValue(constant_v->getType())),
+            "not-PConst2-");
+      }
+
+      if (match(A, m_Not(m_Value(C))) && match(B, m_Not(m_Value(D)))) {
+        // ~(~a | ~b)
+        // simplify to
+        // a & b
+        printvalue(C);
+        printvalue(D);
+        return createAndFolder(builder, C, D, "not-P1-");
+      }
+
+      if (match(A, m_Not(m_Value(C)))) {
+        // ~(~a | b)
+        // simplify to
+        // a & ~b
+        printvalue(C);
+        return createAndFolder(
+            builder,
+            createXorFolder(builder, B, Constant::getAllOnesValue(B->getType()),
+                            "not-p2A-"),
+            C, "not-P2-");
+      }
+
+      if (match(B, m_Not(m_Value(C)))) {
+        // ~(a | ~b)
+        // simplify to
+        // ~a & b
+        printvalue(C);
+        return createAndFolder(
+            builder,
+            createXorFolder(builder, C, Constant::getAllOnesValue(C->getType()),
+                            "not-p3A-"),
+            B, "not-p3-");
+      }
+
+      printvalue(A);
+      printvalue(B);
+    }
+
     break;
   }
+
   default: {
     return nullptr;
   }
@@ -174,130 +287,6 @@ Value* doPatternMatching(Instruction::BinaryOps I, Value* op0, Value* op1) {
 
   return nullptr;
 }
-
-static void computeKnownBitsFromCmp(Value* V, CmpInst::Predicate Pred,
-                                    Value* LHS, Value* RHS, KnownBits& Known,
-                                    const SimplifyQuery& Q) {
-  // Handle comparison of pointer to null explicitly, as it will not be
-  // covered by the m_APInt() logic below.
-
-  if (LHS == V && match(RHS, m_Zero())) {
-    int iszero = Pred;
-    switch (Pred) {
-    case ICmpInst::ICMP_EQ:
-      Known.setAllZero();
-      break;
-    case ICmpInst::ICMP_SGE:
-    case ICmpInst::ICMP_SGT:
-      Known.makeNonNegative();
-      break;
-    case ICmpInst::ICMP_SLT:
-      Known.makeNegative();
-      break;
-    default:
-      break;
-    }
-  }
-
-  unsigned BitWidth = Known.getBitWidth();
-  auto m_V =
-      m_CombineOr(m_Specific(V), m_PtrToIntSameSize(Q.DL, m_Specific(V)));
-
-  const APInt *Mask, *C;
-  uint64_t ShAmt;
-  switch (Pred) {
-  case ICmpInst::ICMP_EQ:
-    // assume(V = C)
-    if (match(LHS, m_V) && match(RHS, m_APInt(C))) {
-      Known = Known.unionWith(KnownBits::makeConstant(*C));
-      // assume(V & Mask = C)
-    } else if (match(LHS, m_And(m_V, m_APInt(Mask))) &&
-               match(RHS, m_APInt(C))) {
-      // For one bits in Mask, we can propagate bits from C to V.
-      Known.Zero |= ~*C & *Mask;
-      Known.One |= *C & *Mask;
-      // assume(V | Mask = C)
-    } else if (match(LHS, m_Or(m_V, m_APInt(Mask))) && match(RHS, m_APInt(C))) {
-      // For zero bits in Mask, we can propagate bits from C to V.
-      Known.Zero |= ~*C & ~*Mask;
-      Known.One |= *C & ~*Mask;
-      // assume(V ^ Mask = C)
-    } else if (match(LHS, m_Xor(m_V, m_APInt(Mask))) &&
-               match(RHS, m_APInt(C))) {
-      // Equivalent to assume(V == Mask ^ C)
-      Known = Known.unionWith(KnownBits::makeConstant(*C ^ *Mask));
-      // assume(V << ShAmt = C)
-    } else if (match(LHS, m_Shl(m_V, m_ConstantInt(ShAmt))) &&
-               match(RHS, m_APInt(C)) && ShAmt < BitWidth) {
-      // For those bits in C that are known, we can propagate them to known
-      // bits in V shifted to the right by ShAmt.
-      KnownBits RHSKnown = KnownBits::makeConstant(*C);
-      RHSKnown.Zero.lshrInPlace(ShAmt);
-      RHSKnown.One.lshrInPlace(ShAmt);
-      Known = Known.unionWith(RHSKnown);
-      // assume(V >> ShAmt = C)
-    } else if (match(LHS, m_Shr(m_V, m_ConstantInt(ShAmt))) &&
-               match(RHS, m_APInt(C)) && ShAmt < BitWidth) {
-      KnownBits RHSKnown = KnownBits::makeConstant(*C);
-      // For those bits in RHS that are known, we can propagate them to known
-      // bits in V shifted to the right by C.
-      Known.Zero |= RHSKnown.Zero << ShAmt;
-      Known.One |= RHSKnown.One << ShAmt;
-    }
-    break;
-  case ICmpInst::ICMP_NE: {
-    // assume (V & B != 0) where B is a power of 2
-    const APInt* BPow2;
-    if (match(LHS, m_And(m_V, m_Power2(BPow2))) && match(RHS, m_Zero()))
-      Known.One |= *BPow2;
-    break;
-  }
-  default:
-    const APInt* Offset = nullptr;
-    if (match(LHS, m_CombineOr(m_V, m_Add(m_V, m_APInt(Offset)))) &&
-        match(RHS, m_APInt(C))) {
-      ConstantRange LHSRange = ConstantRange::makeAllowedICmpRegion(Pred, *C);
-      if (Offset)
-        LHSRange = LHSRange.sub(*Offset);
-      Known = Known.unionWith(LHSRange.toKnownBits());
-    }
-    break;
-  }
-}
-
-void getKnownBitsFromContext(Value* V, KnownBits& Known,
-                             const SimplifyQuery& Q) {
-  if (!Q.CxtI)
-    return;
-  if (Q.DC && Q.DT) {
-
-    // Handle dominating conditions.
-    for (BranchInst* BI : Q.DC->conditionsFor(V)) {
-      auto* Cmp = dyn_cast<ICmpInst>(BI->getCondition());
-      printvalue(BI->getCondition());
-
-      if (!Cmp)
-        continue;
-
-      BasicBlockEdge Edge0(BI->getParent(), BI->getSuccessor(0));
-      if (Q.DT->dominates(Edge0, Q.CxtI->getParent()))
-        computeKnownBitsFromCmp(V, Cmp->getPredicate(), Cmp->getOperand(0),
-                                Cmp->getOperand(1), Known, Q);
-
-      BasicBlockEdge Edge1(BI->getParent(), BI->getSuccessor(1));
-      if (Q.DT->dominates(Edge1, Q.CxtI->getParent()))
-        computeKnownBitsFromCmp(V, Cmp->getInversePredicate(),
-                                Cmp->getOperand(0), Cmp->getOperand(1), Known,
-                                Q);
-    }
-    if (Known.hasConflict())
-      Known.resetAll();
-  }
-}
-
-// how to get all possible values
-// 1- find the value with least amount of known bits (excluding constants)
-// 2- then calculate
 
 KnownBits analyzeValueKnownBits(Value* value, Instruction* ctxI) {
 
@@ -313,11 +302,7 @@ KnownBits analyzeValueKnownBits(Value* value, Instruction* ctxI) {
   auto SQ = GetSimplifyQuery::createSimplifyQuery(
       ctxI->getParent()->getParent(), ctxI);
 
-  computeKnownBits(value, knownBits, 0, SQ);
-
-  // BLAME
-  if (knownBits.getBitWidth() < 64)
-    (&knownBits)->zext(64);
+  computeKnownBits(value, knownBits, -3, SQ);
 
   return knownBits;
 }
@@ -352,6 +337,12 @@ Value* simplifyValue(Value* v, const DataLayout& DL) {
 
     return vsimplified;
   }
+  if (inst->getOpcode() == Instruction::Add) {
+    auto testsimp = (simplifyBinOp(inst->getOpcode(), inst->getOperand(0),
+                                   inst->getOperand(1), SQ));
+    if (testsimp)
+      printvalue(testsimp);
+  }
 
   return v;
 }
@@ -384,6 +375,7 @@ Value* simplifyLoadValue(Value* v) {
 
 struct InstructionKey {
   unsigned opcode;
+  bool cast;
   Value* operand1;
   union {
     Value* operand2;
@@ -391,14 +383,21 @@ struct InstructionKey {
   };
 
   InstructionKey(unsigned opcode, Value* operand1, Value* operand2)
-      : opcode(opcode), operand1(operand1), operand2(operand2) {};
+      : opcode(opcode), cast(0), operand1(operand1), operand2(operand2){};
 
   InstructionKey(unsigned opcode, Value* operand1, Type* destType)
-      : opcode(opcode), operand1(operand1), destType(destType) {};
+      : opcode(opcode), cast(1), operand1(operand1), destType(destType){};
 
   bool operator==(const InstructionKey& other) const {
-    return opcode == other.opcode && operand1 == other.operand1 &&
-           operand2 == other.operand2 && destType == other.destType;
+    if (cast != other.cast)
+      return false;
+    if (cast) {
+      return opcode == other.opcode && operand1 == other.operand1 &&
+             destType == other.destType;
+    } else {
+      return opcode == other.opcode && operand1 == other.operand1 &&
+             operand2 == other.operand2;
+    }
   }
 };
 
@@ -421,45 +420,136 @@ public:
     }
 
     Value* newInstruction = nullptr;
-    if (key.operand2) {
+
+    if (key.cast == 0) {
+      printvalue2(key.opcode);
+      printvalue2(key.cast);
+      printvalue(key.operand1);
+      printvalue(key.operand2);
       // Binary instruction
+      if (auto select_inst = dyn_cast<SelectInst>(key.operand1)) {
+        printvalue2(
+            analyzeValueKnownBits(select_inst->getCondition(), select_inst));
+        if (isa<ConstantInt>(key.operand2))
+          return createSelectFolder(
+              builder, select_inst->getCondition(),
+              builder.CreateBinOp(
+                  static_cast<Instruction::BinaryOps>(key.opcode),
+                  select_inst->getTrueValue(), key.operand2),
+              builder.CreateBinOp(
+                  static_cast<Instruction::BinaryOps>(key.opcode),
+                  select_inst->getFalseValue(), key.operand2),
+              "lola-");
+      }
+
+      if (auto select_inst = dyn_cast<SelectInst>(key.operand2)) {
+        printvalue2(
+            analyzeValueKnownBits(select_inst->getCondition(), select_inst));
+        if (isa<ConstantInt>(key.operand1))
+          return createSelectFolder(
+              builder, select_inst->getCondition(),
+              builder.CreateBinOp(
+                  static_cast<Instruction::BinaryOps>(key.opcode), key.operand1,
+                  select_inst->getTrueValue()),
+              builder.CreateBinOp(
+                  static_cast<Instruction::BinaryOps>(key.opcode), key.operand1,
+                  select_inst->getFalseValue()),
+              "lolb-");
+      }
+      Value *select_inst1, *cnd1, *lhs1, *rhs1;
+      if (match(key.operand1,
+                m_TruncOrSelf(
+                    m_Select(m_Value(cnd1), m_Value(lhs1), m_Value(rhs1))))) {
+        if (auto select_inst = dyn_cast<SelectInst>(key.operand2))
+          if (select_inst && cnd1 == select_inst->getCondition()) // also check
+                                                                  // if inversed
+            return createSelectFolder(
+                builder, select_inst->getCondition(),
+                builder.CreateBinOp(
+                    static_cast<Instruction::BinaryOps>(key.opcode),
+                    select_inst->getTrueValue(), lhs1),
+                builder.CreateBinOp(
+                    static_cast<Instruction::BinaryOps>(key.opcode),
+                    select_inst->getFalseValue(), rhs1),
+                "lol2-");
+      }
+
+      else if (match(key.operand1,
+                     m_ZExtOrSExtOrSelf(m_Select(m_Value(cnd1), m_Value(lhs1),
+                                                 m_Value(rhs1))))) {
+        if (auto select_inst = dyn_cast<SelectInst>(key.operand2))
+          if (select_inst && cnd1 == select_inst->getCondition()) // also check
+                                                                  // if inversed
+            return createSelectFolder(
+                builder, select_inst->getCondition(),
+                builder.CreateBinOp(
+                    static_cast<Instruction::BinaryOps>(key.opcode),
+                    select_inst->getTrueValue(), lhs1),
+                builder.CreateBinOp(
+                    static_cast<Instruction::BinaryOps>(key.opcode),
+                    select_inst->getFalseValue(), rhs1),
+                "lol2-");
+      }
+
+      Value *select_inst2, *cnd, *lhs, *rhs;
+      if (match(key.operand2, m_TruncOrSelf(m_Select(m_Value(cnd), m_Value(lhs),
+                                                     m_Value(rhs))))) {
+        if (auto select_inst = dyn_cast<SelectInst>(key.operand1))
+          if (select_inst && cnd == select_inst->getCondition()) // also check
+                                                                 // if inversed
+            return createSelectFolder(
+                builder, select_inst->getCondition(),
+                builder.CreateBinOp(
+                    static_cast<Instruction::BinaryOps>(key.opcode),
+                    select_inst->getTrueValue(), lhs),
+                builder.CreateBinOp(
+                    static_cast<Instruction::BinaryOps>(key.opcode),
+                    select_inst->getFalseValue(), rhs),
+                "lol2-");
+      } else if (match(key.operand2,
+                       m_ZExtOrSExtOrSelf(m_Select(m_Value(cnd), m_Value(lhs),
+                                                   m_Value(rhs))))) {
+        if (auto select_inst = dyn_cast<SelectInst>(key.operand1))
+          if (select_inst && cnd == select_inst->getCondition()) // also check
+                                                                 // if inversed
+            return createSelectFolder(
+                builder, select_inst->getCondition(),
+                builder.CreateBinOp(
+                    static_cast<Instruction::BinaryOps>(key.opcode),
+                    select_inst->getTrueValue(), lhs),
+                builder.CreateBinOp(
+                    static_cast<Instruction::BinaryOps>(key.opcode),
+                    select_inst->getFalseValue(), rhs),
+                "lol2-");
+      }
       newInstruction =
           builder.CreateBinOp(static_cast<Instruction::BinaryOps>(key.opcode),
                               key.operand1, key.operand2, Name);
-    } else if (key.destType) {
+    } else if (key.cast) {
       // Cast instruction
       switch (key.opcode) {
+
       case Instruction::Trunc:
-        newInstruction = builder.CreateTrunc(key.operand1, key.destType, Name);
-        break;
       case Instruction::ZExt:
-        newInstruction = builder.CreateZExt(key.operand1, key.destType, Name);
-        break;
       case Instruction::SExt:
-        newInstruction = builder.CreateSExt(key.operand1, key.destType, Name);
+        printvalue(key.operand1);
+        if (auto select_inst = dyn_cast<SelectInst>(key.operand1)) {
+          return createSelectFolder(
+              builder, select_inst->getCondition(),
+              builder.CreateCast(static_cast<Instruction::CastOps>(key.opcode),
+                                 select_inst->getTrueValue(), key.destType),
+              builder.CreateCast(static_cast<Instruction::CastOps>(key.opcode),
+                                 select_inst->getFalseValue(), key.destType),
+              "lol-");
+        }
+
+        newInstruction =
+            builder.CreateCast(static_cast<Instruction::CastOps>(key.opcode),
+                               key.operand1, key.destType);
         break;
       // Add other cast operations as needed
       default:
         llvm_unreachable("Unsupported cast opcode");
-      }
-    } else {
-      // Unary instruction
-      switch (key.opcode) {
-      case Instruction::Trunc:
-        newInstruction =
-            builder.CreateTrunc(key.operand1, key.operand1->getType(), Name);
-        break;
-      case Instruction::ZExt:
-        newInstruction =
-            builder.CreateZExt(key.operand1, key.operand1->getType(), Name);
-        break;
-      case Instruction::SExt:
-        newInstruction =
-            builder.CreateSExt(key.operand1, key.operand1->getType(), Name);
-        break;
-      // Add other unary operations as needed
-      default:
-        llvm_unreachable("Unsupported unary opcode");
       }
     }
 
@@ -476,10 +566,13 @@ Value* createInstruction(IRBuilder<>& builder, unsigned opcode, Value* operand1,
   static InstructionCache cache;
   DataLayout DL(builder.GetInsertBlock()->getParent()->getParent());
 
-  InstructionKey key = {opcode, operand1,
-                        (Value*)((uint64_t)operand2 | (uint64_t)destType)};
+  InstructionKey* key;
+  if (destType)
+    key = new InstructionKey(opcode, operand1, destType);
+  else
+    key = new InstructionKey(opcode, operand1, operand2);
 
-  Value* newValue = cache.getOrCreate(builder, key, Name);
+  Value* newValue = cache.getOrCreate(builder, *key, Name);
 
   return simplifyValue(newValue, DL);
 }
@@ -515,23 +608,25 @@ Value* createAddFolder(IRBuilder<>& builder, Value* LHS, Value* RHS,
       return LHS;
   }
 #endif
-
+  if (auto simplifiedByPM = doPatternMatching(Instruction::Add, LHS, RHS))
+    return simplifiedByPM;
   auto addret =
       createInstruction(builder, Instruction::Add, LHS, RHS, nullptr, Name);
 
   auto SQ = GetSimplifyQuery::createSimplifyQuery(
       builder.GetInsertBlock()->getParent(), dyn_cast<Instruction>(addret));
 
-  KnownBits LHSKB(64);
-  getKnownBitsFromContext(LHS, LHSKB, SQ);
+  if (auto ctxI = dyn_cast<Instruction>(addret)) {
+    auto LHSKB = analyzeValueKnownBits(LHS, dyn_cast<Instruction>(addret));
 
-  KnownBits RHSKB(64);
-  getKnownBitsFromContext(LHS, RHSKB, SQ);
+    auto RHSKB = analyzeValueKnownBits(RHS, dyn_cast<Instruction>(addret));
+    // monke pattern matching for converting inc dec to -~x and ~-x
+    auto tryCompute = KnownBits::computeForAddSub(1, 0, LHSKB, RHSKB);
 
-  auto tryCompute = KnownBits::computeForAddSub(1, 0, LHSKB, RHSKB);
-  if (tryCompute.isConstant() && !tryCompute.hasConflict())
-    return builder.getIntN(LHS->getType()->getIntegerBitWidth(),
-                           tryCompute.getConstant().getZExtValue());
+    if (tryCompute.isConstant() && !tryCompute.hasConflict())
+      return builder.getIntN(LHS->getType()->getIntegerBitWidth(),
+                             tryCompute.getConstant().getZExtValue());
+  }
   return addret;
 }
 
@@ -544,22 +639,25 @@ Value* createSubFolder(IRBuilder<>& builder, Value* LHS, Value* RHS,
   }
 #endif
   DataLayout DL(builder.GetInsertBlock()->getParent()->getParent());
-  // sub x, y => add x, -y
-  auto subret = createInstruction(builder, Instruction::Add, LHS,
-                                  builder.CreateNeg(RHS), nullptr, Name);
-  auto SQ = GetSimplifyQuery::createSimplifyQuery(
-      builder.GetInsertBlock()->getParent(), dyn_cast<Instruction>(subret));
 
-  KnownBits LHSKB(64);
-  getKnownBitsFromContext(LHS, LHSKB, SQ);
+  if (auto simplifiedByPM = doPatternMatching(Instruction::Sub, LHS, RHS))
+    return simplifiedByPM;
 
-  KnownBits RHSKB(64);
-  getKnownBitsFromContext(LHS, RHSKB, SQ);
+  auto subret =
+      createInstruction(builder, Instruction::Sub, LHS, RHS, nullptr, Name);
+  if (auto ctxI = dyn_cast<Instruction>(subret)) {
+    auto SQ = GetSimplifyQuery::createSimplifyQuery(
+        builder.GetInsertBlock()->getParent(), dyn_cast<Instruction>(subret));
 
-  auto tryCompute = KnownBits::computeForAddSub(0, 0, LHSKB, RHSKB);
-  if (tryCompute.isConstant() && !tryCompute.hasConflict())
-    return builder.getIntN(LHS->getType()->getIntegerBitWidth(),
-                           tryCompute.getConstant().getZExtValue());
+    auto LHSKB = analyzeValueKnownBits(LHS, dyn_cast<Instruction>(subret));
+
+    auto RHSKB = analyzeValueKnownBits(RHS, dyn_cast<Instruction>(subret));
+
+    auto tryCompute = KnownBits::computeForAddSub(0, 0, LHSKB, RHSKB);
+    if (tryCompute.isConstant() && !tryCompute.hasConflict())
+      return builder.getIntN(LHS->getType()->getIntegerBitWidth(),
+                             tryCompute.getConstant().getZExtValue());
+  }
 
   return subret;
 }
@@ -734,7 +832,8 @@ Value* createOrFolder(IRBuilder<>& builder, Value* LHS, Value* RHS,
     if (RHSConst->isZero())
       return LHS;
   }
-
+  if (auto simplifiedByPM = doPatternMatching(Instruction::Or, LHS, RHS))
+    return simplifiedByPM;
   auto result =
       createInstruction(builder, Instruction::Or, LHS, RHS, nullptr, Name);
   if (auto ctxI = dyn_cast<Instruction>(result)) {
@@ -793,7 +892,8 @@ Value* createXorFolder(IRBuilder<>& builder, Value* LHS, Value* RHS,
     if (RHSConst->isZero())
       return LHS;
   }
-
+  printvalue(LHS);
+  printvalue(RHS);
 #endif
   auto result =
       createInstruction(builder, Instruction::Xor, LHS, RHS, nullptr, Name);
@@ -843,6 +943,11 @@ std::optional<bool> foldKnownBits(CmpInst::Predicate P, KnownBits LHS,
 
 Value* ICMPPatternMatcher(IRBuilder<>& builder, CmpInst::Predicate P,
                           Value* LHS, Value* RHS, const Twine& Name) {
+  if (auto SI = dyn_cast<SelectInst>(LHS)) {
+    if (RHS == SI->getTrueValue())
+      return SI->getCondition();
+    // do stuff
+  }
   switch (P) {
   case CmpInst::ICMP_UGT: {
     // Check if LHS is the result of a call to @llvm.ctpop.i64
@@ -879,17 +984,7 @@ Value* ICMPPatternMatcher(IRBuilder<>& builder, CmpInst::Predicate P,
   // cmp x, a, -b
 
   // lhs is a bin op
-  if (auto* AddInst = dyn_cast<BinaryOperator>(LHS)) {
-    auto binOpcode = AddInst->getOpcode();
-    if (binOpcode == Instruction::Add || binOpcode == Instruction::Sub) {
-      Value* A = AddInst->getOperand(0);
-      Value* B = AddInst->getOperand(1);
-      if (binOpcode == Instruction::Add)
-        B = builder.CreateNeg(B);
-      Value* NewB = builder.CreateAdd(RHS, B);
-      return builder.CreateICmp(P, A, NewB, Name);
-    }
-  }
+
   return nullptr;
 }
 
@@ -987,7 +1082,8 @@ Value* createAndFolder(IRBuilder<>& builder, Value* LHS, Value* RHS,
 // - probably not needed anymore
 Value* createTruncFolder(IRBuilder<>& builder, Value* V, Type* DestTy,
                          const Twine& Name) {
-  Value* result = builder.CreateTrunc(V, DestTy, Name);
+  Value* result =
+      createInstruction(builder, Instruction::Trunc, V, nullptr, DestTy, Name);
 
   DataLayout DL(builder.GetInsertBlock()->getParent()->getParent());
   if (auto ctxI = dyn_cast<Instruction>(result)) {
@@ -1010,7 +1106,8 @@ Value* createTruncFolder(IRBuilder<>& builder, Value* V, Type* DestTy,
 
 Value* createZExtFolder(IRBuilder<>& builder, Value* V, Type* DestTy,
                         const Twine& Name) {
-  auto result = builder.CreateZExt(V, DestTy, Name);
+  auto result =
+      createInstruction(builder, Instruction::ZExt, V, nullptr, DestTy, Name);
   DataLayout DL(builder.GetInsertBlock()->getParent()->getParent());
 #ifdef TESTFOLDER8
   if (auto ctxI = dyn_cast<Instruction>(result)) {
@@ -1035,32 +1132,18 @@ Value* createZExtOrTruncFolder(IRBuilder<>& builder, Value* V, Type* DestTy,
 
 Value* createSExtFolder(IRBuilder<>& builder, Value* V, Type* DestTy,
                         const Twine& Name) {
-#ifdef TESTFOLDER9
-
-  if (V->getType() == DestTy) {
-    return V;
-  }
-
-  if (auto* TruncInsts = dyn_cast<TruncInst>(V)) {
-    Value* OriginalValue = TruncInsts->getOperand(0);
-    Type* OriginalType = OriginalValue->getType();
-
-    if (OriginalType == DestTy) {
-      return OriginalValue;
-    }
-  }
-
-  if (auto* ConstInt = dyn_cast<ConstantInt>(V)) {
-    return ConstantInt::get(
-        DestTy, ConstInt->getValue().sextOrTrunc(DestTy->getIntegerBitWidth()));
-  }
-
-  if (auto* SExtInsts = dyn_cast<SExtInst>(V)) {
-    return builder.CreateSExt(SExtInsts->getOperand(0), DestTy, Name);
+  auto result =
+      createInstruction(builder, Instruction::SExt, V, nullptr, DestTy, Name);
+  DataLayout DL(builder.GetInsertBlock()->getParent()->getParent());
+#ifdef TESTFOLDER8
+  if (auto ctxI = dyn_cast<Instruction>(result)) {
+    KnownBits KnownRHS = analyzeValueKnownBits(result, ctxI);
+    if (!KnownRHS.hasConflict() && KnownRHS.getBitWidth() > 1 &&
+        KnownRHS.isConstant())
+      return ConstantInt::get(DestTy, KnownRHS.getConstant());
   }
 #endif
-
-  return builder.CreateSExt(V, DestTy, Name);
+  return simplifyValue(result, DL);
 }
 
 Value* createSExtOrTruncFolder(IRBuilder<>& builder, Value* V, Type* DestTy,

--- a/lifter/OperandUtils.cpp
+++ b/lifter/OperandUtils.cpp
@@ -1271,12 +1271,6 @@ Value* lifterClass::GetOperandValue(ZydisDecodedOperand& op, int possiblesize,
           dyn_cast<ConstantInt>(effectiveAddress);
       if (!effectiveAddressInt)
         return nullptr;
-
-      uint64_t addr = effectiveAddressInt->getZExtValue();
-
-      unsigned byteSize = loadType->getIntegerBitWidth() / 8;
-
-      APInt value(1, 0);
       Value* solvedLoad = GEPStoreTracker::solveLoad(retval);
       if (solvedLoad) {
         return solvedLoad;
@@ -1462,11 +1456,6 @@ Value* lifterClass::popStack() {
     if (!effectiveAddressInt)
       return nullptr;
 
-    uint64_t addr = effectiveAddressInt->getZExtValue();
-
-    unsigned byteSize = loadType->getBitWidth() / 8;
-
-    APInt value(1, 0);
     Value* solvedLoad = GEPStoreTracker::solveLoad(returnValue);
     if (solvedLoad) {
       return solvedLoad;

--- a/lifter/OperandUtils.h
+++ b/lifter/OperandUtils.h
@@ -59,42 +59,6 @@ Value* createShlFolder(IRBuilder<>& builder, Value* LHS, uint64_t RHS,
 Value* createShlFolder(IRBuilder<>& builder, Value* LHS, APInt RHS,
                        const Twine& Name = "");
 
-Value* GetRegisterValue(IRBuilder<>& builder, int key);
-
-void SetRegisterValue(IRBuilder<>& builder, int key, Value* value);
-
-void SetRegisterValue(int key, Value* value);
-
-RegisterMap InitRegisters(IRBuilder<>& builder, Function* function,
-                          ZyanU64 rip);
-
-Value* ConvertIntToPTR(IRBuilder<>& builder, Value* effectiveAddress);
-
-Value* GetEffectiveAddress(IRBuilder<>& builder, ZydisDecodedOperand& op,
-                           int possiblesize);
-
-IntegerType* getIntSize(int size, LLVMContext& context);
-
-Value* GetOperandValue(IRBuilder<>& builder, ZydisDecodedOperand& op,
-                       int possiblesize, string address = "");
-
-Value* SetOperandValue(IRBuilder<>& builder, ZydisDecodedOperand& op,
-                       Value* value, string address = "");
-
-void pushFlags(IRBuilder<>& builder, vector<Value*> value, string address = "");
-
-RegisterMap getRegisters();
-
-void setRegisters(RegisterMap newRegisterList);
-
-Value* setFlag(IRBuilder<>& builder, Flag flag, Value* newValue);
-
-Value* getFlag(IRBuilder<>& builder, Flag flag);
-
-Value* getMemoryFromValue(IRBuilder<>& builder, Value* value);
-
-vector<Value*> GetRFLAGS(IRBuilder<>& builder);
-
 Value* getMemory();
 
 KnownBits analyzeValueKnownBits(Value* value, const DataLayout& DL);
@@ -103,6 +67,6 @@ Value* simplifyValueLater(Value* v, const DataLayout& DL);
 
 ReverseRegisterMap flipRegisterMap();
 
-Value* popStack(IRBuilder<>& builder);
+Value* ConvertIntToPTR(IRBuilder<>& builder, Value* effectiveAddress);
 
 bool comesBefore(Instruction* a, Instruction* b, DominatorTree& DT);

--- a/lifter/OperandUtils.h
+++ b/lifter/OperandUtils.h
@@ -11,8 +11,6 @@ namespace GetSimplifyQuery {
 
 Value* simplifyValue(Value* v, const DataLayout& DL);
 
-KnownBits analyzeValueKnownBits(Value* value, const DataLayout& DL);
-
 Value* createSelectFolder(IRBuilder<>& builder, Value* C, Value* True,
                           Value* False, const Twine& Name = "");
 
@@ -69,7 +67,7 @@ Value* createShlFolder(IRBuilder<>& builder, Value* LHS, APInt RHS,
 
 Value* getMemory();
 
-KnownBits analyzeValueKnownBits(Value* value, const DataLayout& DL);
+KnownBits analyzeValueKnownBits(Value* value, Instruction* ctxI);
 
 Value* simplifyValueLater(Value* v, const DataLayout& DL);
 

--- a/lifter/OperandUtils.h
+++ b/lifter/OperandUtils.h
@@ -69,8 +69,6 @@ Value* getMemory();
 
 KnownBits analyzeValueKnownBits(Value* value, Instruction* ctxI);
 
-Value* simplifyValueLater(Value* v, const DataLayout& DL);
-
 ReverseRegisterMap flipRegisterMap();
 
 Value* ConvertIntToPTR(IRBuilder<>& builder, Value* effectiveAddress);

--- a/lifter/PathSolver.cpp
+++ b/lifter/PathSolver.cpp
@@ -1,6 +1,7 @@
 #include "CustomPasses.hpp"
 #include "OperandUtils.h"
 #include "includes.h"
+#include "lifterClass.h"
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/Support/Casting.h>
@@ -19,8 +20,8 @@ struct InstructionDependencyOrder {
   }
 };
 
-void replaceAllUsesWithandReplaceRMap(Value* v, Value* nv,
-                                      ReverseRegisterMap rVMap) {
+void lifterClass::replaceAllUsesWithandReplaceRMap(Value* v, Value* nv,
+                                                   ReverseRegisterMap rVMap) {
 
   // if two values are same, we go in a infinite loop
   if (v == nv)
@@ -69,8 +70,8 @@ void replaceAllUsesWithandReplaceRMap(Value* v, Value* nv,
 // not miss
 //
 // also refactor this
-void simplifyUsers(Value* newValue, DataLayout& DL,
-                   ReverseRegisterMap flippedRegisterMap) {
+void lifterClass::simplifyUsers(Value* newValue, DataLayout& DL,
+                                ReverseRegisterMap flippedRegisterMap) {
   unordered_set<Value*> visited;
   std::priority_queue<Instruction*, std::vector<Instruction*>,
                       InstructionDependencyOrder>
@@ -245,7 +246,8 @@ llvm::ValueToValueMapTy* flipVMap(const ValueToValueMapTy& VMap) {
   return RevMap;
 }
 
-PATH_info solvePath(Function* function, uint64_t& dest, Value* simplifyValue) {
+PATH_info lifterClass::solvePath(Function* function, uint64_t& dest,
+                                 Value* simplifyValue) {
 
   PATH_info result = PATH_unsolved;
   if (llvm::ConstantInt* constInt =

--- a/lifter/Semantics.cpp
+++ b/lifter/Semantics.cpp
@@ -291,9 +291,8 @@ void lifterClass::branchHelper(Value* condition, string instname,
 
     lifterClass* newlifter = new lifterClass(builder);
 
-    auto RegisterList = newlifter->InitRegisters(function, false_jump_addr);
-
-    newlifter->blockInfo = make_tuple(false_jump_addr, bb_false, RegisterList);
+    newlifter->blockInfo =
+        make_tuple(false_jump_addr, bb_false, getRegisters());
 
     lifters.push_back(newlifter);
 

--- a/lifter/Semantics.cpp
+++ b/lifter/Semantics.cpp
@@ -3,6 +3,7 @@
 #include "OperandUtils.h"
 #include "PathSolver.h"
 #include "includes.h"
+#include "lifterClass.h"
 #include "utils.h"
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/Function.h>
@@ -10,8 +11,8 @@
 #include <llvm/Support/Casting.h>
 #include <llvm/Support/ErrorHandling.h>
 
-FunctionType* parseArgsType(funcsignatures::functioninfo* funcInfo,
-                            LLVMContext& context) {
+FunctionType* lifterClass::parseArgsType(funcsignatures::functioninfo* funcInfo,
+                                         LLVMContext& context) {
   if (!funcInfo) {
     FunctionType* externFuncType = FunctionType::get(
         Type::getInt64Ty(context),
@@ -42,51 +43,49 @@ FunctionType* parseArgsType(funcsignatures::functioninfo* funcInfo,
                                  false);
 }
 
-vector<Value*> parseArgs(funcsignatures::functioninfo* funcInfo,
-                         IRBuilder<>& builder) {
+vector<Value*> lifterClass::parseArgs(funcsignatures::functioninfo* funcInfo) {
   auto& context = builder.getContext();
 
-  auto RspRegister = GetRegisterValue(builder, ZYDIS_REGISTER_RSP);
+  auto RspRegister = GetRegisterValue(ZYDIS_REGISTER_RSP);
   if (!funcInfo)
-    return {
-        createZExtFolder(builder, GetRegisterValue(builder, ZYDIS_REGISTER_RAX),
-                         Type::getInt64Ty(context)),
-        createZExtFolder(builder, GetRegisterValue(builder, ZYDIS_REGISTER_RCX),
-                         Type::getInt64Ty(context)),
-        createZExtFolder(builder, GetRegisterValue(builder, ZYDIS_REGISTER_RDX),
-                         Type::getInt64Ty(context)),
-        createZExtFolder(builder, GetRegisterValue(builder, ZYDIS_REGISTER_RBX),
-                         Type::getInt64Ty(context)),
-        RspRegister,
-        createZExtFolder(builder, GetRegisterValue(builder, ZYDIS_REGISTER_RBP),
-                         Type::getInt64Ty(context)),
-        createZExtFolder(builder, GetRegisterValue(builder, ZYDIS_REGISTER_RSI),
-                         Type::getInt64Ty(context)),
-        createZExtFolder(builder, GetRegisterValue(builder, ZYDIS_REGISTER_RDI),
-                         Type::getInt64Ty(context)),
-        createZExtFolder(builder, GetRegisterValue(builder, ZYDIS_REGISTER_RDI),
-                         Type::getInt64Ty(context)),
-        createZExtFolder(builder, GetRegisterValue(builder, ZYDIS_REGISTER_R8),
-                         Type::getInt64Ty(context)),
-        createZExtFolder(builder, GetRegisterValue(builder, ZYDIS_REGISTER_R9),
-                         Type::getInt64Ty(context)),
-        createZExtFolder(builder, GetRegisterValue(builder, ZYDIS_REGISTER_R10),
-                         Type::getInt64Ty(context)),
-        createZExtFolder(builder, GetRegisterValue(builder, ZYDIS_REGISTER_R11),
-                         Type::getInt64Ty(context)),
-        createZExtFolder(builder, GetRegisterValue(builder, ZYDIS_REGISTER_R12),
-                         Type::getInt64Ty(context)),
-        createZExtFolder(builder, GetRegisterValue(builder, ZYDIS_REGISTER_R13),
-                         Type::getInt64Ty(context)),
-        createZExtFolder(builder, GetRegisterValue(builder, ZYDIS_REGISTER_R14),
-                         Type::getInt64Ty(context)),
-        createZExtFolder(builder, GetRegisterValue(builder, ZYDIS_REGISTER_R15),
-                         Type::getInt64Ty(context)),
-        getMemory()};
+    return {createZExtFolder(builder, GetRegisterValue(ZYDIS_REGISTER_RAX),
+                             Type::getInt64Ty(context)),
+            createZExtFolder(builder, GetRegisterValue(ZYDIS_REGISTER_RCX),
+                             Type::getInt64Ty(context)),
+            createZExtFolder(builder, GetRegisterValue(ZYDIS_REGISTER_RDX),
+                             Type::getInt64Ty(context)),
+            createZExtFolder(builder, GetRegisterValue(ZYDIS_REGISTER_RBX),
+                             Type::getInt64Ty(context)),
+            RspRegister,
+            createZExtFolder(builder, GetRegisterValue(ZYDIS_REGISTER_RBP),
+                             Type::getInt64Ty(context)),
+            createZExtFolder(builder, GetRegisterValue(ZYDIS_REGISTER_RSI),
+                             Type::getInt64Ty(context)),
+            createZExtFolder(builder, GetRegisterValue(ZYDIS_REGISTER_RDI),
+                             Type::getInt64Ty(context)),
+            createZExtFolder(builder, GetRegisterValue(ZYDIS_REGISTER_RDI),
+                             Type::getInt64Ty(context)),
+            createZExtFolder(builder, GetRegisterValue(ZYDIS_REGISTER_R8),
+                             Type::getInt64Ty(context)),
+            createZExtFolder(builder, GetRegisterValue(ZYDIS_REGISTER_R9),
+                             Type::getInt64Ty(context)),
+            createZExtFolder(builder, GetRegisterValue(ZYDIS_REGISTER_R10),
+                             Type::getInt64Ty(context)),
+            createZExtFolder(builder, GetRegisterValue(ZYDIS_REGISTER_R11),
+                             Type::getInt64Ty(context)),
+            createZExtFolder(builder, GetRegisterValue(ZYDIS_REGISTER_R12),
+                             Type::getInt64Ty(context)),
+            createZExtFolder(builder, GetRegisterValue(ZYDIS_REGISTER_R13),
+                             Type::getInt64Ty(context)),
+            createZExtFolder(builder, GetRegisterValue(ZYDIS_REGISTER_R14),
+                             Type::getInt64Ty(context)),
+            createZExtFolder(builder, GetRegisterValue(ZYDIS_REGISTER_R15),
+                             Type::getInt64Ty(context)),
+            getMemory()};
 
   std::vector<Value*> args;
   for (const auto& arg : funcInfo->args) {
-    Value* argValue = GetRegisterValue(builder, arg.reg);
+    Value* argValue = GetRegisterValue(arg.reg);
     argValue = createZExtOrTruncFolder(
         builder, argValue,
         Type::getIntNTy(context, 8 << (arg.argtype.size - 1)));
@@ -99,8 +98,8 @@ vector<Value*> parseArgs(funcsignatures::functioninfo* funcInfo,
 }
 
 // probably move this stuff somewhere else
-void callFunctionIR(string functionName, IRBuilder<>& builder,
-                    funcsignatures::functioninfo* funcInfo) {
+void lifterClass::callFunctionIR(string functionName,
+                                 funcsignatures::functioninfo* funcInfo) {
   auto& context = builder.getContext();
 
   /*
@@ -123,9 +122,9 @@ void callFunctionIR(string functionName, IRBuilder<>& builder,
   Function* externFunc = cast<Function>(
       M->getOrInsertFunction(functionName, externFuncType).getCallee());
   // fix calling
-  vector<Value*> args = parseArgs(funcInfo, builder);
+  vector<Value*> args = parseArgs(funcInfo);
   auto callresult = builder.CreateCall(externFunc, args);
-  SetRegisterValue(builder, ZYDIS_REGISTER_RAX,
+  SetRegisterValue(ZYDIS_REGISTER_RAX,
                    callresult); // rax = externalfunc()
   // check if the function is exit or something similar to that
 }
@@ -230,10 +229,9 @@ Value* computeSignFlag(IRBuilder<>& builder, Value* value) { // x < 0 = sf
 // this function is used for jumps that are related to user, ex: vms using
 // different handlers, jmptables, etc.
 
-void branchHelper(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction,
-                  shared_ptr<vector<BBInfo>> blockAddresses, Value* condition,
-                  string instname, int numbered) {
+void lifterClass::branchHelper(ZydisDisassembledInstruction& instruction,
+                               Value* condition, string instname,
+                               int numbered) {
   LLVMContext& context = builder.getContext();
   // TODO:
   // save the current state of memory, registers etc.,
@@ -272,1163 +270,1105 @@ void branchHelper(IRBuilder<>& builder,
 
     builder.CreateBr(bb);
 
-    blockAddresses->push_back(make_tuple(destination, bb, getRegisters()));
+    blockInfo = (make_tuple(destination, bb, getRegisters()));
+    run = 0;
   }
 }
 
-namespace mov {
+void lifterClass::lift_movsb(ZydisDisassembledInstruction& instruction) {
 
-  void lift_movsb(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
+  // DEST := SRC;
+  // [esi] = [edi]
+  // sign = DF (-1/+1)
+  // incdecv = size*sign (sb means size is 1)
+  // esi += incdecv
+  // edi += incdecv
+  //
 
-    // DEST := SRC;
-    // [esi] = [edi]
-    // sign = DF (-1/+1)
-    // incdecv = size*sign (sb means size is 1)
-    // esi += incdecv
-    // edi += incdecv
-    //
+  // Value* SRCptrvalue =
+  // GetOperandValue(instruction.operands[0],instruction.operands[0].size);
 
-    // Value* SRCptrvalue =
-    // GetOperandValue(builder,instruction.operands[0],instruction.operands[0].size);
+  Value* DSTptrvalue =
+      GetOperandValue(instruction.operands[1], instruction.operands[1].size);
 
-    Value* DSTptrvalue = GetOperandValue(builder, instruction.operands[1],
-                                         instruction.operands[1].size);
+  SetOperandValue(instruction.operands[0], DSTptrvalue);
 
-    SetOperandValue(builder, instruction.operands[0], DSTptrvalue);
+  bool isREP = (instruction.info.attributes & ZYDIS_ATTRIB_HAS_REP) != 0;
 
-    bool isREP = (instruction.info.attributes & ZYDIS_ATTRIB_HAS_REP) != 0;
+  Value* DF = getFlag(FLAG_DF);
+  auto one = ConstantInt::get(DF->getType(), 1);
+  // sign = (x*(x+1)) - 1
+  // v = sign * bytesize ; bytesize is 1
 
-    Value* DF = getFlag(builder, FLAG_DF);
-    auto one = ConstantInt::get(DF->getType(), 1);
-    // sign = (x*(x+1)) - 1
-    // v = sign * bytesize ; bytesize is 1
+  Value* Direction =
+      builder.CreateSub(builder.CreateMul(DF, builder.CreateAdd(DF, one)), one);
 
-    Value* Direction = builder.CreateSub(
-        builder.CreateMul(DF, builder.CreateAdd(DF, one)), one);
+  auto SRCop = instruction.operands[2 + isREP];
+  auto DSTop = instruction.operands[3 + isREP];
 
-    auto SRCop = instruction.operands[2 + isREP];
-    auto DSTop = instruction.operands[3 + isREP];
+  Value* SRCvalue = GetOperandValue(SRCop, SRCop.size);
+  Value* DSTvalue = GetOperandValue(DSTop, DSTop.size);
 
-    Value* SRCvalue = GetOperandValue(builder, SRCop, SRCop.size);
-    Value* DSTvalue = GetOperandValue(builder, DSTop, DSTop.size);
+  if (isREP) {
+    // if REP, instruction.operands[1] will be e/rax
+    // in that case, repeat and decrement e/rax until its 0
 
-    if (isREP) {
-      // if REP, instruction.operands[1] will be e/rax
-      // in that case, repeat and decrement e/rax until its 0
+    // we can create a loop but I dont know how that would effect our
+    // optimizations
+    Value* count =
+        GetOperandValue(instruction.operands[2], instruction.operands[2].size);
+    if (auto countci = dyn_cast<ConstantInt>(count)) {
+      Value* UpdateSRCvalue = SRCvalue;
+      Value* UpdateDSTvalue = DSTvalue;
+      uint64_t looptime = countci->getZExtValue();
+      printvalue2(looptime);
 
-      // we can create a loop but I dont know how that would effect our
-      // optimizations
-      Value* count = GetOperandValue(builder, instruction.operands[2],
-                                     instruction.operands[2].size);
-      if (auto countci = dyn_cast<ConstantInt>(count)) {
-        Value* UpdateSRCvalue = SRCvalue;
-        Value* UpdateDSTvalue = DSTvalue;
-        uint64_t looptime = countci->getZExtValue();
-        printvalue2(looptime);
+      for (int i = looptime; i > 0; i--) {
+        // TODO: fix this loop
 
-        for (int i = looptime; i > 0; i--) {
-          // TODO: fix this loop
+        // Value* SRCptrvalue = GetOperandValue(
+        // instruction.operands[0],
+        // instruction.operands[0].size);
+        Value* DSTptrvalue = GetOperandValue(instruction.operands[1],
+                                             instruction.operands[1].size);
 
-          // Value* SRCptrvalue = GetOperandValue(builder,
-          // instruction.operands[0],
-          // instruction.operands[0].size);
-          Value* DSTptrvalue = GetOperandValue(builder, instruction.operands[1],
-                                               instruction.operands[1].size);
+        SetOperandValue(instruction.operands[0], DSTptrvalue);
 
-          SetOperandValue(builder, instruction.operands[0], DSTptrvalue);
+        UpdateSRCvalue = builder.CreateAdd(UpdateSRCvalue, Direction);
+        UpdateDSTvalue = builder.CreateAdd(UpdateDSTvalue, Direction);
+        printvalue(UpdateDSTvalue) printvalue(UpdateSRCvalue);
 
-          UpdateSRCvalue = builder.CreateAdd(UpdateSRCvalue, Direction);
-          UpdateDSTvalue = builder.CreateAdd(UpdateDSTvalue, Direction);
-          printvalue(UpdateDSTvalue) printvalue(UpdateSRCvalue);
-
-          SetOperandValue(builder, SRCop, UpdateSRCvalue);
-          SetOperandValue(builder, DSTop, UpdateDSTvalue);
-          // bad cheat
-          if (i > 1)
-            debugging::increaseInstCounter();
-        }
-
-        SetOperandValue(builder, instruction.operands[2],
-                        ConstantInt::get(count->getType(), 0));
-
-        return;
-      } else {
-        throw "fix rep";
+        SetOperandValue(SRCop, UpdateSRCvalue);
+        SetOperandValue(DSTop, UpdateDSTvalue);
+        // bad cheat
+        if (i > 1)
+          debugging::increaseInstCounter();
       }
+
+      SetOperandValue(instruction.operands[2],
+                      ConstantInt::get(count->getType(), 0));
+
+      return;
+    } else {
+      throw "fix rep";
     }
-
-    Value* UpdateSRCvalue = builder.CreateAdd(SRCvalue, Direction);
-    Value* UpdateDSTvalue = builder.CreateAdd(DSTvalue, Direction);
-
-    SetOperandValue(builder, SRCop, UpdateSRCvalue);
-    SetOperandValue(builder, DSTop, UpdateDSTvalue);
   }
 
-  void lift_mov(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
+  Value* UpdateSRCvalue = builder.CreateAdd(SRCvalue, Direction);
+  Value* UpdateDSTvalue = builder.CreateAdd(DSTvalue, Direction);
 
-    auto Rvalue = GetOperandValue(builder, src, src.size,
-                                  to_string(instruction.runtime_address));
+  SetOperandValue(SRCop, UpdateSRCvalue);
+  SetOperandValue(DSTop, UpdateDSTvalue);
+}
+void lifterClass::lift_movaps(ZydisDisassembledInstruction& instruction) {
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
 
-    switch (instruction.info.mnemonic) {
-    case ZYDIS_MNEMONIC_MOVSX: {
-      Rvalue = createSExtFolder(
-          builder, Rvalue, Type::getIntNTy(context, dest.size),
-          "movsx-" + to_string(instruction.runtime_address) + "-");
+  auto Rvalue =
+      GetOperandValue(src, src.size, to_string(instruction.runtime_address));
+  SetOperandValue(dest, Rvalue, to_string(instruction.runtime_address));
+}
+void lifterClass::lift_mov(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  auto Rvalue =
+      GetOperandValue(src, src.size, to_string(instruction.runtime_address));
+
+  switch (instruction.info.mnemonic) {
+  case ZYDIS_MNEMONIC_MOVSX: {
+    Rvalue = createSExtFolder(
+        builder, Rvalue, Type::getIntNTy(context, dest.size),
+        "movsx-" + to_string(instruction.runtime_address) + "-");
+    break;
+  }
+  case ZYDIS_MNEMONIC_MOVZX: {
+    Rvalue = createZExtFolder(
+        builder, Rvalue, Type::getIntNTy(context, dest.size),
+        "movzx-" + to_string(instruction.runtime_address) + "-");
+    break;
+  }
+  case ZYDIS_MNEMONIC_MOVSXD: {
+    Rvalue = createSExtFolder(
+        builder, Rvalue, Type::getIntNTy(context, dest.size),
+        "movsxd-" + to_string(instruction.runtime_address) + "-");
+    break;
+  }
+  default: {
+    break;
+  }
+  }
+  printvalue(Rvalue);
+  if (src.type == ZYDIS_OPERAND_TYPE_IMMEDIATE) {
+    Rvalue = GetOperandValue(src, dest.size);
+  }
+
+  printvalue(Rvalue);
+
+  SetOperandValue(dest, Rvalue, to_string(instruction.runtime_address));
+}
+
+void lifterClass::lift_cmovbz(ZydisDisassembledInstruction& instruction) {
+
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* zf = getFlag(FLAG_ZF);
+  Value* cf = getFlag(FLAG_CF);
+
+  Value* condition = createOrFolder(builder, zf, cf, "cmovbz-or");
+
+  Value* Rvalue = GetOperandValue(src, dest.size);
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+
+  Value* result = createSelectFolder(builder, condition, Rvalue, Lvalue);
+
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_cmovnbz(ZydisDisassembledInstruction& instruction) {
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+  Value* Rvalue = GetOperandValue(src, src.size);
+
+  Value* cf = getFlag(FLAG_CF);
+  Value* zf = getFlag(FLAG_ZF);
+
+  Value* nbeCondition = createAndFolder(builder, builder.CreateNot(cf),
+                                        builder.CreateNot(zf), "nbeCondition");
+
+  Value* resultValue =
+      createSelectFolder(builder, nbeCondition, Rvalue, Lvalue, "cmovnbe");
+
+  SetOperandValue(dest, resultValue, to_string(instruction.runtime_address));
+}
+
+void lifterClass::lift_cmovz(ZydisDisassembledInstruction& instruction) {
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+  Value* Rvalue = GetOperandValue(src, src.size);
+
+  Value* zf = getFlag(FLAG_ZF);
+
+  Value* resultValue = createSelectFolder(builder, zf, Rvalue, Lvalue, "cmovz");
+
+  SetOperandValue(dest, resultValue, to_string(instruction.runtime_address));
+}
+
+void lifterClass::lift_cmovnz(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* zf = getFlag(FLAG_ZF);
+  zf = createICMPFolder(builder, CmpInst::ICMP_EQ, zf,
+                        ConstantInt::get(Type::getInt1Ty(context), 0));
+
+  Value* Rvalue = GetOperandValue(src, dest.size);
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+
+  Value* result = createSelectFolder(builder, zf, Rvalue, Lvalue);
+
+  SetOperandValue(dest, result);
+}
+void lifterClass::lift_cmovl(ZydisDisassembledInstruction& instruction) {
+
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* sf = getFlag(FLAG_SF);
+  Value* of = getFlag(FLAG_OF);
+
+  Value* condition = createICMPFolder(builder, CmpInst::ICMP_NE, sf, of);
+
+  Value* Rvalue = GetOperandValue(src, dest.size);
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+
+  Value* result = createSelectFolder(builder, condition, Rvalue, Lvalue);
+
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_cmovb(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* cf = getFlag(FLAG_CF);
+
+  Value* condition =
+      createICMPFolder(builder, CmpInst::ICMP_EQ, cf,
+                       ConstantInt::get(Type::getInt1Ty(context), 1));
+
+  Value* Rvalue = GetOperandValue(src, dest.size);
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+
+  Value* result = createSelectFolder(builder, condition, Rvalue, Lvalue);
+
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_cmovnb(ZydisDisassembledInstruction& instruction) {
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+  Value* Rvalue = GetOperandValue(src, src.size);
+
+  Value* cf = getFlag(FLAG_CF);
+
+  Value* resultValue = createSelectFolder(builder, builder.CreateNot(cf),
+                                          Rvalue, Lvalue, "cmovnb");
+
+  SetOperandValue(dest, resultValue, to_string(instruction.runtime_address));
+}
+
+void lifterClass::lift_cmovns(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* sf = getFlag(FLAG_SF);
+
+  Value* condition =
+      createICMPFolder(builder, CmpInst::ICMP_EQ, sf,
+                       ConstantInt::get(Type::getInt1Ty(context), 0));
+
+  Value* Rvalue = GetOperandValue(src, dest.size);
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+
+  Value* result = createSelectFolder(builder, condition, Rvalue, Lvalue);
+
+  SetOperandValue(dest, result);
+}
+// cmovnl = cmovge
+void lifterClass::lift_cmovnl(ZydisDisassembledInstruction& instruction) {
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* sf = getFlag(FLAG_SF);
+  Value* of = getFlag(FLAG_OF);
+  Value* condition = createICMPFolder(builder, CmpInst::ICMP_EQ, sf, of);
+
+  Value* Rvalue = GetOperandValue(src, dest.size);
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+  printvalue(sf);
+  printvalue(of);
+  printvalue(condition);
+  printvalue(Lvalue);
+  printvalue(Rvalue);
+
+  Value* result = createSelectFolder(builder, condition, Rvalue, Lvalue);
+
+  SetOperandValue(dest, result);
+}
+void lifterClass::lift_cmovs(ZydisDisassembledInstruction& instruction) {
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* sf = getFlag(FLAG_SF);
+
+  Value* Rvalue = GetOperandValue(src, dest.size);
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+
+  Value* result = createSelectFolder(builder, sf, Rvalue, Lvalue);
+
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_cmovnle(ZydisDisassembledInstruction& instruction) {
+
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* zf = getFlag(FLAG_ZF);
+  Value* sf = getFlag(FLAG_SF);
+  Value* of = getFlag(FLAG_OF);
+
+  Value* condition = createAndFolder(
+      builder, builder.CreateNot(zf, "notZF"),
+      createICMPFolder(builder, CmpInst::ICMP_EQ, sf, of, "sf_eq_of"),
+      "cmovnle_cond");
+
+  Value* Rvalue = GetOperandValue(src, dest.size);
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+
+  Value* result = createSelectFolder(builder, condition, Rvalue, Lvalue);
+
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_cmovle(ZydisDisassembledInstruction& instruction) {
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* zf = getFlag(FLAG_ZF);
+  Value* sf = getFlag(FLAG_SF);
+  Value* of = getFlag(FLAG_OF);
+
+  Value* sf_neq_of = createICMPFolder(builder, CmpInst::ICMP_NE, sf, of);
+  Value* condition = createOrFolder(builder, zf, sf_neq_of, "cmovle-or");
+
+  Value* Rvalue = GetOperandValue(src, dest.size);
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+
+  Value* result = createSelectFolder(builder, condition, Rvalue, Lvalue);
+
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_cmovo(ZydisDisassembledInstruction& instruction) {
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* of = getFlag(FLAG_OF);
+
+  Value* Rvalue = GetOperandValue(src, dest.size);
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+
+  Value* result = createSelectFolder(builder, of, Rvalue, Lvalue);
+  printvalue(Lvalue);
+  printvalue(Rvalue);
+  printvalue(of);
+  printvalue(result);
+  SetOperandValue(dest, result);
+}
+void lifterClass::lift_cmovno(ZydisDisassembledInstruction& instruction) {
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* of = getFlag(FLAG_OF);
+
+  printvalue(of) of = builder.CreateNot(of, "negateOF");
+
+  Value* Rvalue = GetOperandValue(src, dest.size);
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+
+  Value* result = createSelectFolder(builder, of, Rvalue, Lvalue);
+
+  printvalue(Lvalue) printvalue(Rvalue) printvalue(result)
+      SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_cmovp(ZydisDisassembledInstruction& instruction) {
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* pf = getFlag(FLAG_PF);
+
+  Value* Rvalue = GetOperandValue(src, dest.size);
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+  printvalue(pf) printvalue(Lvalue) printvalue(Rvalue)
+
+      Value* result = createSelectFolder(builder, pf, Rvalue, Lvalue);
+
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_cmovnp(ZydisDisassembledInstruction& instruction) {
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* pf = getFlag(FLAG_PF);
+
+  pf = builder.CreateNot(pf, "negatePF");
+
+  Value* Rvalue = GetOperandValue(src, dest.size);
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+
+  Value* result = createSelectFolder(builder, pf, Rvalue, Lvalue);
+
+  SetOperandValue(dest, result);
+}
+
+// for now assume every call is fake
+void lifterClass::lift_call(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  // 0 = function
+  // 1 = rip
+  // 2 = register rsp
+  // 3 = [rsp]
+  auto src = instruction.operands[0];        // value that we are pushing
+  auto rsp = instruction.operands[2];        // value that we are pushing
+  auto rsp_memory = instruction.operands[3]; // value that we are pushing
+
+  auto RspValue = GetOperandValue(rsp, rsp.size);
+
+  auto val = ConstantInt::getSigned(Type::getInt64Ty(context),
+                                    8); // assuming its x64
+  auto result = createSubFolder(builder, RspValue, val, "pushing_newrsp");
+
+  SetOperandValue(rsp, result, to_string(instruction.runtime_address));
+  ; // sub rsp 8 first,
+
+  auto push_into_rsp = GetRegisterValue(ZYDIS_REGISTER_RIP);
+
+  SetOperandValue(rsp_memory, push_into_rsp,
+                  to_string(instruction.runtime_address));
+  ; // sub rsp 8 first,
+
+  string block_name = "jmp-call";
+
+  uint64_t jump_address = instruction.runtime_address + instruction.info.length;
+  switch (src.type) {
+  case ZYDIS_OPERAND_TYPE_IMMEDIATE: {
+    jump_address += src.imm.value.s;
+    break;
+  }
+  case ZYDIS_OPERAND_TYPE_MEMORY:
+  case ZYDIS_OPERAND_TYPE_REGISTER: {
+    auto registerValue = GetOperandValue(src, 64);
+    if (!isa<ConstantInt>(registerValue)) {
+
+      callFunctionIR(registerValue->getName().str() + "fnc_ptr", nullptr);
+
+      SetOperandValue(rsp, RspValue, to_string(instruction.runtime_address));
       break;
+      // registerValue =
+      //    ConstantInt::get(Type::getInt32Ty(context), 0x1337);
+
+      // throw("trying to call an unknown value");
     }
-    case ZYDIS_MNEMONIC_MOVZX: {
-      Rvalue = createZExtFolder(
-          builder, Rvalue, Type::getIntNTy(context, dest.size),
-          "movzx-" + to_string(instruction.runtime_address) + "-");
-      break;
-    }
-    case ZYDIS_MNEMONIC_MOVSXD: {
-      Rvalue = createSExtFolder(
-          builder, Rvalue, Type::getIntNTy(context, dest.size),
-          "movsxd-" + to_string(instruction.runtime_address) + "-");
-      break;
-    }
-    default: {
-      break;
-    }
-    }
-    printvalue(Rvalue);
-    if (src.type == ZYDIS_OPERAND_TYPE_IMMEDIATE) {
-      Rvalue = GetOperandValue(builder, src, dest.size);
-    }
-
-    printvalue(Rvalue);
-
-    SetOperandValue(builder, dest, Rvalue,
-                    to_string(instruction.runtime_address));
+    auto registerCValue = cast<ConstantInt>(registerValue);
+    jump_address = registerCValue->getZExtValue();
+    break;
+  }
+  default:
+    break;
   }
 
-}; // namespace mov
+  auto bb = BasicBlock::Create(context, block_name.c_str(),
+                               builder.GetInsertBlock()->getParent());
+  // if its trying to jump somewhere else than our binary, call it and
+  // continue from [rsp]
+  APInt temp;
 
-namespace cmov {
+  builder.CreateBr(bb);
 
-  void lift_cmovbz(IRBuilder<>& builder,
-                   ZydisDisassembledInstruction& instruction) {
+  printvalue2(jump_address);
 
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
+  blockInfo = (make_tuple(jump_address, bb, getRegisters()));
+  run = 0;
+}
 
-    Value* zf = getFlag(builder, FLAG_ZF);
-    Value* cf = getFlag(builder, FLAG_CF);
+int ret_count = 0;
+void lifterClass::lift_ret(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  // [0] = rip
+  // [1] = rsp
+  // [2] = [rsp]
 
-    Value* condition = createOrFolder(builder, zf, cf, "cmovbz-or");
+  // if its ret 0x10
+  // then its
+  // [0] = 0x10
+  // [1] = rip
+  // [2] = rsp
+  // [3] = [rsp]
 
-    Value* Rvalue = GetOperandValue(builder, src, dest.size);
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
+  auto rspaddr = instruction.operands[2];
 
-    Value* result = createSelectFolder(builder, condition, Rvalue, Lvalue);
-
-    SetOperandValue(builder, dest, result);
+  auto rsp = ZYDIS_REGISTER_RSP;
+  auto rspvalue = GetRegisterValue(rsp);
+  if (instruction.operands[0].type == ZYDIS_OPERAND_TYPE_IMMEDIATE) {
+    rspaddr = instruction.operands[3];
   }
 
-  void lift_cmovnbz(IRBuilder<>& builder,
-                    ZydisDisassembledInstruction& instruction) {
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
+  auto realval = GetOperandValue(rspaddr, rspaddr.size);
 
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-    Value* Rvalue = GetOperandValue(builder, src, src.size);
+  auto block = builder.GetInsertBlock();
+  block->setName("ret_check" + to_string(ret_count));
+  auto function = block->getParent();
+  auto lastinst = builder.CreateRet(realval);
 
-    Value* cf = getFlag(builder, FLAG_CF);
-    Value* zf = getFlag(builder, FLAG_ZF);
+  printvalue(rspvalue) debugging::doIfDebug([&]() {
+    std::string Filename = "output_rets.ll";
+    std::error_code EC;
+    raw_fd_ostream OS(Filename, EC);
+    function->getParent()->print(OS, nullptr);
+  });
 
-    Value* nbeCondition = createAndFolder(
-        builder, builder.CreateNot(cf), builder.CreateNot(zf), "nbeCondition");
+  uint64_t destination = 0;
 
-    Value* resultValue =
-        createSelectFolder(builder, nbeCondition, Rvalue, Lvalue, "cmovnbe");
+  ROP_info result = ROP_return;
 
-    SetOperandValue(builder, dest, resultValue,
-                    to_string(instruction.runtime_address));
+  if (llvm::ConstantInt* constInt =
+          llvm::dyn_cast<llvm::ConstantInt>(rspvalue)) {
+    int64_t rspval = constInt->getSExtValue();
+    printvalue2(rspval);
+    result = rspval == STACKP_VALUE ? REAL_return : ROP_return;
+  }
+  printvalue2(result);
+  if (result == REAL_return) {
+    lastinst->eraseFromParent();
+    block->setName("real_ret");
+    auto rax = GetRegisterValue(ZYDIS_REGISTER_RAX);
+    builder.CreateRet(
+        createZExtFolder(builder, rax, Type::getInt64Ty(rax->getContext())));
+    Function* originalFunc_finalnopt = builder.GetInsertBlock()->getParent();
+
+    std::string Filename_finalnopt = "output_finalnoopt.ll";
+    std::error_code EC_finalnopt;
+    raw_fd_ostream OS_finalnopt(Filename_finalnopt, EC_finalnopt);
+
+    originalFunc_finalnopt->print(OS_finalnopt);
+
+    // function->print(outs());
+
+    final_optpass(originalFunc_finalnopt);
+    debugging::doIfDebug([&]() {
+      std::string Filename = "output_finalopt.ll";
+      std::error_code EC;
+      raw_fd_ostream OS(Filename, EC);
+      originalFunc_finalnopt->print(OS);
+    });
+    run = 0;
+    finished = 1;
+    return;
   }
 
-  void lift_cmovz(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
+  PATH_info pathInfo = solvePath(function, destination, realval);
 
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-    Value* Rvalue = GetOperandValue(builder, src, src.size);
+  block->setName("previousret_block");
 
-    Value* zf = getFlag(builder, FLAG_ZF);
+  if (pathInfo == PATH_solved) {
 
-    Value* resultValue =
-        createSelectFolder(builder, zf, Rvalue, Lvalue, "cmovz");
+    lastinst->eraseFromParent();
+    block->setName("fake_ret");
 
-    SetOperandValue(builder, dest, resultValue,
-                    to_string(instruction.runtime_address));
-  }
-
-  void lift_cmovnz(IRBuilder<>& builder,
-                   ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    Value* zf = getFlag(builder, FLAG_ZF);
-    zf = createICMPFolder(builder, CmpInst::ICMP_EQ, zf,
-                          ConstantInt::get(Type::getInt1Ty(context), 0));
-
-    Value* Rvalue = GetOperandValue(builder, src, dest.size);
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-
-    Value* result = createSelectFolder(builder, zf, Rvalue, Lvalue);
-
-    SetOperandValue(builder, dest, result);
-  }
-  void lift_cmovl(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    Value* sf = getFlag(builder, FLAG_SF);
-    Value* of = getFlag(builder, FLAG_OF);
-
-    Value* condition = createICMPFolder(builder, CmpInst::ICMP_NE, sf, of);
-
-    Value* Rvalue = GetOperandValue(builder, src, dest.size);
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-
-    Value* result = createSelectFolder(builder, condition, Rvalue, Lvalue);
-
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_cmovb(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    Value* cf = getFlag(builder, FLAG_CF);
-
-    Value* condition =
-        createICMPFolder(builder, CmpInst::ICMP_EQ, cf,
-                         ConstantInt::get(Type::getInt1Ty(context), 1));
-
-    Value* Rvalue = GetOperandValue(builder, src, dest.size);
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-
-    Value* result = createSelectFolder(builder, condition, Rvalue, Lvalue);
-
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_cmovnb(IRBuilder<>& builder,
-                   ZydisDisassembledInstruction& instruction) {
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-    Value* Rvalue = GetOperandValue(builder, src, src.size);
-
-    Value* cf = getFlag(builder, FLAG_CF);
-
-    Value* resultValue = createSelectFolder(builder, builder.CreateNot(cf),
-                                            Rvalue, Lvalue, "cmovnb");
-
-    SetOperandValue(builder, dest, resultValue,
-                    to_string(instruction.runtime_address));
-  }
-
-  void lift_cmovns(IRBuilder<>& builder,
-                   ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    Value* sf = getFlag(builder, FLAG_SF);
-
-    Value* condition =
-        createICMPFolder(builder, CmpInst::ICMP_EQ, sf,
-                         ConstantInt::get(Type::getInt1Ty(context), 0));
-
-    Value* Rvalue = GetOperandValue(builder, src, dest.size);
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-
-    Value* result = createSelectFolder(builder, condition, Rvalue, Lvalue);
-
-    SetOperandValue(builder, dest, result);
-  }
-  // cmovnl = cmovge
-  void lift_cmovnl(IRBuilder<>& builder,
-                   ZydisDisassembledInstruction& instruction) {
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    Value* sf = getFlag(builder, FLAG_SF);
-    Value* of = getFlag(builder, FLAG_OF);
-    Value* condition = createICMPFolder(builder, CmpInst::ICMP_EQ, sf, of);
-
-    Value* Rvalue = GetOperandValue(builder, src, dest.size);
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-    printvalue(sf);
-    printvalue(of);
-    printvalue(condition);
-    printvalue(Lvalue);
-    printvalue(Rvalue);
-
-    Value* result = createSelectFolder(builder, condition, Rvalue, Lvalue);
-
-    SetOperandValue(builder, dest, result);
-  }
-  void lift_cmovs(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    Value* sf = getFlag(builder, FLAG_SF);
-
-    Value* Rvalue = GetOperandValue(builder, src, dest.size);
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-
-    Value* result = createSelectFolder(builder, sf, Rvalue, Lvalue);
-
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_cmovnle(IRBuilder<>& builder,
-                    ZydisDisassembledInstruction& instruction) {
-
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    Value* zf = getFlag(builder, FLAG_ZF);
-    Value* sf = getFlag(builder, FLAG_SF);
-    Value* of = getFlag(builder, FLAG_OF);
-
-    Value* condition = createAndFolder(
-        builder, builder.CreateNot(zf, "notZF"),
-        createICMPFolder(builder, CmpInst::ICMP_EQ, sf, of, "sf_eq_of"),
-        "cmovnle_cond");
-
-    Value* Rvalue = GetOperandValue(builder, src, dest.size);
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-
-    Value* result = createSelectFolder(builder, condition, Rvalue, Lvalue);
-
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_cmovle(IRBuilder<>& builder,
-                   ZydisDisassembledInstruction& instruction) {
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    Value* zf = getFlag(builder, FLAG_ZF);
-    Value* sf = getFlag(builder, FLAG_SF);
-    Value* of = getFlag(builder, FLAG_OF);
-
-    Value* sf_neq_of = createICMPFolder(builder, CmpInst::ICMP_NE, sf, of);
-    Value* condition = createOrFolder(builder, zf, sf_neq_of, "cmovle-or");
-
-    Value* Rvalue = GetOperandValue(builder, src, dest.size);
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-
-    Value* result = createSelectFolder(builder, condition, Rvalue, Lvalue);
-
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_cmovo(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    Value* of = getFlag(builder, FLAG_OF);
-
-    Value* Rvalue = GetOperandValue(builder, src, dest.size);
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-
-    Value* result = createSelectFolder(builder, of, Rvalue, Lvalue);
-    printvalue(Lvalue);
-    printvalue(Rvalue);
-    printvalue(of);
-    printvalue(result);
-    SetOperandValue(builder, dest, result);
-  }
-  void lift_cmovno(IRBuilder<>& builder,
-                   ZydisDisassembledInstruction& instruction) {
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    Value* of = getFlag(builder, FLAG_OF);
-
-    printvalue(of) of = builder.CreateNot(of, "negateOF");
-
-    Value* Rvalue = GetOperandValue(builder, src, dest.size);
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-
-    Value* result = createSelectFolder(builder, of, Rvalue, Lvalue);
-
-    printvalue(Lvalue) printvalue(Rvalue) printvalue(result)
-        SetOperandValue(builder, dest, result);
-  }
-
-  void lift_cmovp(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    Value* pf = getFlag(builder, FLAG_PF);
-
-    Value* Rvalue = GetOperandValue(builder, src, dest.size);
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-    printvalue(pf) printvalue(Lvalue) printvalue(Rvalue)
-
-        Value* result = createSelectFolder(builder, pf, Rvalue, Lvalue);
-
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_cmovnp(IRBuilder<>& builder,
-                   ZydisDisassembledInstruction& instruction) {
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    Value* pf = getFlag(builder, FLAG_PF);
-
-    pf = builder.CreateNot(pf, "negatePF");
-
-    Value* Rvalue = GetOperandValue(builder, src, dest.size);
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-
-    Value* result = createSelectFolder(builder, pf, Rvalue, Lvalue);
-
-    SetOperandValue(builder, dest, result);
-  }
-} // namespace cmov
-
-namespace branches {
-
-  // for now assume every call is fake
-  void lift_call(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction,
-                 shared_ptr<vector<BBInfo>> blockAddresses) {
-    LLVMContext& context = builder.getContext();
-    // 0 = function
-    // 1 = rip
-    // 2 = register rsp
-    // 3 = [rsp]
-    auto src = instruction.operands[0];        // value that we are pushing
-    auto rsp = instruction.operands[2];        // value that we are pushing
-    auto rsp_memory = instruction.operands[3]; // value that we are pushing
-
-    auto RspValue = GetOperandValue(builder, rsp, rsp.size);
+    string block_name = "jmp_ret-" + to_string(destination) + "-";
+    auto bb = BasicBlock::Create(context, block_name.c_str(),
+                                 builder.GetInsertBlock()->getParent());
 
     auto val = ConstantInt::getSigned(Type::getInt64Ty(context),
                                       8); // assuming its x64
-    auto result = createSubFolder(builder, RspValue, val, "pushing_newrsp");
+    auto result = createAddFolder(
+        builder, rspvalue, val,
+        "ret-new-rsp-" + to_string(instruction.runtime_address) + "-");
 
-    SetOperandValue(builder, rsp, result,
-                    to_string(instruction.runtime_address));
-    ; // sub rsp 8 first,
-
-    auto push_into_rsp = GetRegisterValue(builder, ZYDIS_REGISTER_RIP);
-
-    SetOperandValue(builder, rsp_memory, push_into_rsp,
-                    to_string(instruction.runtime_address));
-    ; // sub rsp 8 first,
-
-    string block_name = "jmp-call";
-
-    uint64_t jump_address =
-        instruction.runtime_address + instruction.info.length;
-    switch (src.type) {
-    case ZYDIS_OPERAND_TYPE_IMMEDIATE: {
-      jump_address += src.imm.value.s;
-      break;
-    }
-    case ZYDIS_OPERAND_TYPE_MEMORY:
-    case ZYDIS_OPERAND_TYPE_REGISTER: {
-      auto registerValue = GetOperandValue(builder, src, 64);
-      if (!isa<ConstantInt>(registerValue)) {
-
-        callFunctionIR(registerValue->getName().str() + "fnc_ptr", builder,
-                       nullptr);
-
-        SetOperandValue(builder, rsp, RspValue,
-                        to_string(instruction.runtime_address));
-        break;
-        // registerValue =
-        //    ConstantInt::get(Type::getInt32Ty(context), 0x1337);
-
-        // throw("trying to call an unknown value");
-      }
-      auto registerCValue = cast<ConstantInt>(registerValue);
-      jump_address = registerCValue->getZExtValue();
-      break;
-    }
-    default:
-      break;
+    if (instruction.operands[0].type == ZYDIS_OPERAND_TYPE_IMMEDIATE) {
+      rspaddr = instruction.operands[3];
+      result = createAddFolder(
+          builder, result,
+          ConstantInt::get(result->getType(),
+                           instruction.operands[0].imm.value.u));
     }
 
-    auto bb = BasicBlock::Create(context, block_name.c_str(),
-                                 builder.GetInsertBlock()->getParent());
-    // if its trying to jump somewhere else than our binary, call it and
-    // continue from [rsp]
-    APInt temp;
+    SetRegisterValue(rsp, result); // then add rsp 8
 
     builder.CreateBr(bb);
 
-    printvalue2(jump_address);
-
-    blockAddresses->push_back(make_tuple(jump_address, bb, getRegisters()));
+    blockInfo = (make_tuple(destination, bb, getRegisters()));
+    run = 0;
   }
+}
 
-  int ret_count = 0;
-  void lift_ret(IRBuilder<>& builder, ZydisDisassembledInstruction& instruction,
-                shared_ptr<vector<BBInfo>> blockAddresses, bool& run) {
-    LLVMContext& context = builder.getContext();
-    // [0] = rip
-    // [1] = rsp
-    // [2] = [rsp]
+int jmpcount = 0;
+void lifterClass::lift_jmp(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
 
-    // if its ret 0x10
-    // then its
-    // [0] = 0x10
-    // [1] = rip
-    // [2] = rsp
-    // [3] = [rsp]
+  auto Value = GetOperandValue(dest, 64);
+  auto ripval = GetRegisterValue(ZYDIS_REGISTER_RIP);
+  auto newRip = createAddFolder(
+      builder, Value, ripval,
+      "jump-xd-" + to_string(instruction.runtime_address) + "-");
 
-    auto rspaddr = instruction.operands[2];
-
-    auto rsp = ZYDIS_REGISTER_RSP;
-    auto rspvalue = GetRegisterValue(builder, rsp);
-    if (instruction.operands[0].type == ZYDIS_OPERAND_TYPE_IMMEDIATE) {
-      rspaddr = instruction.operands[3];
-    }
-
-    auto realval = GetOperandValue(builder, rspaddr, rspaddr.size);
+  jmpcount++;
+  if (dest.type == ZYDIS_OPERAND_TYPE_REGISTER ||
+      dest.type == ZYDIS_OPERAND_TYPE_MEMORY) {
+    auto rspvalue = GetOperandValue(dest, 64);
+    auto trunc = createZExtOrTruncFolder(
+        builder, rspvalue, Type::getInt64Ty(context), "jmp-register");
 
     auto block = builder.GetInsertBlock();
-    block->setName("ret_check" + to_string(ret_count));
+    block->setName("jmp_check" + to_string(ret_count));
     auto function = block->getParent();
-    auto lastinst = builder.CreateRet(realval);
 
-    printvalue(rspvalue) debugging::doIfDebug([&]() {
-      std::string Filename = "output_rets.ll";
+    auto lastinst = builder.CreateRet(trunc);
+    debugging::doIfDebug([&]() {
+      std::string Filename = "output_beforeJMP.ll";
       std::error_code EC;
       raw_fd_ostream OS(Filename, EC);
-      function->getParent()->print(OS, nullptr);
+      function->print(OS);
     });
 
     uint64_t destination = 0;
+    PATH_info pathInfo = solvePath(function, destination, trunc);
 
-    ROP_info result = ROP_return;
+    ValueToValueMapTy VMap_test;
 
-    if (llvm::ConstantInt* constInt =
-            llvm::dyn_cast<llvm::ConstantInt>(rspvalue)) {
-      int64_t rspval = constInt->getSExtValue();
-      printvalue2(rspval);
-      result = rspval == STACKP_VALUE ? REAL_return : ROP_return;
-    }
-    printvalue2(result);
-    if (result == REAL_return) {
-      lastinst->eraseFromParent();
-      block->setName("real_ret");
-      auto rax = GetRegisterValue(builder, ZYDIS_REGISTER_RAX);
-      builder.CreateRet(
-          createZExtFolder(builder, rax, Type::getInt64Ty(rax->getContext())));
-      Function* originalFunc_finalnopt = builder.GetInsertBlock()->getParent();
-
-      std::string Filename_finalnopt = "output_finalnoopt.ll";
-      std::error_code EC_finalnopt;
-      raw_fd_ostream OS_finalnopt(Filename_finalnopt, EC_finalnopt);
-
-      originalFunc_finalnopt->print(OS_finalnopt);
-
-      // function->print(outs());
-
-      final_optpass(originalFunc_finalnopt);
-      debugging::doIfDebug([&]() {
-        std::string Filename = "output_finalopt.ll";
-        std::error_code EC;
-        raw_fd_ostream OS(Filename, EC);
-        originalFunc_finalnopt->print(OS);
-      });
-      run = 0;
-      return;
-    }
-
-    PATH_info pathInfo = solvePath(function, destination, realval);
-
-    block->setName("previousret_block");
-
+    block->setName("previousjmp_block-" + to_string(destination) + "-");
+    // cout << "pathInfo:" << pathInfo << " dest: " << destination  <<
+    // "\n";
     if (pathInfo == PATH_solved) {
 
       lastinst->eraseFromParent();
-      block->setName("fake_ret");
-
-      string block_name = "jmp_ret-" + to_string(destination) + "-";
+      string block_name = "jmp-" + to_string(destination) + "-";
       auto bb = BasicBlock::Create(context, block_name.c_str(),
                                    builder.GetInsertBlock()->getParent());
 
-      auto val = ConstantInt::getSigned(Type::getInt64Ty(context),
-                                        8); // assuming its x64
-      auto result = createAddFolder(
-          builder, rspvalue, val,
-          "ret-new-rsp-" + to_string(instruction.runtime_address) + "-");
-
-      if (instruction.operands[0].type == ZYDIS_OPERAND_TYPE_IMMEDIATE) {
-        rspaddr = instruction.operands[3];
-        result = createAddFolder(
-            builder, result,
-            ConstantInt::get(result->getType(),
-                             instruction.operands[0].imm.value.u));
-      }
-
-      SetRegisterValue(builder, rsp, result); // then add rsp 8
-
       builder.CreateBr(bb);
 
-      blockAddresses->push_back(make_tuple(destination, bb, getRegisters()));
+      blockInfo = (make_tuple(destination, bb, getRegisters()));
       run = 0;
     }
-  }
-
-  int jmpcount = 0;
-  void lift_jmp(IRBuilder<>& builder, ZydisDisassembledInstruction& instruction,
-                shared_ptr<vector<BBInfo>> blockAddresses, bool& run) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-
-    auto Value = GetOperandValue(builder, dest, 64);
-    auto ripval = GetRegisterValue(builder, ZYDIS_REGISTER_RIP);
-    auto newRip = createAddFolder(
-        builder, Value, ripval,
-        "jump-xd-" + to_string(instruction.runtime_address) + "-");
-
-    jmpcount++;
-    if (dest.type == ZYDIS_OPERAND_TYPE_REGISTER ||
-        dest.type == ZYDIS_OPERAND_TYPE_MEMORY) {
-      auto rspvalue = GetOperandValue(builder, dest, 64);
-      auto trunc = createZExtOrTruncFolder(
-          builder, rspvalue, Type::getInt64Ty(context), "jmp-register");
-
-      auto block = builder.GetInsertBlock();
-      block->setName("jmp_check" + to_string(ret_count));
-      auto function = block->getParent();
-
-      auto lastinst = builder.CreateRet(trunc);
-      debugging::doIfDebug([&]() {
-        std::string Filename = "output_beforeJMP.ll";
-        std::error_code EC;
-        raw_fd_ostream OS(Filename, EC);
-        function->print(OS);
-      });
-
-      uint64_t destination = 0;
-      PATH_info pathInfo = solvePath(function, destination, trunc);
-
-      ValueToValueMapTy VMap_test;
-
-      block->setName("previousjmp_block-" + to_string(destination) + "-");
-      // cout << "pathInfo:" << pathInfo << " dest: " << destination  <<
-      // "\n";
-      if (pathInfo == PATH_solved) {
-
-        lastinst->eraseFromParent();
-        string block_name = "jmp-" + to_string(destination) + "-";
-        auto bb = BasicBlock::Create(context, block_name.c_str(),
-                                     builder.GetInsertBlock()->getParent());
-
-        builder.CreateBr(bb);
-
-        blockAddresses->push_back(make_tuple(destination, bb, getRegisters()));
-        run = 0;
-      }
-      run = 0;
-
-      // if ROP is not JOP_jmp, then its bugged
-      return;
-    }
-
-    SetRegisterValue(builder, ZYDIS_REGISTER_RIP, newRip);
-
-    uint64_t test = dest.imm.value.s + instruction.runtime_address +
-                    instruction.info.length;
-
-    string block_name = "jmp-" + to_string(test) + "-";
-    auto bb = BasicBlock::Create(context, block_name.c_str(),
-                                 builder.GetInsertBlock()->getParent());
-
-    builder.CreateBr(bb);
-
-    blockAddresses->push_back(make_tuple(test, bb, getRegisters()));
     run = 0;
+
+    // if ROP is not JOP_jmp, then its bugged
+    return;
   }
 
-  int branchnumber = 0;
-  // jnz and jne
-  void lift_jnz(IRBuilder<>& builder, ZydisDisassembledInstruction& instruction,
-                shared_ptr<vector<BBInfo>> blockAddresses) {
+  SetRegisterValue(ZYDIS_REGISTER_RIP, newRip);
 
-    LLVMContext& context = builder.getContext();
+  uint64_t test =
+      dest.imm.value.s + instruction.runtime_address + instruction.info.length;
 
-    auto zf = getFlag(builder, FLAG_ZF);
+  string block_name = "jmp-" + to_string(test) + "-";
+  auto bb = BasicBlock::Create(context, block_name.c_str(),
+                               builder.GetInsertBlock()->getParent());
 
-    // auto dest = instruction.operands[0];
+  builder.CreateBr(bb);
 
-    // auto Value = GetOperandValue(builder, dest, 64);
-    // auto ripval = GetRegisterValue(builder, ZYDIS_REGISTER_RIP);
+  blockInfo = (make_tuple(test, bb, getRegisters()));
+  run = 0;
+}
 
-    // auto newRip = createAddFolder(builder, Value, ripval, "jnz");
+int branchnumber = 0;
+// jnz and jne
+void lifterClass::lift_jnz(ZydisDisassembledInstruction& instruction) {
 
-    printvalue(zf);
+  LLVMContext& context = builder.getContext();
 
-    zf = createICMPFolder(builder, CmpInst::ICMP_EQ, zf,
-                          ConstantInt::get(Type::getInt1Ty(context), 0));
+  auto zf = getFlag(FLAG_ZF);
 
-    branchHelper(builder, instruction, blockAddresses, zf, "jnz", branchnumber);
+  // auto dest = instruction.operands[0];
 
-    branchnumber++;
-  }
+  // auto Value = GetOperandValue( dest, 64);
+  // auto ripval = GetRegisterValue( ZYDIS_REGISTER_RIP);
 
-  void lift_js(IRBuilder<>& builder, ZydisDisassembledInstruction& instruction,
-               shared_ptr<vector<BBInfo>> blockAddresses) {
+  // auto newRip = createAddFolder(builder, Value, ripval, "jnz");
 
-    auto sf = getFlag(builder, FLAG_SF);
+  printvalue(zf);
 
-    // auto dest = instruction.operands[0];
+  zf = createICMPFolder(builder, CmpInst::ICMP_EQ, zf,
+                        ConstantInt::get(Type::getInt1Ty(context), 0));
 
-    // auto Value = GetOperandValue(builder, dest, 64);
-    // auto ripval = GetRegisterValue(builder, ZYDIS_REGISTER_RIP);
+  branchHelper(instruction, zf, "jnz", branchnumber);
 
-    // auto newRip = createAddFolder(builder, Value, ripval, "js");
+  branchnumber++;
+}
 
-    branchHelper(builder, instruction, blockAddresses, sf, "js", branchnumber);
+void lifterClass::lift_js(ZydisDisassembledInstruction& instruction) {
 
-    branchnumber++;
-  }
-  void lift_jns(IRBuilder<>& builder, ZydisDisassembledInstruction& instruction,
-                shared_ptr<vector<BBInfo>> blockAddresses) {
+  auto sf = getFlag(FLAG_SF);
 
-    auto sf = getFlag(builder, FLAG_SF);
+  // auto dest = instruction.operands[0];
 
-    // auto dest = instruction.operands[0];
+  // auto Value = GetOperandValue( dest, 64);
+  // auto ripval = GetRegisterValue( ZYDIS_REGISTER_RIP);
 
-    // auto Value = GetOperandValue(builder, dest, 64);
-    // auto ripval = GetRegisterValue(builder, ZYDIS_REGISTER_RIP);
+  // auto newRip = createAddFolder(builder, Value, ripval, "js");
 
-    // auto newRip = createAddFolder(builder, Value, ripval, "jns");
+  branchHelper(instruction, sf, "js", branchnumber);
 
-    sf = builder.CreateNot(sf);
+  branchnumber++;
+}
+void lifterClass::lift_jns(ZydisDisassembledInstruction& instruction) {
 
-    branchHelper(builder, instruction, blockAddresses, sf, "jns", branchnumber);
+  auto sf = getFlag(FLAG_SF);
 
-    branchnumber++;
-  }
+  // auto dest = instruction.operands[0];
 
-  void lift_jz(IRBuilder<>& builder, ZydisDisassembledInstruction& instruction,
-               shared_ptr<vector<BBInfo>> blockAddresses) {
+  // auto Value = GetOperandValue( dest, 64);
+  // auto ripval = GetRegisterValue( ZYDIS_REGISTER_RIP);
 
-    // if 0, then jmp, if not then not jump
+  // auto newRip = createAddFolder(builder, Value, ripval, "jns");
 
-    auto zf = getFlag(builder, FLAG_ZF);
+  sf = builder.CreateNot(sf);
 
-    // auto dest = instruction.operands[0];
+  branchHelper(instruction, sf, "jns", branchnumber);
 
-    // auto Value = GetOperandValue(builder, dest, 64);
-    // auto ripval = GetRegisterValue(builder, ZYDIS_REGISTER_RIP);
+  branchnumber++;
+}
 
-    // auto newRip = createAddFolder(builder, Value, ripval, "jnz");
+void lifterClass::lift_jz(ZydisDisassembledInstruction& instruction) {
 
-    branchHelper(builder, instruction, blockAddresses, zf, "jz", branchnumber);
+  // if 0, then jmp, if not then not jump
 
-    branchnumber++;
-  }
+  auto zf = getFlag(FLAG_ZF);
 
-  void lift_jle(IRBuilder<>& builder, ZydisDisassembledInstruction& instruction,
-                shared_ptr<vector<BBInfo>> blockAddresses) {
-    // If SF != OF or ZF = 1, then jump. Otherwise, do not jump.
+  // auto dest = instruction.operands[0];
 
-    auto sf = getFlag(builder, FLAG_SF);
-    auto of = getFlag(builder, FLAG_OF);
-    auto zf = getFlag(builder, FLAG_ZF);
+  // auto Value = GetOperandValue( dest, 64);
+  // auto ripval = GetRegisterValue( ZYDIS_REGISTER_RIP);
 
-    // auto dest = instruction.operands[0];
-    // auto Value = GetOperandValue(builder, dest, 64);
-    // auto ripval = GetRegisterValue(builder, ZYDIS_REGISTER_RIP);
-    // auto newRip = createAddFolder(builder, Value, ripval, "jle");
+  // auto newRip = createAddFolder(builder, Value, ripval, "jnz");
 
-    // Check if SF != OF or ZF is set
-    auto sf_neq_of = createXorFolder(builder, sf, of, "jle_SF_NEQ_OF");
-    auto condition = createOrFolder(builder, sf_neq_of, zf, "jle_Condition");
+  branchHelper(instruction, zf, "jz", branchnumber);
 
-    branchHelper(builder, instruction, blockAddresses, condition, "jle",
-                 branchnumber);
+  branchnumber++;
+}
 
-    branchnumber++;
-  }
-
-  void lift_jl(IRBuilder<>& builder, ZydisDisassembledInstruction& instruction,
-               shared_ptr<vector<BBInfo>> blockAddresses) {
-    auto sf = getFlag(builder, FLAG_SF);
-    auto of = getFlag(builder, FLAG_OF);
-
-    // auto dest = instruction.operands[0];
-    // auto Value = GetOperandValue(builder, dest, 64);
-    // auto ripval = GetRegisterValue(builder, ZYDIS_REGISTER_RIP);
-    // auto newRip = createAddFolder(builder, Value, ripval, "jl");
-    printvalue(sf);
-    printvalue(of);
-    auto condition = createXorFolder(builder, sf, of, "jl_Condition");
+void lifterClass::lift_jle(ZydisDisassembledInstruction& instruction) {
+  // If SF != OF or ZF = 1, then jump. Otherwise, do not jump.
 
-    branchHelper(builder, instruction, blockAddresses, condition, "jl",
-                 branchnumber);
-
-    branchnumber++;
-  }
-  void lift_jnl(IRBuilder<>& builder, ZydisDisassembledInstruction& instruction,
-                shared_ptr<vector<BBInfo>> blockAddresses) {
-    auto sf = getFlag(builder, FLAG_SF);
-    auto of = getFlag(builder, FLAG_OF);
-
-    // auto dest = instruction.operands[0];
-    // auto Value = GetOperandValue(builder, dest, 64);
-    // auto ripval = GetRegisterValue(builder, ZYDIS_REGISTER_RIP);
-    // auto newRip = createAddFolder(builder, Value, ripval, "jnl");
+  auto sf = getFlag(FLAG_SF);
+  auto of = getFlag(FLAG_OF);
+  auto zf = getFlag(FLAG_ZF);
 
-    printvalue(sf);
-    printvalue(of);
+  // auto dest = instruction.operands[0];
+  // auto Value = GetOperandValue( dest, 64);
+  // auto ripval = GetRegisterValue( ZYDIS_REGISTER_RIP);
+  // auto newRip = createAddFolder(builder, Value, ripval, "jle");
 
-    auto condition =
-        builder.CreateNot(createXorFolder(builder, sf, of), "jnl_Condition");
+  // Check if SF != OF or ZF is set
+  auto sf_neq_of = createXorFolder(builder, sf, of, "jle_SF_NEQ_OF");
+  auto condition = createOrFolder(builder, sf_neq_of, zf, "jle_Condition");
 
-    branchHelper(builder, instruction, blockAddresses, condition, "jnl",
-                 branchnumber);
+  branchHelper(instruction, condition, "jle", branchnumber);
 
-    branchnumber++;
-  }
+  branchnumber++;
+}
 
-  void lift_jnle(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction,
-                 shared_ptr<vector<BBInfo>> blockAddresses) {
+void lifterClass::lift_jl(ZydisDisassembledInstruction& instruction) {
+  auto sf = getFlag(FLAG_SF);
+  auto of = getFlag(FLAG_OF);
 
-    auto sf = getFlag(builder, FLAG_SF);
-    auto of = getFlag(builder, FLAG_OF);
-    auto zf = getFlag(builder, FLAG_ZF);
+  // auto dest = instruction.operands[0];
+  // auto Value = GetOperandValue( dest, 64);
+  // auto ripval = GetRegisterValue( ZYDIS_REGISTER_RIP);
+  // auto newRip = createAddFolder(builder, Value, ripval, "jl");
+  printvalue(sf);
+  printvalue(of);
+  auto condition = createXorFolder(builder, sf, of, "jl_Condition");
 
-    // auto dest = instruction.operands[0];
-    // auto Value = GetOperandValue(builder, dest, 64);
-    // auto ripval = GetRegisterValue(builder, ZYDIS_REGISTER_RIP);
-    // auto newRip = createAddFolder(builder, Value, ripval, "jnle");
-    //  Jump short if greater (ZF=0 and SF=OF).
-    printvalue(sf) printvalue(zf) printvalue(of)
+  branchHelper(instruction, condition, "jl", branchnumber);
 
-        auto sf_eq_of = createXorFolder(builder, sf, of); // 0-0 or 1-1 => 0
-    auto sf_eq_of_not =
-        builder.CreateNot(sf_eq_of, "jnle_SF_EQ_OF_NOT"); // 0 => 1
-    auto zf_not = builder.CreateNot(zf, "jnle_ZF_NOT");   // zf == 0
-    auto condition =
-        createAndFolder(builder, sf_eq_of_not, zf_not, "jnle_Condition");
+  branchnumber++;
+}
+void lifterClass::lift_jnl(ZydisDisassembledInstruction& instruction) {
+  auto sf = getFlag(FLAG_SF);
+  auto of = getFlag(FLAG_OF);
 
-    branchHelper(builder, instruction, blockAddresses, condition, "jnle",
-                 branchnumber);
+  // auto dest = instruction.operands[0];
+  // auto Value = GetOperandValue( dest, 64);
+  // auto ripval = GetRegisterValue( ZYDIS_REGISTER_RIP);
+  // auto newRip = createAddFolder(builder, Value, ripval, "jnl");
 
-    branchnumber++;
-  }
+  printvalue(sf);
+  printvalue(of);
 
-  void lift_jbe(IRBuilder<>& builder, ZydisDisassembledInstruction& instruction,
-                shared_ptr<vector<BBInfo>> blockAddresses) {
+  auto condition =
+      builder.CreateNot(createXorFolder(builder, sf, of), "jnl_Condition");
 
-    auto cf = getFlag(builder, FLAG_CF);
-    auto zf = getFlag(builder, FLAG_ZF);
-    printvalue(cf) printvalue(zf) // auto dest = instruction.operands[0];
+  branchHelper(instruction, condition, "jnl", branchnumber);
 
-        // auto Value = GetOperandValue(builder, dest, 64);
-        // auto ripval = GetRegisterValue(builder, ZYDIS_REGISTER_RIP);
-        // auto newRip = createAddFolder(builder, Value, ripval, "jbe");
+  branchnumber++;
+}
 
-        auto condition = createOrFolder(builder, cf, zf, "jbe_Condition");
+void lifterClass::lift_jnle(ZydisDisassembledInstruction& instruction) {
 
-    branchHelper(builder, instruction, blockAddresses, condition, "jbe",
-                 branchnumber);
+  auto sf = getFlag(FLAG_SF);
+  auto of = getFlag(FLAG_OF);
+  auto zf = getFlag(FLAG_ZF);
 
-    branchnumber++;
-  }
+  // auto dest = instruction.operands[0];
+  // auto Value = GetOperandValue( dest, 64);
+  // auto ripval = GetRegisterValue( ZYDIS_REGISTER_RIP);
+  // auto newRip = createAddFolder(builder, Value, ripval, "jnle");
+  //  Jump short if greater (ZF=0 and SF=OF).
+  printvalue(sf) printvalue(zf) printvalue(of)
 
-  void lift_jb(IRBuilder<>& builder, ZydisDisassembledInstruction& instruction,
-               shared_ptr<vector<BBInfo>> blockAddresses) {
+      auto sf_eq_of = createXorFolder(builder, sf, of); // 0-0 or 1-1 => 0
+  auto sf_eq_of_not =
+      builder.CreateNot(sf_eq_of, "jnle_SF_EQ_OF_NOT"); // 0 => 1
+  auto zf_not = builder.CreateNot(zf, "jnle_ZF_NOT");   // zf == 0
+  auto condition =
+      createAndFolder(builder, sf_eq_of_not, zf_not, "jnle_Condition");
 
-    auto cf = getFlag(builder, FLAG_CF);
-    printvalue(cf);
-    // auto dest = instruction.operands[0];
+  branchHelper(instruction, condition, "jnle", branchnumber);
 
-    // auto Value = GetOperandValue(builder, dest, 64);
-    // auto ripval = GetRegisterValue(builder, ZYDIS_REGISTER_RIP);
-    // auto newRip = createAddFolder(builder, Value, ripval, "jb");
+  branchnumber++;
+}
 
-    auto condition = cf;
-    branchHelper(builder, instruction, blockAddresses, condition, "jb",
-                 branchnumber);
+void lifterClass::lift_jbe(ZydisDisassembledInstruction& instruction) {
 
-    branchnumber++;
-  }
+  auto cf = getFlag(FLAG_CF);
+  auto zf = getFlag(FLAG_ZF);
+  printvalue(cf) printvalue(zf) // auto dest = instruction.operands[0];
 
-  void lift_jnb(IRBuilder<>& builder, ZydisDisassembledInstruction& instruction,
-                shared_ptr<vector<BBInfo>> blockAddresses) {
+      // auto Value = GetOperandValue( dest, 64);
+      // auto ripval = GetRegisterValue( ZYDIS_REGISTER_RIP);
+      // auto newRip = createAddFolder(builder, Value, ripval, "jbe");
 
-    auto cf = getFlag(builder, FLAG_CF);
-    printvalue(cf);
-    // auto dest = instruction.operands[0];
+      auto condition = createOrFolder(builder, cf, zf, "jbe_Condition");
 
-    // auto Value = GetOperandValue(builder, dest, 64);
-    // auto ripval = GetRegisterValue(builder, ZYDIS_REGISTER_RIP);
-    // auto newRip = createAddFolder(builder, Value, ripval, "jnb");
+  branchHelper(instruction, condition, "jbe", branchnumber);
 
-    auto condition = builder.CreateNot(cf, "notCF");
-    branchHelper(builder, instruction, blockAddresses, condition, "jnb",
-                 branchnumber);
+  branchnumber++;
+}
 
-    branchnumber++;
-  }
+void lifterClass::lift_jb(ZydisDisassembledInstruction& instruction) {
 
-  void lift_jnbe(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction,
-                 shared_ptr<vector<BBInfo>> blockAddresses) {
+  auto cf = getFlag(FLAG_CF);
+  printvalue(cf);
+  // auto dest = instruction.operands[0];
 
-    auto cf = getFlag(builder, FLAG_CF);
-    auto zf = getFlag(builder, FLAG_ZF);
+  // auto Value = GetOperandValue( dest, 64);
+  // auto ripval = GetRegisterValue( ZYDIS_REGISTER_RIP);
+  // auto newRip = createAddFolder(builder, Value, ripval, "jb");
 
-    printvalue(cf);
-    printvalue(zf);
-    // auto dest = instruction.operands[0];
+  auto condition = cf;
+  branchHelper(instruction, condition, "jb", branchnumber);
 
-    // auto Value = GetOperandValue(builder, dest, 64);
-    // auto ripval = GetRegisterValue(builder, ZYDIS_REGISTER_RIP);
-    // auto newRip = createAddFolder(builder, Value, ripval, "jnbe");
+  branchnumber++;
+}
 
-    auto condition =
-        createAndFolder(builder, builder.CreateNot(cf, "notCF"),
-                        builder.CreateNot(zf, "notZF"), "jnbe_ja_Condition");
+void lifterClass::lift_jnb(ZydisDisassembledInstruction& instruction) {
 
-    branchHelper(builder, instruction, blockAddresses, condition, "jnbe_ja",
-                 branchnumber);
+  auto cf = getFlag(FLAG_CF);
+  printvalue(cf);
+  // auto dest = instruction.operands[0];
 
-    branchnumber++;
-  }
+  // auto Value = GetOperandValue( dest, 64);
+  // auto ripval = GetRegisterValue( ZYDIS_REGISTER_RIP);
+  // auto newRip = createAddFolder(builder, Value, ripval, "jnb");
 
-  void lift_jo(IRBuilder<>& builder, ZydisDisassembledInstruction& instruction,
-               shared_ptr<vector<BBInfo>> blockAddresses) {
+  auto condition = builder.CreateNot(cf, "notCF");
+  branchHelper(instruction, condition, "jnb", branchnumber);
 
-    auto of = getFlag(builder, FLAG_OF);
+  branchnumber++;
+}
 
-    // auto dest = instruction.operands[0];
+void lifterClass::lift_jnbe(ZydisDisassembledInstruction& instruction) {
 
-    // auto Value = GetOperandValue(builder, dest, 64);
-    // auto ripval = GetRegisterValue(builder, ZYDIS_REGISTER_RIP);
+  auto cf = getFlag(FLAG_CF);
+  auto zf = getFlag(FLAG_ZF);
 
-    // auto newRip = createAddFolder(builder, Value, ripval, "jo");
+  printvalue(cf);
+  printvalue(zf);
+  // auto dest = instruction.operands[0];
 
-    printvalue(of);
-    branchHelper(builder, instruction, blockAddresses, of, "jo", branchnumber);
+  // auto Value = GetOperandValue( dest, 64);
+  // auto ripval = GetRegisterValue( ZYDIS_REGISTER_RIP);
+  // auto newRip = createAddFolder(builder, Value, ripval, "jnbe");
 
-    branchnumber++;
-  }
+  auto condition =
+      createAndFolder(builder, builder.CreateNot(cf, "notCF"),
+                      builder.CreateNot(zf, "notZF"), "jnbe_ja_Condition");
 
-  void lift_jno(IRBuilder<>& builder, ZydisDisassembledInstruction& instruction,
-                shared_ptr<vector<BBInfo>> blockAddresses) {
+  branchHelper(instruction, condition, "jnbe_ja", branchnumber);
 
-    auto of = getFlag(builder, FLAG_OF);
+  branchnumber++;
+}
 
-    // auto dest = instruction.operands[0];
+void lifterClass::lift_jo(ZydisDisassembledInstruction& instruction) {
 
-    // auto Value = GetOperandValue(builder, dest, 64);
-    // auto ripval = GetRegisterValue(builder, ZYDIS_REGISTER_RIP);
+  auto of = getFlag(FLAG_OF);
 
-    // auto newRip = createAddFolder(builder, Value, ripval, "jno");
+  // auto dest = instruction.operands[0];
 
-    of = builder.CreateNot(of);
-    branchHelper(builder, instruction, blockAddresses, of, "jno", branchnumber);
+  // auto Value = GetOperandValue( dest, 64);
+  // auto ripval = GetRegisterValue( ZYDIS_REGISTER_RIP);
 
-    branchnumber++;
-  }
+  // auto newRip = createAddFolder(builder, Value, ripval, "jo");
 
-  void lift_jp(IRBuilder<>& builder, ZydisDisassembledInstruction& instruction,
-               shared_ptr<vector<BBInfo>> blockAddresses) {
+  printvalue(of);
+  branchHelper(instruction, of, "jo", branchnumber);
 
-    auto pf = getFlag(builder, FLAG_PF);
-    printvalue(pf);
-    // auto dest = instruction.operands[0];
+  branchnumber++;
+}
 
-    // auto Value = GetOperandValue(builder, dest, 64);
-    // auto ripval = GetRegisterValue(builder, ZYDIS_REGISTER_RIP);
+void lifterClass::lift_jno(ZydisDisassembledInstruction& instruction) {
 
-    // auto newRip = createAddFolder(builder, Value, ripval, "jp");
+  auto of = getFlag(FLAG_OF);
 
-    branchHelper(builder, instruction, blockAddresses, pf, "jp", branchnumber);
+  // auto dest = instruction.operands[0];
 
-    branchnumber++;
-  }
+  // auto Value = GetOperandValue( dest, 64);
+  // auto ripval = GetRegisterValue( ZYDIS_REGISTER_RIP);
 
-  void lift_jnp(IRBuilder<>& builder, ZydisDisassembledInstruction& instruction,
-                shared_ptr<vector<BBInfo>> blockAddresses) {
+  // auto newRip = createAddFolder(builder, Value, ripval, "jno");
 
-    auto pf = getFlag(builder, FLAG_PF);
+  of = builder.CreateNot(of);
+  branchHelper(instruction, of, "jno", branchnumber);
 
-    // auto dest = instruction.operands[0];
+  branchnumber++;
+}
 
-    // auto Value = GetOperandValue(builder, dest, 64);
-    // auto ripval = GetRegisterValue(builder, ZYDIS_REGISTER_RIP);
+void lifterClass::lift_jp(ZydisDisassembledInstruction& instruction) {
 
-    // auto newRip = createAddFolder(builder, Value, ripval, "jnp");
+  auto pf = getFlag(FLAG_PF);
+  printvalue(pf);
+  // auto dest = instruction.operands[0];
 
-    pf = builder.CreateNot(pf);
-    printvalue(pf);
-    branchHelper(builder, instruction, blockAddresses, pf, "jnp", branchnumber);
+  // auto Value = GetOperandValue( dest, 64);
+  // auto ripval = GetRegisterValue( ZYDIS_REGISTER_RIP);
 
-    branchnumber++;
-  }
+  // auto newRip = createAddFolder(builder, Value, ripval, "jp");
 
-} // namespace branches
+  branchHelper(instruction, pf, "jp", branchnumber);
 
-namespace arithmeticsAndLogical {
-  void lift_sbb(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
+  branchnumber++;
+}
 
-    //
+void lifterClass::lift_jnp(ZydisDisassembledInstruction& instruction) {
 
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
+  auto pf = getFlag(FLAG_PF);
 
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-    Value* Rvalue = GetOperandValue(builder, src, dest.size);
-    Value* cf = createZExtOrTruncFolder(builder, getFlag(builder, FLAG_CF),
-                                        Rvalue->getType());
+  // auto dest = instruction.operands[0];
 
-    Value* srcPlusCF = createAddFolder(builder, Rvalue, cf, "srcPlusCF");
-    Value* tmpResult =
-        createSubFolder(builder, Lvalue, srcPlusCF, "sbbTempResult");
-    SetOperandValue(builder, dest, tmpResult);
+  // auto Value = GetOperandValue( dest, 64);
+  // auto ripval = GetRegisterValue( ZYDIS_REGISTER_RIP);
 
-    Value* newCF = createICMPFolder(builder, CmpInst::ICMP_ULT, Lvalue,
-                                    srcPlusCF, "newCF");
-    Value* sf = computeSignFlag(builder, tmpResult);
-    Value* zf = computeZeroFlag(builder, tmpResult);
-    Value* pf = computeParityFlag(builder, tmpResult);
-    Value* af = computeAuxFlagSbb(builder, Lvalue, Rvalue, cf);
+  // auto newRip = createAddFolder(builder, Value, ripval, "jnp");
 
-    auto of = computeOverflowFlagSbb(builder, Lvalue, Rvalue, cf, tmpResult);
+  pf = builder.CreateNot(pf);
+  printvalue(pf);
+  branchHelper(instruction, pf, "jnp", branchnumber);
 
-    setFlag(builder, FLAG_CF, newCF);
-    setFlag(builder, FLAG_SF, sf);
-    setFlag(builder, FLAG_ZF, zf);
-    setFlag(builder, FLAG_PF, pf);
-    setFlag(builder, FLAG_AF, af);
-    setFlag(builder, FLAG_OF, of);
-    printvalue(Lvalue);
-    printvalue(Rvalue);
-    printvalue(tmpResult);
-    printvalue(sf);
-    printvalue(of);
-  }
+  branchnumber++;
+}
 
-  /*
+void lifterClass::lift_sbb(ZydisDisassembledInstruction& instruction) {
 
-  (* RCL and RCR Instructions *)
-  SIZE := OperandSize;
-  CASE (determine count) OF
-          SIZE := 8: tempCOUNT := (COUNT AND 1FH) MOD 9;
-          SIZE := 16: tempCOUNT := (COUNT AND 1FH) MOD 17;
-          SIZE := 32: tempCOUNT := COUNT AND 1FH;
-          SIZE := 64: tempCOUNT := COUNT AND 3FH;
-  ESAC;
-  IF OperandSize = 64
-          THEN COUNTMASK = 3FH;
-          ELSE COUNTMASK = 1FH;
-  FI;
-  (* RCL Instruction Operation *)
-  WHILE (tempCOUNT ≠ 0)
-          DO
-          tempCF := MSB(DEST);
-          DEST := (DEST ∗ 2) + CF;
-          CF := tempCF;
-          tempCOUNT := tempCOUNT – 1;
-          OD;
-  ELIHW;
-  IF (COUNT & COUNTMASK) = 1
-          THEN OF := MSB(DEST) XOR CF;
-          ELSE OF is undefined;
-  FI;
-  */
+  //
 
-void lift_rcl(IRBuilder<>& builder, ZydisDisassembledInstruction& instruction) {
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+  Value* Rvalue = GetOperandValue(src, dest.size);
+  Value* cf =
+      createZExtOrTruncFolder(builder, getFlag(FLAG_CF), Rvalue->getType());
+
+  Value* srcPlusCF = createAddFolder(builder, Rvalue, cf, "srcPlusCF");
+  Value* tmpResult =
+      createSubFolder(builder, Lvalue, srcPlusCF, "sbbTempResult");
+  SetOperandValue(dest, tmpResult);
+
+  Value* newCF =
+      createICMPFolder(builder, CmpInst::ICMP_ULT, Lvalue, srcPlusCF, "newCF");
+  Value* sf = computeSignFlag(builder, tmpResult);
+  Value* zf = computeZeroFlag(builder, tmpResult);
+  Value* pf = computeParityFlag(builder, tmpResult);
+  Value* af = computeAuxFlagSbb(builder, Lvalue, Rvalue, cf);
+
+  auto of = computeOverflowFlagSbb(builder, Lvalue, Rvalue, cf, tmpResult);
+
+  setFlag(FLAG_CF, newCF);
+  setFlag(FLAG_SF, sf);
+  setFlag(FLAG_ZF, zf);
+  setFlag(FLAG_PF, pf);
+  setFlag(FLAG_AF, af);
+  setFlag(FLAG_OF, of);
+  printvalue(Lvalue);
+  printvalue(Rvalue);
+  printvalue(tmpResult);
+  printvalue(sf);
+  printvalue(of);
+}
+
+/*
+
+(* RCL and RCR Instructions *)
+SIZE := OperandSize;
+CASE (determine count) OF
+        SIZE := 8: tempCOUNT := (COUNT AND 1FH) MOD 9;
+        SIZE := 16: tempCOUNT := (COUNT AND 1FH) MOD 17;
+        SIZE := 32: tempCOUNT := COUNT AND 1FH;
+        SIZE := 64: tempCOUNT := COUNT AND 3FH;
+ESAC;
+IF OperandSize = 64
+        THEN COUNTMASK = 3FH;
+        ELSE COUNTMASK = 1FH;
+FI;
+(* RCL Instruction Operation *)
+WHILE (tempCOUNT ≠ 0)
+        DO
+        tempCF := MSB(DEST);
+        DEST := (DEST ∗ 2) + CF;
+        CF := tempCF;
+        tempCOUNT := tempCOUNT – 1;
+        OD;
+ELIHW;
+IF (COUNT & COUNTMASK) = 1
+        THEN OF := MSB(DEST) XOR CF;
+        ELSE OF is undefined;
+FI;
+*/
+
+void lifterClass::lift_rcl(ZydisDisassembledInstruction& instruction) {
   LLVMContext& context = builder.getContext();
   auto dest = instruction.operands[0];
   auto count = instruction.operands[1];
 
-  Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-  Value* countValue = GetOperandValue(builder, count, dest.size);
-  Value* carryFlag = getFlag(builder, FLAG_CF);
+  auto Lvalue = GetOperandValue(dest, dest.size);
+  auto countValue = GetOperandValue(count, dest.size);
+  auto carryFlag = getFlag(FLAG_CF);
 
   unsigned long bitWidth = Lvalue->getType()->getIntegerBitWidth();
   unsigned maskC = bitWidth == 64 ? 0x3f : 0x1f;
 
-  // Calculate actual count
-  Value* countMask = ConstantInt::get(countValue->getType(), maskC);
-  Value* actualCount = createAndFolder(builder, countValue, countMask, "actualCount");
+  auto actualCount = createAndFolder(
+      builder, countValue, ConstantInt::get(countValue->getType(), maskC),
+      "actualCount");
 
-  // Extend Lvalue to double width
-  Type* wideType = Type::getIntNTy(context, dest.size * 2);
-  Value* wideLvalue = createZExtFolder(builder, Lvalue, wideType);
+  auto wideType = Type::getIntNTy(context, dest.size * 2);
+  auto wideLvalue = createZExtFolder(builder, Lvalue, wideType);
+  auto cf_extended = createZExtFolder(builder, carryFlag, wideType);
+  auto shiftedInCF =
+      createShlFolder(builder, cf_extended, dest.size, "shiftedincf");
+  wideLvalue = createOrFolder(
+      builder, wideLvalue,
+      createZExtFolder(builder, shiftedInCF, wideType, "shiftedInCFExtended"));
 
-  // Shift the carry flag into the LSB
-  Value* cf_extended = createZExtFolder(builder, carryFlag, wideType);
-  Value* shiftedInCF = createOrFolder(builder, wideLvalue, cf_extended, "shiftedincf");
+  auto leftShifted = createShlFolder(
+      builder, wideLvalue,
+      createZExtFolder(builder, actualCount, wideType, "actualCountExtended"),
+      "leftshifted");
+  auto rightShiftAmount = createSubFolder(
+      builder, ConstantInt::get(actualCount->getType(), dest.size), actualCount,
+      "rightshiftamount");
+  auto rightShifted = createLShrFolder(
+      builder, wideLvalue,
+      createZExtFolder(builder, rightShiftAmount, wideType), "rightshifted");
+  auto rotated =
+      createOrFolder(builder, leftShifted,
+                     createZExtFolder(builder, rightShifted, wideType,
+                                      "rightShiftedExtended"));
 
-  // Perform the rotation
-  Value* shiftAmount = createZExtFolder(builder, actualCount, wideType);
-  Value* bitWidthPlusOne = ConstantInt::get(wideType, bitWidth + 1);
-  Value* inverseShiftAmount = createSubFolder(builder, bitWidthPlusOne, shiftAmount);
+  auto result = createZExtOrTruncFolder(builder, rotated, Lvalue->getType());
 
-  Value* leftShifted = createShlFolder(builder, shiftedInCF, shiftAmount, "leftshifted");
-  Value* rightShifted = createLShrFolder(builder, shiftedInCF, inverseShiftAmount, "rightshifted");
-  Value* rotated = createOrFolder(builder, leftShifted, rightShifted);
+  auto newCFBitPosition = ConstantInt::get(rotated->getType(), dest.size - 1);
+  auto newCF = createZExtOrTruncFolder(
+      builder, createLShrFolder(builder, rotated, newCFBitPosition),
+      Type::getInt1Ty(context), "rclnewcf");
 
-  // Extract the result and new carry flag
-  Value* result = createTruncFolder(builder, rotated, Lvalue->getType());
-  Value* newCFShifted = createLShrFolder(builder, rotated, ConstantInt::get(wideType, bitWidth));
-  Value* newCF = createTruncFolder(builder, newCFShifted, Type::getInt1Ty(context), "rclnewcf");
+  auto msbAfterRotate = createZExtOrTruncFolder(
+      builder, createLShrFolder(builder, result, dest.size - 1),
+      Type::getInt1Ty(context), "rclmsbafterrotate");
+  auto isCountOne =
+      createICMPFolder(builder, CmpInst::ICMP_EQ, actualCount,
+                       ConstantInt::get(actualCount->getType(), 1));
+  auto newOF = createZExtOrTruncFolder(
+      builder, createXorFolder(builder, newCF, msbAfterRotate),
+      Type::getInt1Ty(context));
+  newOF = createSelectFolder(builder, isCountOne, newOF, getFlag(FLAG_OF));
 
-  // Calculate OF (only valid when count == 1)
-  Value* resultMSB = createLShrFolder(builder, result, ConstantInt::get(result->getType(), bitWidth - 1));
-  Value* msbAfterRotate = createTruncFolder(builder, resultMSB, Type::getInt1Ty(context), "rclmsbafterrotate");
+  printvalue(Lvalue) printvalue(countValue) printvalue(carryFlag)
+      printvalue(cf_extended) printvalue(shiftedInCF) printvalue(actualCount)
+          printvalue(wideLvalue) printvalue(leftShifted)
+              printvalue(rightShifted) printvalue(rotated) printvalue(result)
 
-  Value* one = ConstantInt::get(actualCount->getType(), 1);
-  Value* isCountOne = createICMPFolder(builder, CmpInst::ICMP_EQ, actualCount, one);
-
-  Value* newOF = createXorFolder(builder, newCF, msbAfterRotate);
-  Value* currentOF = getFlag(builder, FLAG_OF);
-  newOF = createSelectFolder(builder, isCountOne, newOF, currentOF);
-
-  // Set the result and flags
-  SetOperandValue(builder, dest, result);
-  setFlag(builder, FLAG_CF, newCF);
-  setFlag(builder, FLAG_OF, newOF);
-
-  // Debug output
-  printvalue(Lvalue);
-  printvalue(countValue);
-  printvalue(carryFlag);
-  printvalue(actualCount);
-  printvalue(shiftedInCF);
-  printvalue(rotated);
-  printvalue(result);
-  printvalue(newCF);
-  printvalue(newOF);
+                  SetOperandValue(dest, result);
+  setFlag(FLAG_CF, newCF);
+  setFlag(FLAG_OF, newOF);
 }
 
 /*
@@ -1459,2901 +1399,2778 @@ WHILE (tempCOUNT ≠ 0)
 ELIHW;
 
 */
-void lift_rcr(IRBuilder<>& builder, ZydisDisassembledInstruction& instruction) {
+void lifterClass::lift_rcr(ZydisDisassembledInstruction& instruction) {
   LLVMContext& context = builder.getContext();
   auto dest = instruction.operands[0];
   auto count = instruction.operands[1];
 
-  Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-  Value* countValue = GetOperandValue(builder, count, dest.size);
-  Value* carryFlag = getFlag(builder, FLAG_CF);
+  auto Lvalue = GetOperandValue(dest, dest.size);
+  auto countValue = GetOperandValue(count, dest.size);
+  auto carryFlag = getFlag(FLAG_CF);
 
   unsigned long bitWidth = Lvalue->getType()->getIntegerBitWidth();
   unsigned maskC = bitWidth == 64 ? 0x3f : 0x1f;
 
-  // Calculate actual count
-  Value* countMask = ConstantInt::get(countValue->getType(), maskC);
-  Value* actualCount = createAndFolder(builder, countValue, countMask, "actualCount");
+  auto actualCount = createAndFolder(
+      builder, countValue, ConstantInt::get(countValue->getType(), maskC),
+      "actualCount");
+  auto wideType = Type::getIntNTy(context, dest.size * 2);
+  auto wideLvalue = createZExtFolder(builder, Lvalue, wideType);
+  auto shiftedInCF = createShlFolder(
+      builder, createZExtFolder(builder, carryFlag, wideType), dest.size);
+  wideLvalue = createOrFolder(
+      builder, wideLvalue,
+      createZExtFolder(builder, shiftedInCF, wideType, "shiftedInCFExtended"));
 
-  // Extend Lvalue to double width and shift left by 1 to make room for CF
-  Type* wideType = Type::getIntNTy(context, dest.size * 2);
-  Value* wideLvalue = createZExtFolder(builder, Lvalue, wideType);
-  Value* shiftedLvalue =
-      createShlFolder(builder, wideLvalue, ConstantInt::get(wideType, 1));
+  auto rightShifted = createLShrFolder(
+      builder, wideLvalue,
+      createZExtFolder(builder, actualCount, wideType, "actualCountExtended"),
+      "rightshifted");
+  auto leftShiftAmount = createSubFolder(
+      builder, ConstantInt::get(actualCount->getType(), dest.size),
+      actualCount);
+  auto leftShifted =
+      createShlFolder(builder, wideLvalue,
+                      createZExtFolder(builder, leftShiftAmount, wideType,
+                                       "leftShiftAmountExtended"));
+  auto rotated = createOrFolder(builder, rightShifted, leftShifted);
 
-  // Insert the carry flag into the MSB
-  Value* cf_extended = createZExtFolder(builder, carryFlag, wideType);
-  Value* shiftedCF = createShlFolder(builder, cf_extended, ConstantInt::get(wideType, bitWidth));
-  Value* shiftedInCF = createOrFolder(builder, shiftedLvalue, shiftedCF, "shiftedincf");
+  auto result = createZExtOrTruncFolder(builder, rotated, Lvalue->getType());
 
-  // Perform the rotation
-  Value* shiftAmount = createZExtFolder(builder, actualCount, wideType);
-  Value* bitWidthPlusOne = ConstantInt::get(wideType, bitWidth + 1);
-  Value* inverseShiftAmount = createSubFolder(builder, bitWidthPlusOne, shiftAmount);
+  auto newCFBitPosition = ConstantInt::get(rotated->getType(), dest.size - 1);
+  auto newCF = createZExtOrTruncFolder(
+      builder, createLShrFolder(builder, rotated, newCFBitPosition),
+      Type::getInt1Ty(context), "rcrcf");
 
-  Value* rightShifted = createLShrFolder(builder, shiftedInCF, shiftAmount, "rightshifted");
-  Value* leftShifted = createShlFolder(builder, shiftedInCF, inverseShiftAmount, "leftshifted");
-  Value* rotated = createOrFolder(builder, rightShifted, leftShifted);
+  auto msbAfterRotate = createZExtOrTruncFolder(
+      builder, createLShrFolder(builder, result, dest.size - 1),
+      Type::getInt1Ty(context), "rcrmsb");
+  auto newOF = createSelectFolder(
+      builder,
+      createICMPFolder(builder, CmpInst::ICMP_EQ, actualCount,
+                       ConstantInt::get(actualCount->getType(), 1)),
+      createXorFolder(builder, newCF, msbAfterRotate), getFlag(FLAG_OF));
 
-  // Extract the result and new carry flag
-  Value* shiftedResult = createLShrFolder(builder, rotated, ConstantInt::get(wideType, 1));
-  Value* result = createTruncFolder(builder, shiftedResult, Lvalue->getType());
-  Value* newCF = createTruncFolder(builder, rotated, Type::getInt1Ty(context), "rcrnewcf");
+  Value* isCountOne =
+      createICMPFolder(builder, CmpInst::ICMP_EQ, actualCount,
+                       ConstantInt::get(actualCount->getType(), 1));
 
-  // Calculate OF (only valid when count == 1)
-  Value* resultMSB = createLShrFolder(builder, result, ConstantInt::get(result->getType(), bitWidth - 1));
-  Value* msbAfterRotate = createTruncFolder(builder, resultMSB, Type::getInt1Ty(context), "rcrmsbafterrotate");
+  newCF = createSelectFolder(builder, isCountOne, newOF, getFlag(FLAG_OF));
+  result = createSelectFolder(builder, isCountOne, result, Lvalue);
 
-  Value* LvalueMSB = createLShrFolder(builder, Lvalue, ConstantInt::get(Lvalue->getType(), bitWidth - 1));
-  Value* msbBeforeRotate = createTruncFolder(builder, LvalueMSB, Type::getInt1Ty(context), "rcrmsbbeforerotate");
-
-  Value* one = ConstantInt::get(actualCount->getType(), 1);
-  Value* isCountOne = createICMPFolder(builder, CmpInst::ICMP_EQ, actualCount, one);
-
-  Value* newOF = createXorFolder(builder, msbBeforeRotate, msbAfterRotate);
-  Value* currentOF = getFlag(builder, FLAG_OF);
-  newOF = createSelectFolder(builder, isCountOne, newOF, currentOF);
-
-  // Set the result and flags
-  SetOperandValue(builder, dest, result);
-  setFlag(builder, FLAG_CF, newCF);
-  setFlag(builder, FLAG_OF, newOF);
-
-  // Debug output
-  printvalue(Lvalue);
-  printvalue(countValue);
-  printvalue(carryFlag);
-  printvalue(actualCount);
-  printvalue(shiftedInCF);
-  printvalue(rotated);
-  printvalue(result);
-  printvalue(newCF);
-  printvalue(newOF);
+  SetOperandValue(dest, result);
+  setFlag(FLAG_CF, newCF);
+  setFlag(FLAG_OF, newOF);
 }
 
-  void lift_neg(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
+void lifterClass::lift_not(ZydisDisassembledInstruction& instruction) {
 
-    auto dest = instruction.operands[0];
-    auto Rvalue = GetOperandValue(builder, dest, dest.size);
+  auto dest = instruction.operands[0];
 
-    auto cf = createICMPFolder(builder, CmpInst::ICMP_NE, Rvalue,
-                               ConstantInt::get(Rvalue->getType(), 0), "cf");
-    auto result = builder.CreateNeg(Rvalue, "neg");
-    SetOperandValue(builder, dest, result);
+  auto Rvalue = GetOperandValue(dest, dest.size);
+  Rvalue = builder.CreateNot(
+      Rvalue, "realnot-" + to_string(instruction.runtime_address) + "-");
+  SetOperandValue(dest, Rvalue, to_string(instruction.runtime_address));
 
-    auto sf = computeSignFlag(builder, result);
-    auto zf = computeZeroFlag(builder, result);
-    auto pf = computeParityFlag(builder, result);
-    Value* fifteen = ConstantInt::get(Rvalue->getType(), 0xf);
-    auto af = createICMPFolder(builder, CmpInst::ICMP_NE,
-                               createAndFolder(builder, Rvalue, fifteen),
-                               ConstantInt::get(Rvalue->getType(), 0), "af");
-    auto isZero =
-        createICMPFolder(builder, CmpInst::ICMP_NE, Rvalue,
-                         ConstantInt::get(Rvalue->getType(), 0), "zero");
+  printvalue(Rvalue);
+  //  Flags Affected
+  // None
+}
 
-    printvalue(Rvalue) printvalue(result) printvalue(sf);
-    // OF is not cleared?
+void lifterClass::lift_neg(ZydisDisassembledInstruction& instruction) {
 
-    Value* of;
-    if (dest.size > 32)
-      of = ConstantInt::getSigned(Rvalue->getType(), 0);
-    else {
-      of = createICMPFolder(builder, CmpInst::ICMP_EQ, result, Rvalue);
-      of = createSelectFolder(builder, isZero, of,
-                              ConstantInt::get(of->getType(), 0));
-    }
+  auto dest = instruction.operands[0];
+  auto Rvalue = GetOperandValue(dest, dest.size);
 
-    printvalue(of);
-    // The CF flag set to 0 if the source operand is 0; otherwise it is set
-    // to 1. The OF, SF, ZF, AF, and PF flags are set according to the
-    // result.
-    setFlag(builder, FLAG_CF, cf);
-    setFlag(builder, FLAG_SF, sf);
-    setFlag(builder, FLAG_ZF, zf);
-    setFlag(builder, FLAG_PF, pf);
-    setFlag(builder, FLAG_OF, of);
-    setFlag(builder, FLAG_AF, af);
+  auto cf = createICMPFolder(builder, CmpInst::ICMP_NE, Rvalue,
+                             ConstantInt::get(Rvalue->getType(), 0), "cf");
+  auto result = builder.CreateNeg(Rvalue, "neg");
+  SetOperandValue(dest, result);
+
+  auto sf = computeSignFlag(builder, result);
+  auto zf = computeZeroFlag(builder, result);
+  auto pf = computeParityFlag(builder, result);
+  Value* fifteen = ConstantInt::get(Rvalue->getType(), 0xf);
+  auto af = createICMPFolder(builder, CmpInst::ICMP_NE,
+                             createAndFolder(builder, Rvalue, fifteen),
+                             ConstantInt::get(Rvalue->getType(), 0), "af");
+  auto isZero =
+      createICMPFolder(builder, CmpInst::ICMP_NE, Rvalue,
+                       ConstantInt::get(Rvalue->getType(), 0), "zero");
+
+  printvalue(Rvalue) printvalue(result) printvalue(sf);
+  // OF is not cleared?
+
+  Value* of;
+  if (dest.size > 32)
+    of = ConstantInt::getSigned(Rvalue->getType(), 0);
+  else {
+    of = createICMPFolder(builder, CmpInst::ICMP_EQ, result, Rvalue);
+    of = createSelectFolder(builder, isZero, of,
+                            ConstantInt::get(of->getType(), 0));
   }
+
+  printvalue(of);
+  // The CF flag set to 0 if the source operand is 0; otherwise it is set
+  // to 1. The OF, SF, ZF, AF, and PF flags are set according to the
+  // result.
+  setFlag(FLAG_CF, cf);
+  setFlag(FLAG_SF, sf);
+  setFlag(FLAG_ZF, zf);
+  setFlag(FLAG_PF, pf);
+  setFlag(FLAG_OF, of);
+  setFlag(FLAG_AF, af);
+}
+
+/*
+
+IF 64-Bit Mode and using REX.W
+        THEN
+                countMASK := 3FH;
+        ELSE
+                countMASK := 1FH;
+FI
+tempCOUNT := (COUNT AND countMASK);
+tempDEST := DEST;
+WHILE (tempCOUNT ≠ 0)
+DO
+        IF instruction is SAL or SHL
+                THEN
+                CF := MSB(DEST);
+        ELSE (* Instruction is SAR or SHR *)
+                CF := LSB(DEST);
+        FI;
+        IF instruction is SAL or SHL
+                THEN
+                        DEST := DEST ∗ 2;
+        ELSE
+                IF instruction is SAR
+                        THEN
+                                DEST := DEST / 2; (* Signed divide, rounding
+toward negative infinity *) ELSE (* Instruction is SHR *) DEST := DEST / 2 ;
+(* Unsigned divide *) FI; FI; tempCOUNT := tempCOUNT – 1; OD;
+
+(* Determine overflow for the various instructions *)
+IF (COUNT and countMASK) = 1
+        THEN
+        IF instruction is SAL or SHL
+                THEN
+                OF := MSB(DEST) XOR CF;
+        ELSE
+        IF instruction is SAR
+                THEN
+                OF := 0;
+        ELSE (* Instruction is SHR *)
+                OF := MSB(tempDEST);
+        FI;
+FI;
+
+ELSE IF (COUNT AND countMASK) = 0
+        THEN
+        All flags unchanged;
+ELSE (* COUNT not 1 or 0 *)
+OF := undefined;
+FI;
+FI;
+
+*/
+// maybe
+
+void lifterClass::lift_sar(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
+  auto count = instruction.operands[1];
+
+  Value* Lvalue =
+      GetOperandValue(dest, dest.size, to_string(instruction.runtime_address));
+  Value* countValue = GetOperandValue(count, dest.size);
+
+  Value* zero = ConstantInt::get(countValue->getType(), 0);
+  uint8_t bitWidth = Lvalue->getType()->getIntegerBitWidth();
+  uint8_t maskC = bitWidth == 64 ? 0x3f : 0x1f;
+
+  Value* clampedCount = createAndFolder(
+      builder, countValue, ConstantInt::get(countValue->getType(), maskC),
+      "sarclamp");
+  Value* result = builder.CreateAShr(
+      Lvalue, clampedCount,
+      "sar-lshr-" + to_string(instruction.runtime_address) + "-");
+
+  Value* isZeroed =
+      createICMPFolder(builder, CmpInst::ICMP_UGT, clampedCount,
+                       ConstantInt::get(clampedCount->getType(), bitWidth - 1));
+  result = createSelectFolder(builder, isZeroed, zero, result);
+
+  auto cfRvalue = createSubFolder(builder, clampedCount,
+                                  ConstantInt::get(clampedCount->getType(), 1));
+  auto cfShl = createShlFolder(
+      builder, ConstantInt::get(cfRvalue->getType(), 1), cfRvalue);
+  auto cfAnd = createAndFolder(builder, cfShl, Lvalue);
+  auto cfValue = createICMPFolder(builder, CmpInst::ICMP_NE, cfAnd,
+                                  ConstantInt::get(cfAnd->getType(), 0));
+
+  Value* isCountOne =
+      createICMPFolder(builder, CmpInst::ICMP_EQ, clampedCount,
+                       ConstantInt::get(clampedCount->getType(), 1));
+  Value* of = createSelectFolder(builder, isCountOne, builder.getInt1(0),
+                                 getFlag(FLAG_OF));
+
+  Value* isNotZero =
+      createICMPFolder(builder, CmpInst::ICMP_NE, clampedCount, zero);
+  Value* oldcf = getFlag(FLAG_CF);
+  cfValue = createSelectFolder(builder, isNotZero, cfValue, oldcf);
+  cfValue = createSelectFolder(
+      builder, isZeroed, builder.CreateTrunc(zero, Type::getInt1Ty(context)),
+      cfValue);
+
+  Value* sf = computeSignFlag(builder, result);
+  Value* zf = computeZeroFlag(builder, result);
+  Value* pf = computeParityFlag(builder, result);
+  printvalue(Lvalue) printvalue2(bitWidth) printvalue(countValue);
+  printvalue(clampedCount) printvalue(result) printvalue(isNotZero);
+  printvalue(cfValue) printvalue(oldcf);
+  setFlag(FLAG_CF, cfValue);
+  setFlag(FLAG_OF, of);
+  setFlag(FLAG_SF, sf);
+  setFlag(FLAG_ZF, zf);
+  setFlag(FLAG_PF, pf);
+
+  SetOperandValue(dest, result, to_string(instruction.runtime_address));
+  ;
+}
+// TODO fix
+void lifterClass::lift_shr(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
+  auto count = instruction.operands[1];
+
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+  Value* countValue = GetOperandValue(count, dest.size);
+
+  unsigned bitWidth = Lvalue->getType()->getIntegerBitWidth();
+  unsigned maskC = bitWidth == 64 ? 0x3f : 0x1f;
+
+  Value* clampedCount = createAndFolder(
+      builder, countValue, ConstantInt::get(countValue->getType(), maskC),
+      "shrclamp");
+
+  Value* result = createLShrFolder(
+      builder, Lvalue, clampedCount,
+      "shr-lshr-" + to_string(instruction.runtime_address) + "-");
+  Value* zero = ConstantInt::get(countValue->getType(), 0);
+  Value* isZeroed =
+      createICMPFolder(builder, CmpInst::ICMP_UGT, clampedCount,
+                       ConstantInt::get(clampedCount->getType(), bitWidth - 1));
+  result = createSelectFolder(builder, isZeroed, zero, result, "shiftValue");
+
+  Value* cfValue = builder.CreateTrunc(
+      createLShrFolder(
+          builder, Lvalue,
+          createSubFolder(builder, clampedCount,
+                          ConstantInt::get(clampedCount->getType(), 1)),
+          "shrcf"),
+      builder.getInt1Ty());
+
+  Value* isCountOne =
+      createICMPFolder(builder, CmpInst::ICMP_EQ, clampedCount,
+                       ConstantInt::get(clampedCount->getType(), 1));
+  Value* of = createICMPFolder(builder, CmpInst::ICMP_SLT, Lvalue,
+                               ConstantInt::get(Lvalue->getType(), 0));
+  of = createSelectFolder(builder, isCountOne, of, getFlag(FLAG_OF), "of");
+
+  Value* isNotZero =
+      createICMPFolder(builder, CmpInst::ICMP_NE, clampedCount, zero);
+  Value* oldcf = getFlag(FLAG_CF);
+  cfValue = createSelectFolder(builder, isNotZero, cfValue, oldcf, "cfValue1");
+  cfValue = createSelectFolder(
+      builder, isZeroed, builder.CreateTrunc(zero, Type::getInt1Ty(context)),
+      cfValue, "cfValue2");
+  Value* sf = computeSignFlag(builder, result);
+  Value* zf = computeZeroFlag(builder, result);
+  Value* pf = computeParityFlag(builder, result);
+  printvalue(sf);
+  printvalue(result);
+  setFlag(FLAG_CF, cfValue);
+  setFlag(FLAG_OF, of);
+  setFlag(FLAG_SF, sf);
+  setFlag(FLAG_ZF, zf);
+  setFlag(FLAG_PF, pf);
+
+  printvalue(Lvalue) printvalue(clampedCount) printvalue(result)
+      printvalue(isNotZero) printvalue(oldcf) printvalue(cfValue)
+          SetOperandValue(dest, result, to_string(instruction.runtime_address));
+}
+
+void lifterClass::lift_shl(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
+  auto count = instruction.operands[1];
+
+  Value* Lvalue =
+      GetOperandValue(dest, dest.size, to_string(instruction.runtime_address));
+  Value* countValue = GetOperandValue(count, dest.size);
+  unsigned bitWidth = Lvalue->getType()->getIntegerBitWidth();
+  unsigned maskC = bitWidth == 64 ? 0x3f : 0x1f;
+
+  auto bitWidthValue = ConstantInt::get(countValue->getType(), bitWidth);
+
+  Value* clampedCountValue = createAndFolder(
+      builder, countValue, ConstantInt::get(countValue->getType(), maskC),
+      "shlclamp");
+
+  Value* result =
+      createShlFolder(builder, Lvalue, clampedCountValue, "shl-shift");
+  Value* zero = ConstantInt::get(countValue->getType(), 0);
+  Value* isZeroed = createICMPFolder(
+      builder, CmpInst::ICMP_UGT, clampedCountValue,
+      ConstantInt::get(clampedCountValue->getType(), bitWidth - 1));
+  result = createSelectFolder(builder, isZeroed, zero, result);
+
+  Value* cfValue = createLShrFolder(
+      builder, Lvalue,
+      createSubFolder(builder, bitWidthValue, clampedCountValue), "shlcf");
+  Value* one = ConstantInt::get(cfValue->getType(), 1);
+  cfValue = createAndFolder(builder, cfValue, one, "shlcf");
+  cfValue = createZExtOrTruncFolder(builder, cfValue, Type::getInt1Ty(context));
+
+  auto countIsNotZero =
+      createICMPFolder(builder, CmpInst::ICMP_NE, clampedCountValue,
+                       ConstantInt::get(clampedCountValue->getType(), 0));
+
+  auto cfRvalue =
+      createSubFolder(builder, clampedCountValue,
+                      ConstantInt::get(clampedCountValue->getType(), 1));
+  auto cfShl = createShlFolder(builder, Lvalue, cfRvalue);
+  auto cfIntT = cast<IntegerType>(cfShl->getType());
+  auto cfRightCount = ConstantInt::get(cfIntT, cfIntT->getBitWidth() - 1);
+  auto cfLow = createLShrFolder(builder, cfShl, cfRightCount, "lowcfshr");
+  cfValue = createSelectFolder(
+      builder, countIsNotZero,
+      createZExtOrTruncFolder(builder, cfLow, Type::getInt1Ty(context)),
+      getFlag(FLAG_CF));
+  cfValue = createSelectFolder(
+      builder, isZeroed,
+      createZExtOrTruncFolder(builder, zero, Type::getInt1Ty(context)),
+      cfValue);
+
+  Value* isCountOne =
+      createICMPFolder(builder, CmpInst::ICMP_EQ, clampedCountValue,
+                       ConstantInt::get(clampedCountValue->getType(), 1));
+
+  Value* originalMSB = createLShrFolder(
+      builder, Lvalue, ConstantInt::get(Lvalue->getType(), bitWidth - 1),
+      "shlmsb");
+  originalMSB = createAndFolder(
+      builder, originalMSB, ConstantInt::get(Lvalue->getType(), 1), "shlmsb");
+  originalMSB =
+      createZExtOrTruncFolder(builder, originalMSB, Type::getInt1Ty(context));
+
+  Value* cfAsMSB = createZExtOrTruncFolder(
+      builder,
+      createLShrFolder(builder, Lvalue,
+                       ConstantInt::get(Lvalue->getType(), bitWidth - 1),
+                       "shlcfasmsb"),
+      Type::getInt1Ty(context));
+
+  Value* resultMSB = createZExtOrTruncFolder(
+      builder,
+      createLShrFolder(builder, result,
+                       ConstantInt::get(result->getType(), bitWidth - 1),
+                       "shlresultmsb"),
+      Type::getInt1Ty(context));
+
+  Value* ofValue = createSelectFolder(
+      builder, isCountOne, createXorFolder(builder, resultMSB, cfAsMSB),
+      getFlag(FLAG_OF));
+
+  setFlag(FLAG_CF, cfValue);
+  setFlag(FLAG_OF, ofValue);
+
+  Value* sf = computeSignFlag(builder, result);
+  Value* zf = computeZeroFlag(builder, result);
+  Value* pf = computeParityFlag(builder, result);
+  printvalue(Lvalue);
+  printvalue(countValue);
+  printvalue(clampedCountValue);
+  printvalue(isCountOne);
+  printvalue(result);
+  printvalue(ofValue);
+  printvalue(cfValue);
+  setFlag(FLAG_SF, sf);
+  setFlag(FLAG_ZF, zf);
+  setFlag(FLAG_PF, pf);
+
+  SetOperandValue(dest, result, to_string(instruction.runtime_address));
+}
+
+void lifterClass::lift_bswap(ZydisDisassembledInstruction& instruction) {
+  auto dest = instruction.operands[0];
+
+  auto Lvalue = GetOperandValue(dest, dest.size);
+  // if 16bit, 0 it
+  if (dest.size == 16) {
+    Value* zero = ConstantInt::get(Lvalue->getType(), 0);
+    SetOperandValue(dest, zero);
+    return;
+  }
+  Value* newswappedvalue = ConstantInt::get(Lvalue->getType(), 0);
+  Value* mask = ConstantInt::get(Lvalue->getType(), 0xff);
+  for (unsigned i = 0; i < Lvalue->getType()->getIntegerBitWidth() / 8; i++) {
+    // 0xff
+    // b = a & 0xff >> 0
+    // b = 0x78
+    // nb |=  b << 24
+    // nb |= 0x78000000
+    // 0xff00
+    // b = a & 0xff00 >> 8
+    // b = 0x56
+    // nb |= b << 16
+    // nb = 0x78560000
+    auto byte = createLShrFolder(
+        builder, createAndFolder(builder, Lvalue, mask), i * 8, "shlresultmsb");
+    auto shiftby = Lvalue->getType()->getIntegerBitWidth() - (i + 1) * 8;
+    auto newposbyte = createShlFolder(builder, byte, shiftby);
+    newswappedvalue = createOrFolder(builder, newswappedvalue, newposbyte);
+    mask = createShlFolder(builder, mask, 8);
+  }
+
+  SetOperandValue(dest, newswappedvalue);
+}
+
+void lifterClass::lift_cmpxchg(ZydisDisassembledInstruction& instruction) {
+
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+  auto accop = instruction.operands[2];
+
+  auto Rvalue = GetOperandValue(src, src.size);
+  auto Lvalue = GetOperandValue(dest, dest.size);
+  auto accum = GetOperandValue(accop, dest.size);
+
+  auto sub = builder.CreateSub(accum, Lvalue);
+
+  auto of = computeOverflowFlagSub(builder, Lvalue, Rvalue, sub);
+
+  auto lowerNibbleMask = ConstantInt::get(Lvalue->getType(), 0xF);
+  auto RvalueLowerNibble =
+      createAndFolder(builder, Lvalue, lowerNibbleMask, "lvalLowerNibble");
+  auto op2LowerNibble =
+      createAndFolder(builder, Rvalue, lowerNibbleMask, "rvalLowerNibble");
+
+  auto cf =
+      createICMPFolder(builder, CmpInst::ICMP_UGT, Rvalue, Lvalue, "add_cf");
+  auto af = createICMPFolder(builder, CmpInst::ICMP_ULT, RvalueLowerNibble,
+                             op2LowerNibble, "add_af");
+
+  auto sf = computeSignFlag(builder, sub);
 
   /*
-
-  IF 64-Bit Mode and using REX.W
+  TEMP := DEST
+  IF accumulator = TEMP
           THEN
-                  countMASK := 3FH;
+                  ZF := 1;
+                  DEST := SRC;
           ELSE
-                  countMASK := 1FH;
-  FI
-  tempCOUNT := (COUNT AND countMASK);
-  tempDEST := DEST;
-  WHILE (tempCOUNT ≠ 0)
-  DO
-          IF instruction is SAL or SHL
-                  THEN
-                  CF := MSB(DEST);
-          ELSE (* Instruction is SAR or SHR *)
-                  CF := LSB(DEST);
-          FI;
-          IF instruction is SAL or SHL
-                  THEN
-                          DEST := DEST ∗ 2;
-          ELSE
-                  IF instruction is SAR
-                          THEN
-                                  DEST := DEST / 2; (* Signed divide, rounding
-  toward negative infinity *) ELSE (* Instruction is SHR *) DEST := DEST / 2 ;
-  (* Unsigned divide *) FI; FI; tempCOUNT := tempCOUNT – 1; OD;
-
-  (* Determine overflow for the various instructions *)
-  IF (COUNT and countMASK) = 1
-          THEN
-          IF instruction is SAL or SHL
-                  THEN
-                  OF := MSB(DEST) XOR CF;
-          ELSE
-          IF instruction is SAR
-                  THEN
-                  OF := 0;
-          ELSE (* Instruction is SHR *)
-                  OF := MSB(tempDEST);
-          FI;
+                  ZF := 0;
+                  accumulator := TEMP;
+                  DEST := TEMP;
   FI;
-
-  ELSE IF (COUNT AND countMASK) = 0
-          THEN
-          All flags unchanged;
-  ELSE (* COUNT not 1 or 0 *)
-  OF := undefined;
-  FI;
-  FI;
-
   */
-  // maybe
-
-  void lift_sar(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-    auto count = instruction.operands[1];
-
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size,
-                                    to_string(instruction.runtime_address));
-    Value* countValue = GetOperandValue(builder, count, dest.size);
-
-    Value* zero = ConstantInt::get(countValue->getType(), 0);
-    uint8_t bitWidth = Lvalue->getType()->getIntegerBitWidth();
-    uint8_t maskC = bitWidth == 64 ? 0x3f : 0x1f;
-
-    Value* clampedCount = createAndFolder(
-        builder, countValue, ConstantInt::get(countValue->getType(), maskC),
-        "sarclamp");
-    Value* result = builder.CreateAShr(
-        Lvalue, clampedCount,
-        "sar-lshr-" + to_string(instruction.runtime_address) + "-");
-
-    Value* isZeroed = createICMPFolder(
-        builder, CmpInst::ICMP_UGT, clampedCount,
-        ConstantInt::get(clampedCount->getType(), bitWidth - 1));
-    result = createSelectFolder(builder, isZeroed, zero, result);
-
-    auto cfRvalue = createSubFolder(
-        builder, clampedCount, ConstantInt::get(clampedCount->getType(), 1));
-    auto cfShl = createShlFolder(
-        builder, ConstantInt::get(cfRvalue->getType(), 1), cfRvalue);
-    auto cfAnd = createAndFolder(builder, cfShl, Lvalue);
-    auto cfValue = createICMPFolder(builder, CmpInst::ICMP_NE, cfAnd,
-                                    ConstantInt::get(cfAnd->getType(), 0));
-
-    Value* isCountOne =
-        createICMPFolder(builder, CmpInst::ICMP_EQ, clampedCount,
-                         ConstantInt::get(clampedCount->getType(), 1));
-    Value* of = createSelectFolder(builder, isCountOne, builder.getInt1(0),
-                                   getFlag(builder, FLAG_OF));
-
-    Value* isNotZero =
-        createICMPFolder(builder, CmpInst::ICMP_NE, clampedCount, zero);
-    Value* oldcf = getFlag(builder, FLAG_CF);
-    cfValue = createSelectFolder(builder, isNotZero, cfValue, oldcf);
-    cfValue = createSelectFolder(
-        builder, isZeroed, builder.CreateTrunc(zero, Type::getInt1Ty(context)),
-        cfValue);
-
-    Value* sf = computeSignFlag(builder, result);
-    Value* zf = computeZeroFlag(builder, result);
-    Value* pf = computeParityFlag(builder, result);
-    printvalue(Lvalue) printvalue2(bitWidth) printvalue(countValue);
-    printvalue(clampedCount) printvalue(result) printvalue(isNotZero);
-    printvalue(cfValue) printvalue(oldcf);
-    setFlag(builder, FLAG_CF, cfValue);
-    setFlag(builder, FLAG_OF, of);
-    setFlag(builder, FLAG_SF, sf);
-    setFlag(builder, FLAG_ZF, zf);
-    setFlag(builder, FLAG_PF, pf);
-
-    SetOperandValue(builder, dest, result,
-                    to_string(instruction.runtime_address));
-    ;
-  }
-  // TODO fix
-  void lift_shr(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-    auto count = instruction.operands[1];
-
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-    Value* countValue = GetOperandValue(builder, count, dest.size);
-
-    unsigned bitWidth = Lvalue->getType()->getIntegerBitWidth();
-    unsigned maskC = bitWidth == 64 ? 0x3f : 0x1f;
-
-    Value* clampedCount = createAndFolder(
-        builder, countValue, ConstantInt::get(countValue->getType(), maskC),
-        "shrclamp");
-
-    Value* result = createLShrFolder(
-        builder, Lvalue, clampedCount,
-        "shr-lshr-" + to_string(instruction.runtime_address) + "-");
-    Value* zero = ConstantInt::get(countValue->getType(), 0);
-    Value* isZeroed = createICMPFolder(
-        builder, CmpInst::ICMP_UGT, clampedCount,
-        ConstantInt::get(clampedCount->getType(), bitWidth - 1));
-    result = createSelectFolder(builder, isZeroed, zero, result, "shiftValue");
-
-    Value* cfValue = builder.CreateTrunc(
-        createLShrFolder(
-            builder, Lvalue,
-            createSubFolder(builder, clampedCount,
-                            ConstantInt::get(clampedCount->getType(), 1)),
-            "shrcf"),
-        builder.getInt1Ty());
-
-    Value* isCountOne =
-        createICMPFolder(builder, CmpInst::ICMP_EQ, clampedCount,
-                         ConstantInt::get(clampedCount->getType(), 1));
-    Value* of = createICMPFolder(builder, CmpInst::ICMP_SLT, Lvalue,
-                                 ConstantInt::get(Lvalue->getType(), 0));
-    of = createSelectFolder(builder, isCountOne, of, getFlag(builder, FLAG_OF),
-                            "of");
-
-    Value* isNotZero =
-        createICMPFolder(builder, CmpInst::ICMP_NE, clampedCount, zero);
-    Value* oldcf = getFlag(builder, FLAG_CF);
-    cfValue =
-        createSelectFolder(builder, isNotZero, cfValue, oldcf, "cfValue1");
-    cfValue = createSelectFolder(
-        builder, isZeroed, builder.CreateTrunc(zero, Type::getInt1Ty(context)),
-        cfValue, "cfValue2");
-    Value* sf = computeSignFlag(builder, result);
-    Value* zf = computeZeroFlag(builder, result);
-    Value* pf = computeParityFlag(builder, result);
-    printvalue(sf);
-    printvalue(result);
-    setFlag(builder, FLAG_CF, cfValue);
-    setFlag(builder, FLAG_OF, of);
-    setFlag(builder, FLAG_SF, sf);
-    setFlag(builder, FLAG_ZF, zf);
-    setFlag(builder, FLAG_PF, pf);
-
-    printvalue(Lvalue) printvalue(clampedCount) printvalue(result)
-        printvalue(isNotZero) printvalue(oldcf) printvalue(cfValue)
-            SetOperandValue(builder, dest, result,
-                            to_string(instruction.runtime_address));
-  }
-
-  void lift_shl(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-    auto count = instruction.operands[1];
-
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size,
-                                    to_string(instruction.runtime_address));
-    Value* countValue = GetOperandValue(builder, count, dest.size);
-    unsigned bitWidth = Lvalue->getType()->getIntegerBitWidth();
-    unsigned maskC = bitWidth == 64 ? 0x3f : 0x1f;
-
-    auto bitWidthValue = ConstantInt::get(countValue->getType(), bitWidth);
-
-    Value* clampedCountValue = createAndFolder(
-        builder, countValue, ConstantInt::get(countValue->getType(), maskC),
-        "shlclamp");
-
-    Value* result =
-        createShlFolder(builder, Lvalue, clampedCountValue, "shl-shift");
-    Value* zero = ConstantInt::get(countValue->getType(), 0);
-    Value* isZeroed = createICMPFolder(
-        builder, CmpInst::ICMP_UGT, clampedCountValue,
-        ConstantInt::get(clampedCountValue->getType(), bitWidth - 1));
-    result = createSelectFolder(builder, isZeroed, zero, result);
-
-    Value* cfValue = createLShrFolder(
-        builder, Lvalue,
-        createSubFolder(builder, bitWidthValue, clampedCountValue), "shlcf");
-    Value* one = ConstantInt::get(cfValue->getType(), 1);
-    cfValue = createAndFolder(builder, cfValue, one, "shlcf");
-    cfValue =
-        createZExtOrTruncFolder(builder, cfValue, Type::getInt1Ty(context));
-
-    auto countIsNotZero =
-        createICMPFolder(builder, CmpInst::ICMP_NE, clampedCountValue,
-                         ConstantInt::get(clampedCountValue->getType(), 0));
-
-    auto cfRvalue =
-        createSubFolder(builder, clampedCountValue,
-                        ConstantInt::get(clampedCountValue->getType(), 1));
-    auto cfShl = createShlFolder(builder, Lvalue, cfRvalue);
-    auto cfIntT = cast<IntegerType>(cfShl->getType());
-    auto cfRightCount = ConstantInt::get(cfIntT, cfIntT->getBitWidth() - 1);
-    auto cfLow = createLShrFolder(builder, cfShl, cfRightCount, "lowcfshr");
-    cfValue = createSelectFolder(
-        builder, countIsNotZero,
-        createZExtOrTruncFolder(builder, cfLow, Type::getInt1Ty(context)),
-        getFlag(builder, FLAG_CF));
-    cfValue = createSelectFolder(
-        builder, isZeroed,
-        createZExtOrTruncFolder(builder, zero, Type::getInt1Ty(context)),
-        cfValue);
-
-    Value* isCountOne =
-        createICMPFolder(builder, CmpInst::ICMP_EQ, clampedCountValue,
-                         ConstantInt::get(clampedCountValue->getType(), 1));
-
-    Value* originalMSB = createLShrFolder(
-        builder, Lvalue, ConstantInt::get(Lvalue->getType(), bitWidth - 1),
-        "shlmsb");
-    originalMSB = createAndFolder(
-        builder, originalMSB, ConstantInt::get(Lvalue->getType(), 1), "shlmsb");
-    originalMSB =
-        createZExtOrTruncFolder(builder, originalMSB, Type::getInt1Ty(context));
-
-    Value* cfAsMSB = createZExtOrTruncFolder(
-        builder,
-        createLShrFolder(builder, Lvalue,
-                         ConstantInt::get(Lvalue->getType(), bitWidth - 1),
-                         "shlcfasmsb"),
-        Type::getInt1Ty(context));
-
-    Value* resultMSB = createZExtOrTruncFolder(
-        builder,
-        createLShrFolder(builder, result,
-                         ConstantInt::get(result->getType(), bitWidth - 1),
-                         "shlresultmsb"),
-        Type::getInt1Ty(context));
-
-    Value* ofValue = createSelectFolder(
-        builder, isCountOne, createXorFolder(builder, resultMSB, cfAsMSB),
-        getFlag(builder, FLAG_OF));
-
-    setFlag(builder, FLAG_CF, cfValue);
-    setFlag(builder, FLAG_OF, ofValue);
-
-    Value* sf = computeSignFlag(builder, result);
-    Value* zf = computeZeroFlag(builder, result);
-    Value* pf = computeParityFlag(builder, result);
-    printvalue(Lvalue);
-    printvalue(countValue);
-    printvalue(clampedCountValue);
-    printvalue(isCountOne);
-    printvalue(result);
-    printvalue(ofValue);
-    printvalue(cfValue);
-    setFlag(builder, FLAG_SF, sf);
-    setFlag(builder, FLAG_ZF, zf);
-    setFlag(builder, FLAG_PF, pf);
-
-    SetOperandValue(builder, dest, result,
-                    to_string(instruction.runtime_address));
-  }
-
-  void lift_bswap(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-    auto dest = instruction.operands[0];
-
-    auto Lvalue = GetOperandValue(builder, dest, dest.size);
-    // if 16bit, 0 it
-    if (dest.size == 16) {
-      Value* zero = ConstantInt::get(Lvalue->getType(), 0);
-      SetOperandValue(builder, dest, zero);
-      return;
-    }
-    Value* newswappedvalue = ConstantInt::get(Lvalue->getType(), 0);
-    Value* mask = ConstantInt::get(Lvalue->getType(), 0xff);
-    for (unsigned i = 0; i < Lvalue->getType()->getIntegerBitWidth() / 8; i++) {
-      // 0xff
-      // b = a & 0xff >> 0
-      // b = 0x78
-      // nb |=  b << 24
-      // nb |= 0x78000000
-      // 0xff00
-      // b = a & 0xff00 >> 8
-      // b = 0x56
-      // nb |= b << 16
-      // nb = 0x78560000
-      auto byte =
-          createLShrFolder(builder, createAndFolder(builder, Lvalue, mask),
-                           i * 8, "shlresultmsb");
-      auto shiftby = Lvalue->getType()->getIntegerBitWidth() - (i + 1) * 8;
-      auto newposbyte = createShlFolder(builder, byte, shiftby);
-      newswappedvalue = createOrFolder(builder, newswappedvalue, newposbyte);
-      mask = createShlFolder(builder, mask, 8);
-    }
-
-    SetOperandValue(builder, dest, newswappedvalue);
-  }
-
-  void lift_cmpxchg(IRBuilder<>& builder,
-                    ZydisDisassembledInstruction& instruction) {
-
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-    auto accop = instruction.operands[2];
-
-    auto Rvalue = GetOperandValue(builder, src, src.size);
-    auto Lvalue = GetOperandValue(builder, dest, dest.size);
-    auto accum = GetOperandValue(builder, accop, dest.size);
-
-    auto sub = builder.CreateSub(accum, Lvalue);
-
-    auto of = computeOverflowFlagSub(builder, Lvalue, Rvalue, sub);
-
-    auto lowerNibbleMask = ConstantInt::get(Lvalue->getType(), 0xF);
-    auto RvalueLowerNibble =
-        createAndFolder(builder, Lvalue, lowerNibbleMask, "lvalLowerNibble");
-    auto op2LowerNibble =
-        createAndFolder(builder, Rvalue, lowerNibbleMask, "rvalLowerNibble");
-
-    auto cf =
-        createICMPFolder(builder, CmpInst::ICMP_UGT, Rvalue, Lvalue, "add_cf");
-    auto af = createICMPFolder(builder, CmpInst::ICMP_ULT, RvalueLowerNibble,
-                               op2LowerNibble, "add_af");
-
-    auto sf = computeSignFlag(builder, sub);
-
-    /*
-    TEMP := DEST
-    IF accumulator = TEMP
-            THEN
-                    ZF := 1;
-                    DEST := SRC;
-            ELSE
-                    ZF := 0;
-                    accumulator := TEMP;
-                    DEST := TEMP;
-    FI;
-    */
-    auto zf = createICMPFolder(builder, CmpInst::ICMP_EQ, accum, Lvalue);
-    // if zf dest = src
-    auto result = createSelectFolder(builder, zf, Rvalue, Lvalue);
-
-    SetOperandValue(builder, dest, result);
-    setFlag(builder, FLAG_OF, of);
-    setFlag(builder, FLAG_CF, cf);
-    setFlag(builder, FLAG_AF, af);
-    setFlag(builder, FLAG_SF, sf);
-    setFlag(builder, FLAG_ZF, zf);
-  }
-  
-  void lift_not(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-
-    auto dest = instruction.operands[0];
-
-    auto Rvalue = GetOperandValue(builder, dest, dest.size);
-    Rvalue = builder.CreateNot(
-        Rvalue, "realnot-" + to_string(instruction.runtime_address) + "-");
-    SetOperandValue(builder, dest, Rvalue,
-                    to_string(instruction.runtime_address));
-
-    printvalue(Rvalue);
-    //  Flags Affected
-    // None
-  }
-
-  void lift_xchg(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction) {
-
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    auto Rvalue = GetOperandValue(builder, src, src.size);
-    auto Lvalue = GetOperandValue(builder, dest, dest.size);
-
-    printvalue(Lvalue) printvalue(Rvalue);
-
-    SetOperandValue(builder, dest, Rvalue,
-                    to_string(instruction.runtime_address));
-    ;
-    SetOperandValue(builder, src, Lvalue);
-  }
-
-  void lift_shld(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-    auto source = instruction.operands[1];
-    auto count = instruction.operands[2];
-
-    auto Lvalue = GetOperandValue(builder, dest, dest.size);
-    auto sourceValue = GetOperandValue(builder, source, dest.size);
-    auto countValue = GetOperandValue(builder, count, dest.size);
-
-    unsigned bitWidth = Lvalue->getType()->getIntegerBitWidth();
-    auto effectiveCountValue = builder.CreateURem(
-        countValue, ConstantInt::get(countValue->getType(), bitWidth),
-        "effectiveShiftCount");
-
-    auto shiftedDest =
-        createShlFolder(builder, Lvalue, effectiveCountValue, "shiftedDest");
-    auto complementCount = createSubFolder(
-        builder, ConstantInt::get(countValue->getType(), bitWidth),
-        effectiveCountValue, "complementCount");
-    auto shiftedSource = createLShrFolder(builder, sourceValue, complementCount,
-                                          "shiftedSource");
-    auto resultValue =
-        createOrFolder(builder, shiftedDest, shiftedSource, "shldResult");
-
-    auto countIsNotZero =
-        createICMPFolder(builder, CmpInst::ICMP_NE, effectiveCountValue,
-                         ConstantInt::get(effectiveCountValue->getType(), 0));
-    auto lastShiftedBitPosition =
-        createSubFolder(builder, effectiveCountValue,
-                        ConstantInt::get(effectiveCountValue->getType(), 1));
-    auto lastShiftedBit = createAndFolder(
-        builder, createLShrFolder(builder, Lvalue, lastShiftedBitPosition),
-        ConstantInt::get(Lvalue->getType(), 1), "shldresultmsb");
-    auto cf =
-        createSelectFolder(builder, countIsNotZero,
-                           createZExtOrTruncFolder(builder, lastShiftedBit,
-                                                   Type::getInt1Ty(context)),
-                           getFlag(builder, FLAG_CF));
-    resultValue =
-        createSelectFolder(builder, countIsNotZero, resultValue, Lvalue);
-
-    auto isOne =
-        createICMPFolder(builder, CmpInst::ICMP_EQ, effectiveCountValue,
-                         ConstantInt::get(effectiveCountValue->getType(), 1));
-    auto newOF = createXorFolder(
-        builder,
-        createLShrFolder(builder, Lvalue,
-                         ConstantInt::get(Lvalue->getType(), bitWidth - 1),
-                         "subof"),
-        createLShrFolder(builder, resultValue,
-                         ConstantInt::get(resultValue->getType(), bitWidth - 1),
-                         "subof2"),
-        "subxorof");
-    auto of = createSelectFolder(
-        builder, isOne,
-        createZExtOrTruncFolder(builder, newOF, Type::getInt1Ty(context)),
-        getFlag(builder, FLAG_OF));
-
-    //  CF := BIT[DEST, SIZE – COUNT]; if shifted,
-    setFlag(builder, FLAG_CF, cf);
-    setFlag(builder, FLAG_OF, of);
-
-    SetOperandValue(builder, dest, resultValue,
-                    to_string(instruction.runtime_address));
-  }
-
-  void lift_shrd(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-    auto source = instruction.operands[1];
-    auto count = instruction.operands[2];
-
-    auto Lvalue = GetOperandValue(builder, dest, dest.size);
-    auto sourceValue = GetOperandValue(builder, source, dest.size);
-    auto countValue = GetOperandValue(builder, count, dest.size);
-
-    unsigned bitWidth = Lvalue->getType()->getIntegerBitWidth();
-    auto effectiveCountValue = builder.CreateURem(
-        countValue, ConstantInt::get(countValue->getType(), bitWidth),
-        "effectiveShiftCount");
-
-    auto shiftedDest =
-        createLShrFolder(builder, Lvalue, effectiveCountValue, "shiftedDest");
-    auto complementCount = createSubFolder(
-        builder, ConstantInt::get(countValue->getType(), bitWidth),
-        effectiveCountValue, "complementCount");
-    auto shiftedSource =
-        createShlFolder(builder, sourceValue, complementCount, "shiftedSource");
-    auto resultValue =
-        createOrFolder(builder, shiftedDest, shiftedSource, "shrdResult");
-
-    // Calculate CF
-    auto cfBitPosition =
-        createSubFolder(builder, effectiveCountValue,
-                        ConstantInt::get(effectiveCountValue->getType(), 1));
-    Value* cf = createLShrFolder(builder, Lvalue, cfBitPosition);
-    cf = createAndFolder(builder, cf, ConstantInt::get(cf->getType(), 1),
-                         "shrdcf");
-    cf = createZExtOrTruncFolder(builder, cf, Type::getInt1Ty(context));
-
-    // Calculate OF, only when count is 1
-    Value* isCountOne =
-        createICMPFolder(builder, CmpInst::ICMP_EQ, effectiveCountValue,
-                         ConstantInt::get(effectiveCountValue->getType(), 1));
-    Value* mostSignificantBitOfDest = createLShrFolder(
-        builder, Lvalue, ConstantInt::get(Lvalue->getType(), bitWidth - 1),
-        "shlmsbdest");
-    mostSignificantBitOfDest = createAndFolder(
-        builder, mostSignificantBitOfDest,
-        ConstantInt::get(mostSignificantBitOfDest->getType(), 1), "shrdmsb");
-    Value* mostSignificantBitOfResult = createLShrFolder(
-        builder, resultValue,
-        ConstantInt::get(resultValue->getType(), bitWidth - 1), "shlmsbresult");
-    mostSignificantBitOfResult = createAndFolder(
-        builder, mostSignificantBitOfResult,
-        ConstantInt::get(mostSignificantBitOfResult->getType(), 1), "shrdmsb2");
-    Value* of = createXorFolder(builder, mostSignificantBitOfDest,
-                                mostSignificantBitOfResult);
-    of = createZExtOrTruncFolder(builder, of, Type::getInt1Ty(context));
-    of = createSelectFolder(builder, isCountOne, of,
-                            ConstantInt::getFalse(context));
-    of = createZExtFolder(builder, of, Type::getInt1Ty(context));
-
-    setFlag(builder, FLAG_CF, cf);
-    setFlag(builder, FLAG_OF, of);
-
-    SetOperandValue(builder, dest, resultValue,
-                    to_string(instruction.runtime_address));
-  }
-
-  void lift_lea(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    auto Rvalue = GetEffectiveAddress(builder, src, dest.size);
-
-    printvalue(Rvalue)
-
-        SetOperandValue(builder, dest, Rvalue,
-                        to_string(instruction.runtime_address));
-    ;
-  }
-
-  // extract sub from this function, this is convoluted for no reason
-  void lift_add_sub(IRBuilder<>& builder,
-                    ZydisDisassembledInstruction& instruction) {
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    auto Rvalue = GetOperandValue(builder, src, dest.size);
-    auto Lvalue = GetOperandValue(builder, dest, dest.size);
-
-    Value* result = nullptr;
-    Value* cf = nullptr;
-    Value* af = nullptr;
-    Value* of = nullptr;
-
-    auto lowerNibbleMask = ConstantInt::get(Lvalue->getType(), 0xF);
-    auto RvalueLowerNibble =
-        createAndFolder(builder, Lvalue, lowerNibbleMask, "lvalLowerNibble");
-    auto op2LowerNibble =
-        createAndFolder(builder, Rvalue, lowerNibbleMask, "rvalLowerNibble");
-
-    switch (instruction.info.mnemonic) {
-    case ZYDIS_MNEMONIC_ADD: {
-      result = createAddFolder(
-          builder, Lvalue, Rvalue,
-          "realadd-" + to_string(instruction.runtime_address) + "-");
-      cf = createOrFolder(builder,
-                          createICMPFolder(builder, CmpInst::ICMP_ULT, result,
-                                           Lvalue, "add_cf1"),
-                          createICMPFolder(builder, CmpInst::ICMP_ULT, result,
-                                           Rvalue, "add_cf2"),
-                          "add_cf");
-      auto sumLowerNibble = createAddFolder(
-          builder, RvalueLowerNibble, op2LowerNibble, "add_sumLowerNibble");
-      af = createICMPFolder(builder, CmpInst::ICMP_UGT, sumLowerNibble,
-                            lowerNibbleMask, "add_af");
-      of = computeOverflowFlagAdd(builder, Lvalue, Rvalue, result);
-      break;
-    }
-    case ZYDIS_MNEMONIC_SUB: {
-      result = createSubFolder(
-          builder, Lvalue, Rvalue,
-          "realsub-" + to_string(instruction.runtime_address) + "-");
-
-      of = computeOverflowFlagSub(builder, Lvalue, Rvalue, result);
-
-      cf = createICMPFolder(builder, CmpInst::ICMP_UGT, Rvalue, Lvalue,
-                            "add_cf");
-      af = createICMPFolder(builder, CmpInst::ICMP_ULT, RvalueLowerNibble,
-                            op2LowerNibble, "add_af");
-      break;
-    }
-    default:
-      break;
-    }
-
-    /*
-    Flags Affected
-    The OF, SF, ZF, AF, CF, and PF flags are set according to the result.
-    */
-
-    auto sf = computeSignFlag(builder, result);
-    auto zf = computeZeroFlag(builder, result);
-    auto pf = computeParityFlag(builder, result);
-
-    setFlag(builder, FLAG_OF, of);
-    setFlag(builder, FLAG_SF, sf);
-    setFlag(builder, FLAG_ZF, zf);
-    setFlag(builder, FLAG_AF, af);
-    setFlag(builder, FLAG_CF, cf);
-    setFlag(builder, FLAG_PF, pf);
-
-    printvalue(Lvalue);
-    printvalue(Rvalue);
-    printvalue(result);
-    printvalue(cf);
-    printvalue(sf);
-    printvalue(of);
-
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_imul2(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction, bool isSigned) {
-    LLVMContext& context = builder.getContext();
-    auto src = instruction.operands[0];
-    auto Rvalue = GetRegisterValue(builder, ZYDIS_REGISTER_AL);
-
-    Value* Lvalue = GetOperandValue(builder, src, src.size);
-    if (isSigned) { // do this in a prettier way
-      Lvalue =
-          builder.CreateSExt(Lvalue, Type::getIntNTy(context, src.size * 2));
-
-      Rvalue = builder.CreateSExtOrTrunc(
-          Rvalue, Type::getIntNTy(context,
-                                  src.size)); // make sure the size is correct,
-                                              // 1 byte, GetRegisterValue doesnt
-                                              // ensure we have the correct size
-      Rvalue = builder.CreateSExtOrTrunc(Rvalue, Lvalue->getType());
-    } else {
-      Lvalue = createZExtFolder(builder, Lvalue,
-                                Type::getIntNTy(context, src.size * 2));
-
-      Rvalue = createZExtOrTruncFolder(
-          builder, Rvalue,
-          Type::getIntNTy(context,
-                          src.size)); // make sure the size is correct, 1
-                                      // byte, GetRegisterValue doesnt
-                                      // ensure we have the correct size
-      Rvalue = createZExtOrTruncFolder(builder, Rvalue, Lvalue->getType());
-    }
-    Value* result = builder.CreateMul(Rvalue, Lvalue);
-    Value* lowerresult = builder.CreateTrunc(
-        result, Type::getIntNTy(context, src.size), "lowerResult");
-    Value* of;
-    Value* cf;
-    if (isSigned) {
-      of = builder.CreateICmpNE(
-          result, builder.CreateSExt(lowerresult, result->getType()));
-      cf = of;
-    } else {
-      Value* highPart = builder.CreateLShr(result, src.size, "highPart");
-      Value* highPartTruncated = builder.CreateTrunc(
-          highPart, Type::getIntNTy(context, src.size), "truncatedHighPart");
-      cf = builder.CreateICmpNE(highPartTruncated,
-                                ConstantInt::get(result->getType(), 0), "cf");
-      of = cf;
-    }
-
-    setFlag(builder, FLAG_CF, cf);
-    setFlag(builder, FLAG_OF, of);
-    printvalue(cf);
-    printvalue(of);
-    SetRegisterValue(builder, ZYDIS_REGISTER_AX, result);
-    printvalue(Lvalue);
-    printvalue(Rvalue);
-    printvalue(result);
-    // if imul modify cf and of flags
-    // if not, dont do anything else
-  }
-
-  // TODO rewrite this
-  void lift_imul(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-
-    auto dest = instruction.operands[0]; // dest ?
-    if (dest.size == 8 && instruction.info.operand_count_visible == 1) {
-      lift_imul2(builder, instruction, 1);
-      return;
-    }
-    auto src = instruction.operands[1];
-    auto src2 = (instruction.info.operand_count_visible == 3)
-                    ? instruction.operands[2]
-                    : dest; // if exists third operand
-
-    Value* Rvalue = GetOperandValue(builder, src, src.size);
-    Value* Lvalue = GetOperandValue(builder, src2, src2.size);
-    uint8_t initialSize = src.size;
-    printvalue2(initialSize);
-    printvalue(Rvalue);
-    printvalue(Lvalue);
-    Rvalue =
-        builder.CreateSExt(Rvalue, Type::getIntNTy(context, initialSize * 2));
-    Lvalue =
-        builder.CreateSExt(Lvalue, Type::getIntNTy(context, initialSize * 2));
-
-    Value* result = builder.CreateMul(Lvalue, Rvalue, "intmul");
-
-    // Flags
-
-    Value* highPart = builder.CreateLShr(result, initialSize, "highPart");
-    Value* highPartTruncated = builder.CreateTrunc(
-        highPart, Type::getIntNTy(context, initialSize), "truncatedHighPart");
-
-    /*
-    For the one operand form of the instruction, the CF and OF flags are set
-    when significant bits are carried into the upper half of the result and
-    cleared when the result fits exactly in the lower half of the result.
-    For the two- and three-operand forms of the instruction, the CF and OF
-    flags are set when the result must be truncated to fit in the
-    destination operand size and cleared when the result fits exactly in the
-    destination operand size. The SF, ZF, AF, and PF flags are undefined.
-    */
-
-    /*
-    DEST := TruncateToOperandSize(TMP_XP);
-    IF SignExtend(DEST) ≠ TMP_XP
-    THEN CF := 1; OF := 1;
-            ELSE CF := 0; OF := 0; FI;
-    */
-
-    Value* truncresult = builder.CreateTrunc(
-        result, Type::getIntNTy(context, initialSize), "truncRes");
-
-    Value* cf = builder.CreateICmpNE(
-        result, builder.CreateSExt(truncresult, result->getType()), "cf");
-    Value* of = cf;
-
-    if (instruction.info.operand_count_visible == 3) {
-      SetOperandValue(builder, dest, truncresult);
-    } else if (instruction.info.operand_count_visible == 2) {
-      SetOperandValue(builder, instruction.operands[0], truncresult);
-    } else { // For one operand, result goes into ?dx:?ax if not a byte
-             // operation
-      auto splitResult = builder.CreateTruncOrBitCast(
-          result, Type::getIntNTy(context, initialSize), "splitResult");
-      Value* SEsplitResult = builder.CreateSExt(splitResult, result->getType());
-      printvalue(splitResult);
-      printvalue(result);
-      cf = builder.CreateICmpNE(SEsplitResult, result);
-      of = cf;
-      printvalue(of);
-      printvalue(result);
-      printvalue(SEsplitResult);
-
-      if (initialSize == 8) {
-        SetOperandValue(builder, instruction.operands[1], result);
-      } else {
-
-        SetOperandValue(builder, instruction.operands[1], splitResult);
-        SetOperandValue(builder, instruction.operands[2], highPartTruncated);
-      }
-    }
-
-    setFlag(builder, FLAG_CF, cf);
-    setFlag(builder, FLAG_OF, of);
-    printvalue(Lvalue) printvalue(Rvalue) printvalue(result)
-        printvalue(highPartTruncated) printvalue(of) printvalue(cf)
-  }
-  // rewrite this too
-  void lift_mul(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    /*
-    mul rdx
-    [0] rdx
-    [1] rax
-    [2] rdx
-    [3] flags
-    */
-    /*
-    IF (Byte operation)
-            THEN
-                    AX := AL ∗ SRC;
-            ELSE (* Word or doubleword operation *)
-                    IF OperandSize = 16
-                            THEN
-                                    DX:AX := AX ∗ SRC;
-                            ELSE IF OperandSize = 32
-                                    THEN EDX:EAX := EAX ∗ SRC; FI;
-                            ELSE (* OperandSize = 64 *)
-                                    RDX:RAX := RAX ∗ SRC;
-                    FI;
-    FI;
-    */
-
-    LLVMContext& context = builder.getContext();
-    auto src = instruction.operands[0];
-
-    if (src.size == 8 && instruction.info.operand_count_visible == 1) {
-      lift_imul2(builder, instruction, 0);
-      return;
-    }
-    auto dest1 = instruction.operands[1]; // ax
-    auto dest2 = instruction.operands[2];
-
-    Value* Rvalue = GetOperandValue(builder, src, dest1.size);
-    Value* Lvalue = GetOperandValue(builder, dest1, dest1.size);
-
-    uint8_t initialSize = Rvalue->getType()->getIntegerBitWidth();
-    printvalue2(initialSize);
-    Rvalue = createZExtFolder(builder, Rvalue,
-                              Type::getIntNTy(context, initialSize * 2));
-    Lvalue = createZExtFolder(builder, Lvalue,
-                              Type::getIntNTy(context, initialSize * 2));
-
-    Value* result = builder.CreateMul(Lvalue, Rvalue, "intmul");
-
-    // Flags
-    auto resultType = Type::getIntNTy(context, initialSize);
-
-    Value* highPart = builder.CreateLShr(result, initialSize, "highPart");
-    Value* highPartTruncated = builder.CreateTrunc(
-        highPart, Type::getIntNTy(context, initialSize), "truncatedHighPart");
-
-    /* The OF and CF flags are set to 0 if the upper half of the result is
-     * 0; otherwise, they are set to 1. The SF, ZF, AF, and PF flags are
-     * undefined.
-     */
-    Value* cf = builder.CreateICmpNE(highPartTruncated,
-                                     ConstantInt::get(resultType, 0), "cf");
-    Value* of = cf;
-    setFlag(builder, FLAG_CF, cf);
-    setFlag(builder, FLAG_OF, of);
-
-    auto splitResult = builder.CreateTruncOrBitCast(
-        result, Type::getIntNTy(context, initialSize), "splitResult");
-    // if not byte operation, result goes into ?dx:?ax
-
-    SetOperandValue(builder, dest1, splitResult);
-    SetOperandValue(builder, dest2, highPartTruncated);
-
-    printvalue(Lvalue) printvalue(Rvalue) printvalue(result)
-        printvalue(highPart) printvalue(highPartTruncated)
-            printvalue(splitResult) printvalue(of) printvalue(cf)
-  }
-
-  void lift_div2(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto src = instruction.operands[0];
-    auto dividend = GetRegisterValue(builder, ZYDIS_REGISTER_AX);
-
-    Value* divisor = GetOperandValue(builder, src, src.size);
-    divisor = createZExtFolder(builder, divisor,
-                               Type::getIntNTy(context, src.size * 2));
-    dividend = createZExtOrTruncFolder(builder, dividend, divisor->getType());
-    Value* remainder = builder.CreateURem(dividend, divisor);
-    Value* quotient = builder.CreateUDiv(dividend, divisor);
-
-    SetRegisterValue(
-        builder, ZYDIS_REGISTER_AL,
-        createZExtOrTruncFolder(builder, quotient,
-                                Type::getIntNTy(context, src.size)));
-
-    SetRegisterValue(
-        builder, ZYDIS_REGISTER_AH,
-        createZExtOrTruncFolder(builder, remainder,
-                                Type::getIntNTy(context, src.size)));
-
-    printvalue(remainder);
-    printvalue(quotient);
-    printvalue(divisor);
-    printvalue(dividend);
-  }
-
-  void lift_idiv2(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto src = instruction.operands[0];
-    auto dividend = GetRegisterValue(builder, ZYDIS_REGISTER_AX);
-
-    Value* divisor = GetOperandValue(builder, src, src.size);
-    divisor =
-        builder.CreateSExt(divisor, Type::getIntNTy(context, src.size * 2));
-    dividend = builder.CreateSExtOrTrunc(dividend, divisor->getType());
-    Value* remainder = builder.CreateSRem(dividend, divisor);
-    Value* quotient = builder.CreateSDiv(dividend, divisor);
-
-    SetRegisterValue(
-        builder, ZYDIS_REGISTER_AL,
-        createZExtOrTruncFolder(builder, quotient,
-                                Type::getIntNTy(context, src.size)));
-
-    SetRegisterValue(
-        builder, ZYDIS_REGISTER_AH,
-        createZExtOrTruncFolder(builder, remainder,
-                                Type::getIntNTy(context, src.size)));
-
-    printvalue(remainder);
-    printvalue(quotient);
-    printvalue(divisor);
-    printvalue(dividend);
-  }
-
-  void lift_div(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-
-    LLVMContext& context = builder.getContext();
-    auto src = instruction.operands[0];
-    if (src.size == 8) {
-      lift_div2(builder, instruction);
-      return;
-    }
-    auto dividendLowop = instruction.operands[1];  // eax
-    auto dividendHighop = instruction.operands[2]; // edx
-
-    auto Rvalue = GetOperandValue(builder, src, src.size);
-
-    Value *dividendLow, *dividendHigh, *dividend;
-
-    dividendLow = GetOperandValue(builder, dividendLowop, src.size);
-    dividendHigh = GetOperandValue(builder, dividendHighop, src.size);
-
-    dividendLow = createZExtFolder(builder, dividendLow,
-                                   Type::getIntNTy(context, src.size * 2));
-    dividendHigh =
-        createZExtFolder(builder, dividendHigh, dividendLow->getType());
-    uint8_t bitWidth = src.size;
-
-    dividendHigh = builder.CreateShl(dividendHigh, bitWidth);
-    printvalue2(bitWidth);
-    printvalue(dividendLow);
-    printvalue(dividendHigh);
-
-    dividend = builder.CreateOr(dividendHigh, dividendLow);
-    printvalue(dividend);
-    Value* divide = createZExtFolder(builder, Rvalue, dividend->getType());
-    Value *quotient, *remainder;
-    if (isa<ConstantInt>(divide) && isa<ConstantInt>(dividend)) {
-
-      APInt divideCI = cast<ConstantInt>(divide)->getValue();
-      APInt dividendCI = cast<ConstantInt>(dividend)->getValue();
-
-      APInt quotientCI = dividendCI.udiv(divideCI);
-      APInt remainderCI = dividendCI.urem(divideCI);
-
-      printvalue2(divideCI);
-      printvalue2(dividendCI);
-      printvalue2(quotientCI);
-      printvalue2(remainderCI);
-      quotient = ConstantInt::get(Rvalue->getType(), quotientCI);
-      remainder = ConstantInt::get(Rvalue->getType(), remainderCI);
-    } else {
-      quotient = builder.CreateUDiv(dividend, divide);
-      remainder = builder.CreateURem(dividend, divide);
-    }
-    SetOperandValue(
-        builder, dividendLowop,
-        createZExtOrTruncFolder(builder, quotient, Rvalue->getType()));
-
-    SetOperandValue(
-        builder, dividendHighop,
-        createZExtOrTruncFolder(builder, remainder, Rvalue->getType()));
-
-    printvalue(Rvalue) printvalue(dividend) printvalue(remainder)
-        printvalue(quotient)
-  }
-
-  void lift_idiv(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto src = instruction.operands[0];
-    if (src.size == 8) {
-      lift_idiv2(builder, instruction);
-      return;
-    }
-    auto dividendLowop = instruction.operands[1];  // eax
-    auto dividendHighop = instruction.operands[2]; // edx
-
-    auto Rvalue = GetOperandValue(builder, src, src.size);
-
-    Value *dividendLow, *dividendHigh, *dividend;
-
-    dividendLow = GetOperandValue(builder, dividendLowop, src.size);
-    dividendHigh = GetOperandValue(builder, dividendHighop, src.size);
-
-    dividendLow = createZExtFolder(builder, dividendLow,
-                                   Type::getIntNTy(context, src.size * 2));
-    dividendHigh =
-        createZExtFolder(builder, dividendHigh, dividendLow->getType());
-    uint8_t bitWidth = src.size;
-
-    dividendHigh = builder.CreateShl(dividendHigh, bitWidth);
-    printvalue2(bitWidth);
-    printvalue(dividendLow);
-    printvalue(dividendHigh);
-
-    dividend = builder.CreateOr(dividendHigh, dividendLow);
-    printvalue(dividend);
-    Value* divide = builder.CreateSExt(Rvalue, dividend->getType());
-    Value *quotient, *remainder;
-    if (isa<ConstantInt>(divide) && isa<ConstantInt>(dividend)) {
-
-      APInt divideCI = cast<ConstantInt>(divide)->getValue();
-      APInt dividendCI = cast<ConstantInt>(dividend)->getValue();
-
-      APInt quotientCI = dividendCI.sdiv(divideCI);
-      APInt remainderCI = dividendCI.srem(divideCI);
-
-      printvalue2(divideCI);
-      printvalue2(dividendCI);
-      printvalue2(quotientCI);
-      printvalue2(remainderCI);
-      quotient = ConstantInt::get(Rvalue->getType(), quotientCI);
-      remainder = ConstantInt::get(Rvalue->getType(), remainderCI);
-    } else {
-      quotient = builder.CreateSDiv(dividend, divide);
-      remainder = builder.CreateSRem(dividend, divide);
-    }
-    SetOperandValue(
-        builder, dividendLowop,
-        createZExtOrTruncFolder(builder, quotient, Rvalue->getType()));
-
-    SetOperandValue(
-        builder, dividendHighop,
-        createZExtOrTruncFolder(builder, remainder, Rvalue->getType()));
-
-    printvalue(Rvalue) printvalue(dividend) printvalue(remainder)
-        printvalue(quotient)
-  }
-
-  void lift_xor(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-    auto Rvalue = GetOperandValue(builder, src, dest.size);
-    auto Lvalue = GetOperandValue(builder, dest, dest.size);
-    auto result = createXorFolder(
-        builder, Lvalue, Rvalue,
-        "realxor-" + to_string(instruction.runtime_address) + "-");
-
-    printvalue(Lvalue) printvalue(Rvalue) printvalue(result)
-
-        auto sf = computeSignFlag(builder, result);
-    auto zf = computeZeroFlag(builder, result);
-    auto pf = computeParityFlag(builder, result);
-    //  The OF and CF flags are cleared; the SF, ZF, and PF flags are set
-    //  according to the result. The state of the AF flag is undefined.
-
-    setFlag(builder, FLAG_SF, sf);
-    setFlag(builder, FLAG_ZF, zf);
-    setFlag(builder, FLAG_PF, pf);
-
-    setFlag(builder, FLAG_OF,
-            ConstantInt::getSigned(Type::getInt1Ty(context), 0));
-    setFlag(builder, FLAG_CF,
-            ConstantInt::getSigned(Type::getInt1Ty(context), 0));
-
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_or(IRBuilder<>& builder,
-               ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-    auto Rvalue = GetOperandValue(builder, src, dest.size);
-    auto Lvalue = GetOperandValue(builder, dest, dest.size);
-    auto result = createOrFolder(
-        builder, Lvalue, Rvalue,
-        "realor-" + to_string(instruction.runtime_address) + "-");
-
-    printvalue(Lvalue);
-    printvalue(Rvalue);
-    printvalue(result);
-
-    auto sf = computeSignFlag(builder, result);
-    auto zf = computeZeroFlag(builder, result);
-    auto pf = computeParityFlag(builder, result);
-    printvalue(sf);
-    // The OF and CF flags are cleared; the SF, ZF, and PF flags are set
-    // according to the result. The state of the AF flag is undefined.
-
-    setFlag(builder, FLAG_SF, sf);
-    setFlag(builder, FLAG_ZF, zf);
-    setFlag(builder, FLAG_PF, pf);
-
-    setFlag(builder, FLAG_OF,
-            ConstantInt::getSigned(Type::getInt1Ty(context), 0));
-    setFlag(builder, FLAG_CF,
-            ConstantInt::getSigned(Type::getInt1Ty(context), 0));
-
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_and(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-    auto Rvalue = GetOperandValue(builder, src, dest.size);
-    auto Lvalue = GetOperandValue(builder, dest, dest.size);
-
-    auto result = createAndFolder(
-        builder, Lvalue, Rvalue,
-        "realand-" + to_string(instruction.runtime_address) + "-");
-
-    auto sf = computeSignFlag(builder, result);
-    auto zf = computeZeroFlag(builder, result);
-    auto pf = computeParityFlag(builder, result);
-
-    // The OF and CF flags are cleared; the SF, ZF, and PF flags are set
-    // according to the result. The state of the AF flag is undefined.
-    setFlag(builder, FLAG_SF, sf);
-    setFlag(builder, FLAG_ZF, zf);
-    setFlag(builder, FLAG_PF, pf);
-
-    setFlag(builder, FLAG_OF,
-            ConstantInt::getSigned(Type::getInt1Ty(context), 0));
-    setFlag(builder, FLAG_CF,
-            ConstantInt::getSigned(Type::getInt1Ty(context), 0));
-
-    printvalue(Lvalue) printvalue(Rvalue) printvalue(result);
-
-    SetOperandValue(builder, dest, result,
-                    "and" + to_string(instruction.runtime_address));
-  }
-
-  /*
-
-  tempCOUNT := (COUNT & COUNTMASK) MOD SIZE
-  WHILE (tempCOUNT ≠ 0)
-          DO
-          tempCF := MSB(DEST);
-          DEST := (DEST ∗ 2) + tempCF;
-          tempCOUNT := tempCOUNT – 1;
-          OD;
-  ELIHW;
-  IF (COUNT & COUNTMASK) ≠ 0
-          THEN CF := LSB(DEST);
-  FI;
-  IF (COUNT & COUNTMASK) = 1
-          THEN OF := MSB(DEST) XOR CF;
-          ELSE OF is undefined;
-  FI
-  */
-  void lift_rol(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-    auto Lvalue = GetOperandValue(builder, dest, dest.size);
-    auto Rvalue = GetOperandValue(builder, src, dest.size);
-
-    unsigned bitWidth = Lvalue->getType()->getIntegerBitWidth();
-    Rvalue = createAndFolder(builder, Rvalue,
-                             ConstantInt::get(Rvalue->getType(), bitWidth - 1),
-                             "maskRvalue");
-
-    Value* shiftedLeft = createShlFolder(builder, Lvalue, Rvalue);
-    Value* shiftedRight = createLShrFolder(
-        builder, Lvalue,
-        createSubFolder(builder, ConstantInt::get(Rvalue->getType(), bitWidth),
-                        Rvalue),
-        "rol");
-    Value* result = createOrFolder(builder, shiftedLeft, shiftedRight);
-
-    Value* lastBit =
-        createAndFolder(builder, shiftedRight,
-                        ConstantInt::get(Lvalue->getType(), 1), "rollastbit");
-    Value* cf =
-        createZExtOrTruncFolder(builder, lastBit, Type::getInt1Ty(context));
-
-    Value* zero = ConstantInt::get(Rvalue->getType(), 0);
-    Value* isNotZero =
-        createICMPFolder(builder, CmpInst::ICMP_NE, Rvalue, zero);
-    Value* oldcf = getFlag(builder, FLAG_CF);
-    cf = createSelectFolder(builder, isNotZero, cf, oldcf);
-    result = createSelectFolder(builder, isNotZero, result, Lvalue);
-
-    // of = cf ^ MSB
-    Value* newMSB = createLShrFolder(builder, result, bitWidth - 1, "rolmsb");
-    Value* of = createXorFolder(
-        builder, cf,
-        createZExtOrTruncFolder(builder, newMSB, Type::getInt1Ty(context)));
-
-    // Use Select to conditionally update OF based on whether the shift
-    // amount is 1
-    Value* isOneBitRotation =
-        createICMPFolder(builder, CmpInst::ICMP_EQ, Rvalue,
-                         ConstantInt::get(Rvalue->getType(), 1));
-    Value* ofCurrent = getFlag(builder, FLAG_OF);
-
-    of = createSelectFolder(builder, isOneBitRotation, of, ofCurrent);
-
-    setFlag(builder, FLAG_CF, cf);
-    setFlag(builder, FLAG_OF, of);
-
-    printvalue(Lvalue) printvalue(Rvalue) printvalue(result)
-        SetOperandValue(builder, dest, result);
-  }
-
-  /*
-
-  tempCOUNT := (COUNT & COUNTMASK) MOD SIZE
-  WHILE (tempCOUNT ≠ 0)
-          DO
-          tempCF := LSB(SRC);
-          DEST := (DEST / 2) + (tempCF ∗ 2SIZE);
-          tempCOUNT := tempCOUNT – 1;
-          OD;
-  ELIHW;
-  IF (COUNT & COUNTMASK) ≠ 0
-          THEN CF := MSB(DEST);
-  FI;
-  IF (COUNT & COUNTMASK) = 1
-          THEN OF := MSB(DEST) XOR MSB − 1(DEST);
-          ELSE OF is undefined;
-  FI
-
-  */
-  void lift_ror(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-    auto Lvalue = GetOperandValue(builder, dest, dest.size);
-    auto Rvalue = GetOperandValue(builder, src, dest.size);
-
-    auto size = ConstantInt::getSigned(Lvalue->getType(),
-                                       Lvalue->getType()->getIntegerBitWidth());
-    Rvalue = builder.CreateURem(Rvalue, size);
-
-    Value* result = createOrFolder(
-        builder, createLShrFolder(builder, Lvalue, Rvalue),
-        createShlFolder(builder, Lvalue,
-                        createSubFolder(builder, size, Rvalue)),
-        "ror-" + std::to_string(instruction.runtime_address) + "-");
-
-    Value* msb = createLShrFolder(
-        builder, result,
-        createSubFolder(
-            builder, size,
-            ConstantInt::get(
-                context, APInt(Rvalue->getType()->getIntegerBitWidth(), 1))));
-    Value* cf = createZExtOrTruncFolder(builder, msb, Type::getInt1Ty(context),
-                                        "ror-cf");
-
-    Value* secondMsb = createLShrFolder(
-        builder, result,
-        createSubFolder(
-            builder, size,
-            ConstantInt::get(
-                context, APInt(Rvalue->getType()->getIntegerBitWidth(), 2))),
-        "ror2ndmsb");
-    auto ofDefined = createZExtOrTruncFolder(
-        builder, createXorFolder(builder, msb, secondMsb), cf->getType());
-    auto isOneBitRotation = createICMPFolder(
-        builder, CmpInst::ICMP_EQ, Rvalue,
-        ConstantInt::get(context,
-                         APInt(Rvalue->getType()->getIntegerBitWidth(), 1)));
-    Value* ofCurrent = getFlag(builder, FLAG_OF);
-    Value* of = createSelectFolder(builder, isOneBitRotation, ofDefined,
-                                   ofCurrent, "ror-of");
-
-    setFlag(builder, FLAG_CF, cf);
-    setFlag(builder, FLAG_OF, of);
-
-    auto isZeroBitRotation = createICMPFolder(
-        builder, CmpInst::ICMP_EQ, Rvalue,
-        ConstantInt::get(context,
-                         APInt(Rvalue->getType()->getIntegerBitWidth(), 0)),
-        "iszerobit");
-    result = createSelectFolder(builder, isZeroBitRotation, Lvalue, result,
-                                "ror-result");
-
-    printvalue(Lvalue) printvalue(Rvalue) printvalue(result)
-
-        SetOperandValue(builder, dest, result);
-  }
-
-  void lift_inc_dec(IRBuilder<>& builder,
-                    ZydisDisassembledInstruction& instruction) {
-    auto operand = instruction.operands[0];
-
-    Value* Lvalue = GetOperandValue(builder, operand, operand.size);
-
-    Value* one = ConstantInt::get(Lvalue->getType(), 1, true);
-    Value* result;
-    Value* of;
-    // The CF flag is not affected. The OF, SF, ZF, AF, and PF flags are set
-    // according to the result.
-    if (instruction.info.mnemonic == ZYDIS_MNEMONIC_INC) {
-      // treat it as add r, 1 for flags
-      result = createAddFolder(builder, Lvalue, one,
-                               "inc-" + to_string(instruction.runtime_address) +
-                                   "-");
-      of = computeOverflowFlagAdd(builder, Lvalue, one, result);
-
-    } else {
-      // treat it as sub r, 1 for flags
-      result = createSubFolder(builder, Lvalue, one,
-                               "dec-" + to_string(instruction.runtime_address) +
-                                   "-");
-      of = computeOverflowFlagSub(builder, Lvalue, one, result);
-    }
-
-    printvalue(Lvalue) printvalue(result)
-
-        Value* sf = computeSignFlag(builder, result);
-    Value* zf = computeZeroFlag(builder, result);
-    Value* pf = computeParityFlag(builder, result);
-
-    printvalue(sf)
-
-        setFlag(builder, FLAG_OF, of);
-    setFlag(builder, FLAG_SF, sf);
-    setFlag(builder, FLAG_ZF, zf);
-    setFlag(builder, FLAG_PF, pf);
-    SetOperandValue(builder, operand, result);
-  }
-
-  void lift_push(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto src = instruction.operands[0]; // value that we are pushing
-    auto dest = instruction.operands[2];
-    auto rsp = instruction.operands[1];
-
-    auto Rvalue = GetOperandValue(builder, src, dest.size);
-    auto RspValue = GetOperandValue(builder, rsp, rsp.size); // ?
-    auto val = ConstantInt::getSigned(
-        Type::getInt64Ty(context),
-        dest.size / 8); // jokes on me apparently this is not a fixed value
-    auto result = createSubFolder(
-        builder, RspValue, val,
-        "pushing_newrsp-" + to_string(instruction.runtime_address) + "-");
-
-    printvalue(RspValue) printvalue(result) SetOperandValue(
-        builder, rsp, result, to_string(instruction.runtime_address));
-    ; // sub rsp 8 first,
-
-    SetOperandValue(builder, dest, Rvalue,
-                    to_string(instruction.runtime_address));
-    ; // then mov rsp, val
-  }
-
-  void lift_pushfq(IRBuilder<>& builder,
-                   ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto src = instruction.operands[2];  // value that we are pushing rflags
-    auto dest = instruction.operands[1]; // [rsp]
-    auto rsp = instruction.operands[0];  // rsp
-
-    auto Rvalue = GetOperandValue(builder, src, dest.size);
-    // auto Rvalue = GetRFLAGS(builder);
-    auto RspValue = GetOperandValue(builder, rsp, rsp.size);
-
-    auto val = ConstantInt::get(Type::getInt64Ty(context), 8);
-    auto result = createSubFolder(builder, RspValue, val);
-
-    SetOperandValue(builder, rsp, result,
-                    to_string(instruction.runtime_address));
-    ; // sub rsp 8 first,
-
-    // pushFlags(builder, dest, Rvalue,
-    // to_string(instruction.runtime_address));;
-    SetOperandValue(builder, dest, Rvalue,
-                    to_string(instruction.runtime_address));
-    ; // then mov rsp, val
-  }
-
-  void lift_pop(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0]; // value that we are pushing
-    auto src = instruction.operands[2];
-    auto rsp = instruction.operands[1];
-
-    auto Rvalue = GetOperandValue(builder, src, dest.size,
-                                  to_string(instruction.runtime_address));
-    ;
-    auto RspValue = GetOperandValue(builder, rsp, rsp.size,
-                                    to_string(instruction.runtime_address));
-    ;
-
-    auto val = ConstantInt::getSigned(Type::getInt64Ty(context),
-                                      dest.size / 8); // assuming its x64
-    auto result = createAddFolder(
-        builder, RspValue, val,
-        "popping_new_rsp-" + to_string(instruction.runtime_address) + "-");
-
-    printvalue(Rvalue) printvalue(RspValue) printvalue(result)
-
-        SetOperandValue(builder, rsp, result); // then add rsp 8
-
-    SetOperandValue(builder, dest, Rvalue,
-                    to_string(instruction.runtime_address));
-    ; // mov val, rsp first
-  }
-
-  void lift_popfq(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[2]; // value that we are pushing
-    auto src = instruction.operands[1];  // [rsp]
-    auto rsp = instruction.operands[0];  // rsp
-
-    auto Rvalue = GetOperandValue(builder, src, dest.size,
-                                  to_string(instruction.runtime_address));
-    ;
-    auto RspValue = GetOperandValue(builder, rsp, rsp.size,
-                                    to_string(instruction.runtime_address));
-    ;
-
-    auto val = ConstantInt::getSigned(Type::getInt64Ty(context),
-                                      8); // assuming its x64
-    auto result = createAddFolder(
-        builder, RspValue, val,
-        "popfq-" + to_string(instruction.runtime_address) + "-");
-
-    SetOperandValue(builder, dest, Rvalue,
-                    to_string(instruction.runtime_address));
-    ; // mov val, rsp first
-    SetOperandValue(builder, rsp, result,
-                    to_string(instruction.runtime_address));
-    ; // then add rsp 8
-  }
-
-  void lift_adc(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    Value* Lvalue = GetOperandValue(builder, dest, dest.size);
-    Value* Rvalue = GetOperandValue(builder, src, dest.size);
-
-    Value* cf = getFlag(builder, FLAG_CF);
-    cf = createZExtFolder(builder, cf, Lvalue->getType());
-
-    Value* tempResult = createAddFolder(
-        builder, Lvalue, Rvalue,
-        "adc-temp-" + to_string(instruction.runtime_address) + "-");
-    Value* result = createAddFolder(
-        builder, tempResult, cf,
-        "adc-result-" + to_string(instruction.runtime_address) + "-");
-    // The OF, SF, ZF, AF, CF, and PF flags are set according to the result.
-
-    printvalue(Lvalue) printvalue(Rvalue) printvalue(tempResult) printvalue(
-        result)
-
-        auto cfAfterFirstAdd = createOrFolder(
-            builder,
-            createICMPFolder(builder, CmpInst::ICMP_ULT, tempResult, Lvalue),
-            createICMPFolder(builder, CmpInst::ICMP_ULT, tempResult, Rvalue));
-    auto cfFinal = createOrFolder(
-        builder, cfAfterFirstAdd,
-        createICMPFolder(builder, CmpInst::ICMP_ULT, result, cf));
-
-    auto lowerNibbleMask = ConstantInt::get(Lvalue->getType(), 0xF);
-    auto destLowerNibble =
-        createAndFolder(builder, Lvalue, lowerNibbleMask, "adcdst");
-    auto srcLowerNibble =
-        createAndFolder(builder, Rvalue, lowerNibbleMask, "adcsrc");
-    auto sumLowerNibble =
-        createAddFolder(builder, destLowerNibble, srcLowerNibble);
-    auto af = createICMPFolder(builder, CmpInst::ICMP_UGT, sumLowerNibble,
-                               lowerNibbleMask);
-
-    auto of = computeOverflowFlagAdc(builder, Lvalue, Rvalue, cf, result);
-
-    Value* sf = computeSignFlag(builder, result);
-    Value* zf = computeZeroFlag(builder, result);
-    Value* pf = computeParityFlag(builder, result);
-
-    setFlag(builder, FLAG_OF, of);
-    setFlag(builder, FLAG_AF, af);
-    setFlag(builder, FLAG_CF, cfFinal);
-    setFlag(builder, FLAG_SF, sf);
-    setFlag(builder, FLAG_ZF, zf);
-    setFlag(builder, FLAG_PF, pf);
-
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_xadd(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction) {
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    auto Lvalue = GetOperandValue(builder, dest, dest.size);
-    auto Rvalue = GetOperandValue(builder, src, src.size);
-
-    Value* sumValue = createAddFolder(
-        builder, Lvalue, Rvalue,
-        "xadd_sum-" + to_string(instruction.runtime_address) + "-");
-
-    SetOperandValue(builder, dest, sumValue,
-                    to_string(instruction.runtime_address));
-    ;
-
-    SetOperandValue(builder, src, Lvalue,
-                    to_string(instruction.runtime_address));
-    ;
-    /*
-    TEMP := SRC + DEST;
-    SRC := DEST;
-    DEST := TEMP;
-    */
-    printvalue(Lvalue) printvalue(Rvalue) printvalue(sumValue)
-
-        auto cf = createOrFolder(
-            builder,
-            createICMPFolder(builder, CmpInst::ICMP_ULT, sumValue, Lvalue),
-            createICMPFolder(builder, CmpInst::ICMP_ULT, sumValue, Rvalue));
-
-    auto lowerNibbleMask = ConstantInt::get(Lvalue->getType(), 0xF);
-    auto destLowerNibble =
-        createAndFolder(builder, Lvalue, lowerNibbleMask, "xadddst");
-    auto srcLowerNibble =
-        createAndFolder(builder, Rvalue, lowerNibbleMask, "xaddsrc");
-    auto sumLowerNibble =
-        createAddFolder(builder, destLowerNibble, srcLowerNibble);
-    auto af = createICMPFolder(builder, CmpInst::ICMP_UGT, sumLowerNibble,
-                               lowerNibbleMask);
-
-    auto resultSign = createICMPFolder(builder, CmpInst::ICMP_SLT, sumValue,
-                                       ConstantInt::get(Lvalue->getType(), 0));
-    auto destSign = createICMPFolder(builder, CmpInst::ICMP_SLT, Lvalue,
-                                     ConstantInt::get(Lvalue->getType(), 0));
-    auto srcSign = createICMPFolder(builder, CmpInst::ICMP_SLT, Rvalue,
-                                    ConstantInt::get(Rvalue->getType(), 0));
-    auto inputSameSign =
-        createICMPFolder(builder, CmpInst::ICMP_EQ, destSign, srcSign);
-    auto of = createAndFolder(
-        builder, inputSameSign,
-        createICMPFolder(builder, CmpInst::ICMP_NE, destSign, resultSign),
-        "xaddof");
-
-    Value* sf = computeSignFlag(builder, sumValue);
-    Value* zf = computeZeroFlag(builder, sumValue);
-    Value* pf = computeParityFlag(builder, sumValue);
-
-    setFlag(builder, FLAG_OF, of);
-    setFlag(builder, FLAG_AF, af);
-    setFlag(builder, FLAG_CF, cf);
-    setFlag(builder, FLAG_SF, sf);
-    setFlag(builder, FLAG_ZF, zf);
-    setFlag(builder, FLAG_PF, pf);
-
-    // The CF, PF, AF, SF, ZF, and OF flags are set according to the result
-    // of the addition, which is stored in the destination operand.
-  }
-
-  void lift_test(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    Value* Lvalue = GetOperandValue(builder, instruction.operands[0],
-                                    instruction.operands[0].size);
-    Value* Rvalue = GetOperandValue(builder, instruction.operands[1],
-                                    instruction.operands[0].size);
-
-    Value* testResult = createAndFolder(builder, Lvalue, Rvalue, "testAnd");
-
-    Value* of = ConstantInt::get(Type::getInt64Ty(context), 0, "of");
-    Value* cf = ConstantInt::get(Type::getInt64Ty(context), 0, "cf");
-
-    Value* sf =
-        createICMPFolder(builder, CmpInst::ICMP_SLT, testResult,
-                         ConstantInt::get(testResult->getType(), 0), "sf");
-    Value* zf =
-        createICMPFolder(builder, CmpInst::ICMP_EQ, testResult,
-                         ConstantInt::get(testResult->getType(), 0), "zf");
-    Value* pf = computeParityFlag(builder, testResult);
-
-    setFlag(builder, FLAG_OF, of);
-    setFlag(builder, FLAG_CF, cf);
-    setFlag(builder, FLAG_SF, sf);
-    setFlag(builder, FLAG_ZF, zf);
-    setFlag(builder, FLAG_PF, pf);
-  }
-
-  void lift_cmp(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-
-    Value* Lvalue = GetOperandValue(builder, instruction.operands[0],
-                                    instruction.operands[0].size);
-    Value* Rvalue = GetOperandValue(builder, instruction.operands[1],
-                                    instruction.operands[0].size);
-
-    Value* cmpResult = createSubFolder(builder, Lvalue, Rvalue);
-
-    Value* signL = createICMPFolder(builder, CmpInst::ICMP_SLT, Lvalue,
-                                    ConstantInt::get(Lvalue->getType(), 0));
-    Value* signR = createICMPFolder(builder, CmpInst::ICMP_SLT, Rvalue,
-                                    ConstantInt::get(Rvalue->getType(), 0));
-    Value* signResult =
-        createICMPFolder(builder, CmpInst::ICMP_SLT, cmpResult,
-                         ConstantInt::get(cmpResult->getType(), 0));
-
-    Value* of = createOrFolder(
-        builder,
-        createAndFolder(builder, signL,
-                        createAndFolder(builder, builder.CreateNot(signR),
-                                        builder.CreateNot(signResult),
-                                        "cmp-and1-")),
-        createAndFolder(builder, builder.CreateNot(signL),
-                        createAndFolder(builder, signR, signResult),
-                        "cmp-and2-"),
-        "cmp-OF-or");
-
-    Value* cf = createICMPFolder(builder, CmpInst::ICMP_ULT, Lvalue, Rvalue);
-    Value* zf = createICMPFolder(builder, CmpInst::ICMP_EQ, cmpResult,
-                                 ConstantInt::get(cmpResult->getType(), 0));
-    Value* sf = createICMPFolder(builder, CmpInst::ICMP_SLT, cmpResult,
-                                 ConstantInt::get(cmpResult->getType(), 0));
-    Value* pf = computeParityFlag(builder, cmpResult);
-
-    setFlag(builder, FLAG_OF, of);
-    setFlag(builder, FLAG_CF, cf);
-    setFlag(builder, FLAG_SF, sf);
-    setFlag(builder, FLAG_ZF, zf);
-    setFlag(builder, FLAG_PF, pf);
-  }
-
-  void lift_rdtsc(IRBuilder<>& builder) {
-    // cout << instruction.runtime_address << "\n";
-    LLVMContext& context = builder.getContext();
-    auto rdtscCall =
-        builder.CreateIntrinsic(Intrinsic::readcyclecounter, {}, {});
-    auto edxPart = createLShrFolder(builder, rdtscCall, 32, "to_edx");
-    auto eaxPart = createZExtOrTruncFolder(builder, rdtscCall,
-                                           Type::getInt32Ty(context), "to_eax");
-    SetRegisterValue(builder, ZYDIS_REGISTER_EDX, edxPart);
-    SetRegisterValue(builder, ZYDIS_REGISTER_EAX, eaxPart);
-  }
-
-  void lift_cpuid(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    // instruction.operands[0] = eax
-    // instruction.operands[1] = ebx
-    // instruction.operands[2] = ecx
-    // instruction.operands[3] = edx
-    /*
-
-    c++
-    #include <intrin.h>
-
-    int getcpuid() {
-            int cpuInfo[4];
-            __cpuid(cpuInfo, 1);
-            return cpuInfo[0] + cpuInfo[1];
-    }
-
-    ir
-    define dso_local noundef i32 @getcpuid() #0 {
-      %1 = alloca [4 x i32], align 16
-      %2 = getelementptr inbounds [4 x i32], ptr %1, i64 0, i64 0
-      %3 = call { i32, i32, i32, i32 } asm "xchgq %rbx,
-    ${1:q}\0Acpuid\0Axchgq %rbx, ${1:q}", "={ax},=r,={cx},={dx},0,2"(i32 1,
-    i32 0) %4 = getelementptr inbounds [4 x i32], ptr %1, i64 0, i64 0 %5 =
-    extractvalue { i32, i32, i32, i32 } %3, 0 %6 = getelementptr inbounds
-    i32, ptr %4, i32 0 store i32 %5, ptr %6, align 4 %7 = extractvalue {
-    i32, i32, i32, i32 } %3, 1 %8 = getelementptr inbounds i32, ptr %4, i32
-    1 store i32 %7, ptr %8, align 4 %9 = extractvalue { i32, i32, i32, i32 }
-    %3, 2 %10 = getelementptr inbounds i32, ptr %4, i32 2 store i32 %9, ptr
-    %10, align 4 %11 = extractvalue { i32, i32, i32, i32 } %3, 3 %12 =
-    getelementptr inbounds i32, ptr %4, i32 3 store i32 %11, ptr %12, align
-    4
-
-      %13 = getelementptr inbounds [4 x i32], ptr %1, i64 0, i64 0
-      %14 = load i32, ptr %13, align 16
-
-      %15 = getelementptr inbounds [4 x i32], ptr %1, i64 0, i64 1
-      %16 = load i32, ptr %15, align 4
-      %17 = add nsw i32 %14, %16
-      ret i32 %17
-    }
-    opt
-    define dso_local noundef i32 @getcpuid() local_unnamed_addr {
-      %1 = tail call { i32, i32, i32, i32 } asm "xchgq %rbx,
-    ${1:q}\0Acpuid\0Axchgq %rbx, ${1:q}", "={ax},=r,={cx},={dx},0,2"(i32 1,
-    i32 0) #0 %2 = extractvalue { i32, i32, i32, i32 } %1, 1 ret i32 %2
-    }
-
-    */
-    // int cpuInfo[4];
-    // ArrayType* CpuInfoTy = ArrayType::get(Type::getInt32Ty(context), 4);
-
-    Value* eax = GetOperandValue(builder, instruction.operands[0],
-                                 instruction.operands[0].size);
-    // one is eax, other is always 0?
-    std::vector<Type*> AsmOutputs = {
-        Type::getInt32Ty(context), Type::getInt32Ty(context),
-        Type::getInt32Ty(context), Type::getInt32Ty(context)};
-    StructType* AsmStructType = StructType::get(context, AsmOutputs);
-
-    std::vector<Type*> ArgTypes = {Type::getInt32Ty(context),
-                                   Type::getInt32Ty(context)};
-
-    // this is probably incorrect
-    InlineAsm* IA =
-        InlineAsm::get(FunctionType::get(AsmStructType, ArgTypes, false),
-                       "xchgq %rbx, ${1:q}\ncpuid\nxchgq %rbx, ${1:q}",
-                       "={ax},=r,={cx},={dx},0,2", true);
-
-    std::vector<Value*> Args{eax, ConstantInt::get(eax->getType(), 0)};
-
-    Value* cpuidCall = builder.CreateCall(IA, Args);
-
-    Value* eaxv = builder.CreateExtractValue(cpuidCall, 0, "eax");
-    Value* ebx = builder.CreateExtractValue(cpuidCall, 1, "ebx");
-    Value* ecx = builder.CreateExtractValue(cpuidCall, 2, "ecx");
-    Value* edx = builder.CreateExtractValue(cpuidCall, 3, "edx");
-
-    SetOperandValue(builder, instruction.operands[0], eaxv);
-    SetOperandValue(builder, instruction.operands[1], ebx);
-    SetOperandValue(builder, instruction.operands[2], ecx);
-    SetOperandValue(builder, instruction.operands[3], edx);
-  }
-
-} // namespace arithmeticsAndLogical
-
-namespace flagOperation {
-  void lift_setnz(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-
-    auto dest = instruction.operands[0];
-
-    Value* zf = getFlag(builder, FLAG_ZF);
-
-    Value* result = createZExtFolder(builder, builder.CreateNot(zf),
-                                     Type::getInt8Ty(context));
-
-    SetOperandValue(builder, dest, result);
-  }
-  void lift_seto(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-
-    auto dest = instruction.operands[0];
-
-    Value* of = getFlag(builder, FLAG_OF);
-
-    Value* result = createZExtFolder(builder, of, Type::getInt8Ty(context));
-
-    SetOperandValue(builder, dest, result);
-  }
-  void lift_setno(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-
-    auto dest = instruction.operands[0];
-
-    Value* of = getFlag(builder, FLAG_OF);
-
-    Value* notOf = builder.CreateNot(of, "notOF");
-
-    Value* result = createZExtFolder(builder, notOf, Type::getInt8Ty(context));
-
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_setnb(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-
-    auto dest = instruction.operands[0];
-
-    Value* cf = getFlag(builder, FLAG_CF);
-
-    Value* result =
-        createICMPFolder(builder, CmpInst::ICMP_EQ, cf,
-                         ConstantInt::get(Type::getInt1Ty(context), 0));
-
-    Value* byteResult =
-        createZExtFolder(builder, result, Type::getInt8Ty(context));
-
-    SetOperandValue(builder, dest, byteResult);
-  }
-
-  void lift_setbe(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-
-    Value* cf = getFlag(builder, FLAG_CF);
-    Value* zf = getFlag(builder, FLAG_ZF);
-
-    Value* condition = createOrFolder(builder, cf, zf, "setbe-or");
-
-    Value* result =
-        createZExtFolder(builder, condition, Type::getInt8Ty(context));
-
-    auto dest = instruction.operands[0];
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_setnbe(IRBuilder<>& builder,
-                   ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-
-    Value* cf = getFlag(builder, FLAG_CF);
-    Value* zf = getFlag(builder, FLAG_ZF);
-
-    Value* condition = createAndFolder(builder, builder.CreateNot(cf),
-                                       builder.CreateNot(zf), "setnbe-and");
-
-    Value* result =
-        createZExtFolder(builder, condition, Type::getInt8Ty(context));
-
-    auto dest = instruction.operands[0];
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_setns(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-
-    auto dest = instruction.operands[0];
-
-    Value* sf = getFlag(builder, FLAG_SF);
-
-    Value* result =
-        createICMPFolder(builder, CmpInst::ICMP_EQ, sf,
-                         ConstantInt::get(Type::getInt1Ty(context), 0));
-
-    Value* byteResult =
-        createZExtFolder(builder, result, Type::getInt8Ty(context));
-
-    SetOperandValue(builder, dest, byteResult);
-  }
-
-  void lift_setp(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-
-    Value* pf = getFlag(builder, FLAG_PF);
-
-    Value* result = createZExtFolder(builder, pf, Type::getInt8Ty(context));
-
-    auto dest = instruction.operands[0];
-
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_setnp(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-
-    Value* pf = getFlag(builder, FLAG_PF);
-
-    Value* resultValue = createZExtFolder(builder, builder.CreateNot(pf),
-                                          Type::getInt8Ty(context));
-
-    SetOperandValue(builder, dest, resultValue,
-                    to_string(instruction.runtime_address));
-  }
-
-  void lift_setb(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-
-    auto dest = instruction.operands[0];
-
-    Value* cf = getFlag(builder, FLAG_CF);
-
-    Value* result = createZExtFolder(builder, cf, Type::getInt8Ty(context));
-
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_sets(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    Value* sf = getFlag(builder, FLAG_SF);
-
-    Value* result = createZExtFolder(builder, sf, Type::getInt8Ty(context));
-
-    auto dest = instruction.operands[0];
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_stosx(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-
-    auto dest = instruction.operands[0]; // xdi
-    Value* destValue = GetOperandValue(builder, dest, dest.size);
-    Value* DF = getFlag(builder, FLAG_DF);
-    // if df is 1, +
-    // else -
-    auto destbitwidth = dest.size;
-
-    auto one = ConstantInt::get(DF->getType(), 1);
-    Value* Direction = builder.CreateSub(
-        builder.CreateMul(DF, builder.CreateAdd(DF, one)), one);
-
-    Value* result = createAddFolder(
-        builder, destValue,
-        builder.CreateMul(Direction,
-                          ConstantInt::get(DF->getType(), destbitwidth)));
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_setz(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-
-    Value* zf = getFlag(builder, FLAG_ZF);
-
-    Value* extendedZF =
-        createZExtFolder(builder, zf, Type::getInt8Ty(context), "setz_extend");
-
-    SetOperandValue(builder, dest, extendedZF);
-  }
-
-  void lift_setnle(IRBuilder<>& builder,
-                   ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-
-    Value* zf = getFlag(builder, FLAG_ZF);
-    Value* sf = getFlag(builder, FLAG_SF);
-    Value* of = getFlag(builder, FLAG_OF);
-
-    Value* zfNotSet =
-        createICMPFolder(builder, CmpInst::ICMP_EQ, zf,
-                         ConstantInt::get(Type::getInt1Ty(context), 0));
-
-    Value* sfEqualsOf = createICMPFolder(builder, CmpInst::ICMP_EQ, sf, of);
-
-    printvalue(zf) printvalue(sf) printvalue(of)
-
-        Value* combinedCondition =
-            createAndFolder(builder, zfNotSet, sfEqualsOf, "setnle-and");
-
-    Value* byteResult =
-        createZExtFolder(builder, combinedCondition, Type::getInt8Ty(context));
-
-    SetOperandValue(builder, dest, byteResult);
-  }
-
-  void lift_setle(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    Value* zf = getFlag(builder, FLAG_ZF);
-    Value* sf = getFlag(builder, FLAG_SF);
-    Value* of = getFlag(builder, FLAG_OF);
-
-    Value* sf_ne_of = createICMPFolder(builder, CmpInst::ICMP_NE, sf, of);
-    Value* condition = createOrFolder(builder, zf, sf_ne_of, "setle-or");
-
-    Value* result =
-        createZExtFolder(builder, condition, Type::getInt8Ty(context));
-
-    auto dest = instruction.operands[0];
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_setnl(IRBuilder<>& builder,
-                  ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    Value* sf = getFlag(builder, FLAG_SF);
-    Value* of = getFlag(builder, FLAG_OF);
-
-    Value* condition = createICMPFolder(builder, CmpInst::ICMP_EQ, sf, of);
-
-    Value* result =
-        createZExtFolder(builder, condition, Type::getInt8Ty(context));
-
-    auto dest = instruction.operands[0];
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_setl(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    Value* sf = getFlag(builder, FLAG_SF);
-    Value* of = getFlag(builder, FLAG_OF);
-
-    Value* condition = createICMPFolder(builder, CmpInst::ICMP_NE, sf, of);
-
-    Value* result =
-        createZExtFolder(builder, condition, Type::getInt8Ty(context));
-
-    auto dest = instruction.operands[0];
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_bt(IRBuilder<>& builder,
-               ZydisDisassembledInstruction& instruction) {
-
-    auto dest = instruction.operands[0];
-    auto bitIndex = instruction.operands[1];
-
-    // If the bit base operand specifies a register, the instruction takes
-    // the modulo 16, 32, or 64 of the bit offset operand (modulo size
-    // depends on the mode and register size; 64-bit operands are available
-    // only in 64-bit mode). If the bit base operand specifies a memory
-    // location, the operand represents the address of the byte in memory
-    // that contains the bit base (bit 0 of the specified byte) of the bit
-    // string. The range of the bit position that can be referenced by the
-    // offset operand depends on the operand size. CF := Bit(BitBase,
-    // BitOffset);
-
-    auto Lvalue = GetOperandValue(builder, dest, dest.size);
-    auto bitIndexValue = GetOperandValue(builder, bitIndex, dest.size);
-
-    unsigned LvalueBitW = cast<IntegerType>(Lvalue->getType())->getBitWidth();
-
-    auto Rvalue = createAndFolder(
-        builder, bitIndexValue,
-        ConstantInt::get(bitIndexValue->getType(), LvalueBitW - 1));
-
-    auto shl = createShlFolder(
-        builder, ConstantInt::get(bitIndexValue->getType(), 1), Rvalue);
-
-    auto andd = createAndFolder(builder, shl, Lvalue);
-
-    auto cf = createICMPFolder(builder, CmpInst::ICMP_NE, andd,
-                               ConstantInt::get(andd->getType(), 0));
-
-    setFlag(builder, FLAG_CF, cf);
-    printvalue(Rvalue);
-    printvalue(Lvalue);
-    printvalue(shl);
-    printvalue(andd);
-    printvalue(cf);
-  }
-
-  void lift_btr(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    auto base = instruction.operands[0];
-    auto offset = instruction.operands[1];
-
-    unsigned baseBitWidth = base.size;
-
-    Value* bitOffset = GetOperandValue(builder, offset, base.size);
-
-    Value* bitOffsetMasked = createAndFolder(
-        builder, bitOffset,
-        ConstantInt::get(bitOffset->getType(), baseBitWidth - 1),
-        "bitOffsetMasked");
-
-    Value* baseVal = GetOperandValue(builder, base, base.size);
-
-    Value* bit = createLShrFolder(
-        builder, baseVal, bitOffsetMasked,
-        "btr-lshr-" + to_string(instruction.runtime_address) + "-");
-
-    Value* one = ConstantInt::get(bit->getType(), 1);
-
-    bit = createAndFolder(builder, bit, one, "btr-and");
-
-    setFlag(builder, FLAG_CF, bit);
-
-    Value* mask =
-        createShlFolder(builder, ConstantInt::get(baseVal->getType(), 1),
-                        bitOffsetMasked, "btr-shl");
-
-    mask = builder.CreateNot(mask); // invert mask
-    baseVal = createAndFolder(builder, baseVal, mask,
-                              "btr-and-" +
-                                  to_string(instruction.runtime_address) + "-");
-
-    SetOperandValue(builder, base, baseVal);
-    printvalue(bitOffset);
-    printvalue(baseVal);
-    printvalue(mask);
-  }
-
-  void lift_bsr(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    Value* Rvalue = GetOperandValue(builder, src, src.size);
-    Value* isZero = createICMPFolder(builder, CmpInst::ICMP_EQ, Rvalue,
-                                     ConstantInt::get(Rvalue->getType(), 0));
-    setFlag(builder, FLAG_ZF, isZero);
-
-    unsigned bitWidth = Rvalue->getType()->getIntegerBitWidth();
-
-    Value* index = ConstantInt::get(Rvalue->getType(), bitWidth - 1);
-    Value* zeroVal = ConstantInt::get(Rvalue->getType(), 0);
-    Value* oneVal = ConstantInt::get(Rvalue->getType(), 1);
-
-    Value* bitPosition = ConstantInt::get(Rvalue->getType(), -1);
-
-    for (unsigned i = 0; i < bitWidth; ++i) {
-
-      Value* mask = createShlFolder(builder, oneVal, index);
-
-      Value* test = createAndFolder(builder, Rvalue, mask, "bsrtest");
-      Value* isBitSet =
-          createICMPFolder(builder, CmpInst::ICMP_NE, test, zeroVal);
-
-      Value* tmpPosition =
-          createSelectFolder(builder, isBitSet, index, bitPosition);
-
-      Value* isPositionUnset =
-          createICMPFolder(builder, CmpInst::ICMP_EQ, bitPosition,
-                           ConstantInt::get(Rvalue->getType(), -1));
-      bitPosition = createSelectFolder(builder, isPositionUnset, tmpPosition,
-                                       bitPosition);
-
-      index = createSubFolder(builder, index, oneVal);
-    }
-
-    SetOperandValue(builder, dest, bitPosition);
-  }
-
-  void lift_bsf(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    auto dest = instruction.operands[0];
-    auto src = instruction.operands[1];
-
-    Value* Rvalue = GetOperandValue(builder, src, src.size);
-
-    Value* isZero = createICMPFolder(builder, CmpInst::ICMP_EQ, Rvalue,
-                                     ConstantInt::get(Rvalue->getType(), 0));
-    setFlag(builder, FLAG_ZF, isZero);
-
-    Type* intType = Rvalue->getType();
-    uint64_t intWidth = intType->getIntegerBitWidth();
-
-    Value* result = ConstantInt::get(intType, intWidth);
-    Value* one = ConstantInt::get(intType, 1);
-
-    Value* continuecounting = ConstantInt::get(Type::getInt1Ty(context), 1);
-    for (uint64_t i = 0; i < intWidth; ++i) {
-      Value* bitMask =
-          createShlFolder(builder, one, ConstantInt::get(intType, i));
-      Value* bitSet = createAndFolder(builder, Rvalue, bitMask, "bsfbitset");
-      Value* isBitZero = createICMPFolder(builder, CmpInst::ICMP_EQ, bitSet,
-                                          ConstantInt::get(intType, 0));
-      // continue until isBitZero is 1
-      // 0010
-      // if continuecounting, select
-      Value* possibleResult = ConstantInt::get(intType, i);
-      Value* condition =
-          createAndFolder(builder, continuecounting, isBitZero, "bsfcondition");
-      continuecounting = builder.CreateNot(isBitZero);
-      result = createSelectFolder(builder, condition, result, possibleResult,
-                                  "updateResultOnFirstNonZeroBit");
-    }
-
-    SetOperandValue(builder, dest, result);
-  }
-
-  void lift_btc(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    auto base = instruction.operands[0];
-    auto offset = instruction.operands[1];
-
-    unsigned baseBitWidth = base.size;
-
-    Value* bitOffset = GetOperandValue(builder, offset, base.size);
-
-    Value* bitOffsetMasked = createAndFolder(
-        builder, bitOffset,
-        ConstantInt::get(bitOffset->getType(), baseBitWidth - 1),
-        "bitOffsetMasked");
-
-    Value* baseVal = GetOperandValue(builder, base, base.size);
-
-    Value* bit = createLShrFolder(
-        builder, baseVal, bitOffsetMasked,
-        "btc-lshr-" + to_string(instruction.runtime_address) + "-");
-
-    Value* one = ConstantInt::get(bit->getType(), 1);
-
-    bit = createAndFolder(builder, bit, one, "btc-and");
-
-    setFlag(builder, FLAG_CF, bit);
-
-    Value* mask =
-        createShlFolder(builder, ConstantInt::get(baseVal->getType(), 1),
-                        bitOffsetMasked, "btc-shl");
-
-    baseVal = createXorFolder(builder, baseVal, mask,
-                              "btc-and-" +
-                                  to_string(instruction.runtime_address) + "-");
-
-    SetOperandValue(builder, base, baseVal);
-    printvalue(bitOffset);
-    printvalue(baseVal);
-    printvalue(mask);
-  }
-
-  void lift_lahf(IRBuilder<>& builder) {
-
-    LLVMContext& context = builder.getContext();
-
-    auto sf = getFlag(builder, FLAG_SF);
-    auto zf = getFlag(builder, FLAG_ZF);
-    auto af = getFlag(builder, FLAG_AF);
-    auto pf = getFlag(builder, FLAG_PF);
-    auto cf = getFlag(builder, FLAG_CF);
-
-    printvalue(sf) printvalue(zf) printvalue(af) printvalue(pf) printvalue(cf);
-
-    cf = createZExtFolder(builder, cf, Type::getInt8Ty(context));
-    pf = createShlFolder(
-        builder, createZExtFolder(builder, pf, Type::getInt8Ty(context)),
-        FLAG_PF);
-    af = createShlFolder(
-        builder, createZExtFolder(builder, af, Type::getInt8Ty(context)),
-        FLAG_AF);
-    zf = createShlFolder(
-        builder, createZExtFolder(builder, zf, Type::getInt8Ty(context)),
-        FLAG_ZF);
-    sf = createShlFolder(
-        builder, createZExtFolder(builder, sf, Type::getInt8Ty(context)),
-        FLAG_SF);
-    Value* Rvalue =
-        createOrFolder(builder,
-                       createOrFolder(builder, createOrFolder(builder, cf, pf),
-                                      createOrFolder(builder, af, sf)),
-                       sf);
-
-    printvalue(sf) printvalue(zf) printvalue(af) printvalue(pf) printvalue(cf);
-
-    SetRegisterValue(builder, ZYDIS_REGISTER_AH, Rvalue);
-  }
-
-  void lift_stc(IRBuilder<>& builder) {
-    LLVMContext& context = builder.getContext();
-
-    setFlag(builder, FLAG_CF, ConstantInt::get(Type::getInt1Ty(context), 1));
-  }
-
-  void lift_cmc(IRBuilder<>& builder) {
-
-    Value* cf = getFlag(builder, FLAG_CF);
-
-    Value* one = ConstantInt::get(cf->getType(), 1);
-
-    setFlag(builder, FLAG_CF, createXorFolder(builder, cf, one));
-  }
-
-  void lift_clc(IRBuilder<>& builder) {
-
-    LLVMContext& context = builder.getContext();
-
-    Value* clearedCF = ConstantInt::get(Type::getInt1Ty(context), 0);
-
-    setFlag(builder, FLAG_CF, clearedCF);
-  }
-
-  void lift_cld(IRBuilder<>& builder) {
-
-    LLVMContext& context = builder.getContext();
-
-    Value* clearedDF = ConstantInt::get(Type::getInt1Ty(context), 0);
-
-    setFlag(builder, FLAG_DF, clearedDF);
-  }
-
-  void lift_cli(IRBuilder<>& builder) {
-
-    LLVMContext& context = builder.getContext();
-
-    Value* resetIF = ConstantInt::get(Type::getInt1Ty(context), 0);
-
-    setFlag(builder, FLAG_IF, resetIF);
-  }
-
-  void lift_bts(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    auto base = instruction.operands[0];
-    auto offset = instruction.operands[1];
-
-    unsigned baseBitWidth = base.size;
-
-    Value* bitOffset = GetOperandValue(builder, offset, base.size);
-
-    Value* bitOffsetMasked = createAndFolder(
-        builder, bitOffset,
-        ConstantInt::get(bitOffset->getType(), baseBitWidth - 1),
-        "bitOffsetMasked");
-
-    Value* baseVal = GetOperandValue(builder, base, base.size);
-
-    Value* bit = createLShrFolder(
-        builder, baseVal, bitOffsetMasked,
-        "bts-lshr-" + to_string(instruction.runtime_address) + "-");
-
-    Value* one = ConstantInt::get(bit->getType(), 1);
-
-    bit = createAndFolder(builder, bit, one, "bts-and");
-
-    setFlag(builder, FLAG_CF, bit);
-
-    Value* mask =
-        createShlFolder(builder, ConstantInt::get(baseVal->getType(), 1),
-                        bitOffsetMasked, "bts-shl");
-
-    baseVal = createOrFolder(builder, baseVal, mask,
-                             "bts-or-" +
-                                 to_string(instruction.runtime_address) + "-");
-
-    SetOperandValue(builder, base, baseVal);
-    printvalue(bitOffset);
-    printvalue(baseVal);
-    printvalue(mask);
-  }
-
-  void lift_cwd(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-
-    Value* ax = createZExtOrTruncFolder(
-        builder,
-        GetOperandValue(builder, instruction.operands[1],
-                        instruction.operands[1].size),
-        Type::getInt16Ty(context));
-
-    Value* signBit = computeSignFlag(builder, ax);
-
-    Value* dx = createSelectFolder(
-        builder,
-        createICMPFolder(builder, CmpInst::ICMP_EQ, signBit,
-                         ConstantInt::get(signBit->getType(), 0)),
-        ConstantInt::get(Type::getInt16Ty(context), 0),
-        ConstantInt::get(Type::getInt16Ty(context), 0xFFFF), "setDX");
-
-    SetOperandValue(builder, instruction.operands[0], dx);
-  }
-
-  void lift_cdq(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    // if eax is -, then edx is filled with ones FFFF_FFFF
-    Value* eax = createZExtOrTruncFolder(
-        builder,
-        GetOperandValue(builder, instruction.operands[1],
-                        instruction.operands[1].size),
-        Type::getInt32Ty(context));
-
-    Value* signBit = computeSignFlag(builder, eax);
-
-    Value* edx = createSelectFolder(
-        builder,
-        createICMPFolder(builder, CmpInst::ICMP_EQ, signBit,
-                         ConstantInt::get(signBit->getType(), 0)),
-        ConstantInt::get(Type::getInt32Ty(context), 0),
-        ConstantInt::get(Type::getInt32Ty(context), 0xFFFFFFFF), "setEDX");
-
-    SetOperandValue(builder, instruction.operands[0], edx);
-  }
-
-  void lift_cqo(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-
-    LLVMContext& context = builder.getContext();
-    // if rax is -, then rdx is filled with ones FFFF_FFFF_FFFF_FFFF
-    Value* rax = createZExtOrTruncFolder(
-        builder,
-        GetOperandValue(builder, instruction.operands[1],
-                        instruction.operands[1].size),
-        Type::getInt64Ty(context));
-
-    Value* signBit = computeSignFlag(builder, rax);
-
-    Value* rdx = createSelectFolder(
-        builder,
-        createICMPFolder(builder, CmpInst::ICMP_EQ, signBit,
-                         ConstantInt::get(signBit->getType(), 0)),
-        ConstantInt::get(Type::getInt64Ty(context), 0),
-        ConstantInt::get(Type::getInt64Ty(context), 0xFFFFFFFFFFFFFFFF),
-        "setRDX");
-    printvalue(rax) printvalue(signBit) printvalue(rdx)
-        SetOperandValue(builder, instruction.operands[0], rdx);
-  }
-
-  void lift_cbw(IRBuilder<>& builder,
-                ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    Value* al = createZExtOrTruncFolder(
-        builder,
-        GetOperandValue(builder, instruction.operands[1],
-                        instruction.operands[1].size),
-        Type::getInt8Ty(context));
-
-    Value* ax = createSExtFolder(builder, al, Type::getInt16Ty(context), "cbw");
-
-    SetOperandValue(builder, instruction.operands[0], ax);
-  }
-
-  void lift_cwde(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-    Value* ax = createZExtOrTruncFolder(
-        builder,
-        GetOperandValue(builder, instruction.operands[1],
-                        instruction.operands[1].size),
-        Type::getInt16Ty(context));
-    printvalue(ax);
-    Value* eax =
-        createSExtFolder(builder, ax, Type::getInt32Ty(context), "cwde");
-    printvalue(eax);
-    SetOperandValue(builder, instruction.operands[0], eax);
-  }
-
-  void lift_cdqe(IRBuilder<>& builder,
-                 ZydisDisassembledInstruction& instruction) {
-    LLVMContext& context = builder.getContext();
-
-    Value* eax = createZExtOrTruncFolder(
-        builder,
-        GetOperandValue(builder, instruction.operands[1],
-                        instruction.operands[1].size),
-        Type::getInt32Ty(context), "cdqe-trunc");
-
-    Value* rax =
-        createSExtFolder(builder, eax, Type::getInt64Ty(context), "cdqe");
-
-    SetOperandValue(builder, instruction.operands[0], rax);
-  }
-
-} // namespace flagOperation
-
-void liftInstructionSemantics(IRBuilder<>& builder,
-                              ZydisDisassembledInstruction& instruction,
-                              shared_ptr<vector<BBInfo>> blockAddresses,
-                              bool& run) {
+  auto zf = createICMPFolder(builder, CmpInst::ICMP_EQ, accum, Lvalue);
+  // if zf dest = src
+  auto result = createSelectFolder(builder, zf, Rvalue, Lvalue);
+
+  SetOperandValue(dest, result);
+  setFlag(FLAG_OF, of);
+  setFlag(FLAG_CF, cf);
+  setFlag(FLAG_AF, af);
+  setFlag(FLAG_SF, sf);
+  setFlag(FLAG_ZF, zf);
+}
+
+void lifterClass::lift_xchg(ZydisDisassembledInstruction& instruction) {
+
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  auto Rvalue = GetOperandValue(src, src.size);
+  auto Lvalue = GetOperandValue(dest, dest.size);
+
+  printvalue(Lvalue) printvalue(Rvalue);
+
+  SetOperandValue(dest, Rvalue, to_string(instruction.runtime_address));
+  ;
+  SetOperandValue(src, Lvalue);
+}
+
+void lifterClass::lift_shld(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
+  auto source = instruction.operands[1];
+  auto count = instruction.operands[2];
+
+  auto Lvalue = GetOperandValue(dest, dest.size);
+  auto sourceValue = GetOperandValue(source, dest.size);
+  auto countValue = GetOperandValue(count, dest.size);
+
+  unsigned bitWidth = Lvalue->getType()->getIntegerBitWidth();
+  auto effectiveCountValue = builder.CreateURem(
+      countValue, ConstantInt::get(countValue->getType(), bitWidth),
+      "effectiveShiftCount");
+
+  auto shiftedDest =
+      createShlFolder(builder, Lvalue, effectiveCountValue, "shiftedDest");
+  auto complementCount = createSubFolder(
+      builder, ConstantInt::get(countValue->getType(), bitWidth),
+      effectiveCountValue, "complementCount");
+  auto shiftedSource =
+      createLShrFolder(builder, sourceValue, complementCount, "shiftedSource");
+  auto resultValue =
+      createOrFolder(builder, shiftedDest, shiftedSource, "shldResult");
+
+  auto countIsNotZero =
+      createICMPFolder(builder, CmpInst::ICMP_NE, effectiveCountValue,
+                       ConstantInt::get(effectiveCountValue->getType(), 0));
+  auto lastShiftedBitPosition =
+      createSubFolder(builder, effectiveCountValue,
+                      ConstantInt::get(effectiveCountValue->getType(), 1));
+  auto lastShiftedBit = createAndFolder(
+      builder, createLShrFolder(builder, Lvalue, lastShiftedBitPosition),
+      ConstantInt::get(Lvalue->getType(), 1), "shldresultmsb");
+  auto cf =
+      createSelectFolder(builder, countIsNotZero,
+                         createZExtOrTruncFolder(builder, lastShiftedBit,
+                                                 Type::getInt1Ty(context)),
+                         getFlag(FLAG_CF));
+  resultValue =
+      createSelectFolder(builder, countIsNotZero, resultValue, Lvalue);
+
+  auto isOne =
+      createICMPFolder(builder, CmpInst::ICMP_EQ, effectiveCountValue,
+                       ConstantInt::get(effectiveCountValue->getType(), 1));
+  auto newOF = createXorFolder(
+      builder,
+      createLShrFolder(builder, Lvalue,
+                       ConstantInt::get(Lvalue->getType(), bitWidth - 1),
+                       "subof"),
+      createLShrFolder(builder, resultValue,
+                       ConstantInt::get(resultValue->getType(), bitWidth - 1),
+                       "subof2"),
+      "subxorof");
+  auto of = createSelectFolder(
+      builder, isOne,
+      createZExtOrTruncFolder(builder, newOF, Type::getInt1Ty(context)),
+      getFlag(FLAG_OF));
+
+  //  CF := BIT[DEST, SIZE – COUNT]; if shifted,
+  setFlag(FLAG_CF, cf);
+  setFlag(FLAG_OF, of);
+
+  SetOperandValue(dest, resultValue, to_string(instruction.runtime_address));
+}
+
+void lifterClass::lift_shrd(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
+  auto source = instruction.operands[1];
+  auto count = instruction.operands[2];
+
+  auto Lvalue = GetOperandValue(dest, dest.size);
+  auto sourceValue = GetOperandValue(source, dest.size);
+  auto countValue = GetOperandValue(count, dest.size);
+
+  unsigned bitWidth = Lvalue->getType()->getIntegerBitWidth();
+  auto effectiveCountValue = builder.CreateURem(
+      countValue, ConstantInt::get(countValue->getType(), bitWidth),
+      "effectiveShiftCount");
+
+  auto shiftedDest =
+      createLShrFolder(builder, Lvalue, effectiveCountValue, "shiftedDest");
+  auto complementCount = createSubFolder(
+      builder, ConstantInt::get(countValue->getType(), bitWidth),
+      effectiveCountValue, "complementCount");
+  auto shiftedSource =
+      createShlFolder(builder, sourceValue, complementCount, "shiftedSource");
+  auto resultValue =
+      createOrFolder(builder, shiftedDest, shiftedSource, "shrdResult");
+
+  // Calculate CF
+  auto cfBitPosition =
+      createSubFolder(builder, effectiveCountValue,
+                      ConstantInt::get(effectiveCountValue->getType(), 1));
+  Value* cf = createLShrFolder(builder, Lvalue, cfBitPosition);
+  cf = createAndFolder(builder, cf, ConstantInt::get(cf->getType(), 1),
+                       "shrdcf");
+  cf = createZExtOrTruncFolder(builder, cf, Type::getInt1Ty(context));
+
+  // Calculate OF, only when count is 1
+  Value* isCountOne =
+      createICMPFolder(builder, CmpInst::ICMP_EQ, effectiveCountValue,
+                       ConstantInt::get(effectiveCountValue->getType(), 1));
+  Value* mostSignificantBitOfDest = createLShrFolder(
+      builder, Lvalue, ConstantInt::get(Lvalue->getType(), bitWidth - 1),
+      "shlmsbdest");
+  mostSignificantBitOfDest = createAndFolder(
+      builder, mostSignificantBitOfDest,
+      ConstantInt::get(mostSignificantBitOfDest->getType(), 1), "shrdmsb");
+  Value* mostSignificantBitOfResult = createLShrFolder(
+      builder, resultValue,
+      ConstantInt::get(resultValue->getType(), bitWidth - 1), "shlmsbresult");
+  mostSignificantBitOfResult = createAndFolder(
+      builder, mostSignificantBitOfResult,
+      ConstantInt::get(mostSignificantBitOfResult->getType(), 1), "shrdmsb2");
+  Value* of = createXorFolder(builder, mostSignificantBitOfDest,
+                              mostSignificantBitOfResult);
+  of = createZExtOrTruncFolder(builder, of, Type::getInt1Ty(context));
+  of = createSelectFolder(builder, isCountOne, of,
+                          ConstantInt::getFalse(context));
+  of = createZExtFolder(builder, of, Type::getInt1Ty(context));
+
+  setFlag(FLAG_CF, cf);
+  setFlag(FLAG_OF, of);
+
+  SetOperandValue(dest, resultValue, to_string(instruction.runtime_address));
+}
+
+void lifterClass::lift_lea(ZydisDisassembledInstruction& instruction) {
+
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  auto Rvalue = GetEffectiveAddress(src, dest.size);
+
+  printvalue(Rvalue)
+
+      SetOperandValue(dest, Rvalue, to_string(instruction.runtime_address));
+  ;
+}
+
+// extract sub from this function, this is convoluted for no reason
+void lifterClass::lift_add_sub(ZydisDisassembledInstruction& instruction) {
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  auto Rvalue = GetOperandValue(src, dest.size);
+  auto Lvalue = GetOperandValue(dest, dest.size);
+
+  Value* result = nullptr;
+  Value* cf = nullptr;
+  Value* af = nullptr;
+  Value* of = nullptr;
+
+  auto lowerNibbleMask = ConstantInt::get(Lvalue->getType(), 0xF);
+  auto RvalueLowerNibble =
+      createAndFolder(builder, Lvalue, lowerNibbleMask, "lvalLowerNibble");
+  auto op2LowerNibble =
+      createAndFolder(builder, Rvalue, lowerNibbleMask, "rvalLowerNibble");
 
   switch (instruction.info.mnemonic) {
-  // mov s
+  case ZYDIS_MNEMONIC_ADD: {
+    result = createAddFolder(builder, Lvalue, Rvalue,
+                             "realadd-" +
+                                 to_string(instruction.runtime_address) + "-");
+    cf = createOrFolder(
+        builder,
+        createICMPFolder(builder, CmpInst::ICMP_ULT, result, Lvalue, "add_cf1"),
+        createICMPFolder(builder, CmpInst::ICMP_ULT, result, Rvalue, "add_cf2"),
+        "add_cf");
+    auto sumLowerNibble = createAddFolder(builder, RvalueLowerNibble,
+                                          op2LowerNibble, "add_sumLowerNibble");
+    af = createICMPFolder(builder, CmpInst::ICMP_UGT, sumLowerNibble,
+                          lowerNibbleMask, "add_af");
+    of = computeOverflowFlagAdd(builder, Lvalue, Rvalue, result);
+    break;
+  }
+  case ZYDIS_MNEMONIC_SUB: {
+    result = createSubFolder(builder, Lvalue, Rvalue,
+                             "realsub-" +
+                                 to_string(instruction.runtime_address) + "-");
+
+    of = computeOverflowFlagSub(builder, Lvalue, Rvalue, result);
+
+    cf = createICMPFolder(builder, CmpInst::ICMP_UGT, Rvalue, Lvalue, "add_cf");
+    af = createICMPFolder(builder, CmpInst::ICMP_ULT, RvalueLowerNibble,
+                          op2LowerNibble, "add_af");
+    break;
+  }
+  default:
+    break;
+  }
+
+  /*
+  Flags Affected
+  The OF, SF, ZF, AF, CF, and PF flags are set according to the result.
+  */
+
+  auto sf = computeSignFlag(builder, result);
+  auto zf = computeZeroFlag(builder, result);
+  auto pf = computeParityFlag(builder, result);
+
+  setFlag(FLAG_OF, of);
+  setFlag(FLAG_SF, sf);
+  setFlag(FLAG_ZF, zf);
+  setFlag(FLAG_AF, af);
+  setFlag(FLAG_CF, cf);
+  setFlag(FLAG_PF, pf);
+
+  printvalue(Lvalue);
+  printvalue(Rvalue);
+  printvalue(result);
+  printvalue(cf);
+  printvalue(sf);
+  printvalue(of);
+
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_imul2(ZydisDisassembledInstruction& instruction,
+                             bool isSigned) {
+  LLVMContext& context = builder.getContext();
+  auto src = instruction.operands[0];
+  auto Rvalue = GetRegisterValue(ZYDIS_REGISTER_AL);
+
+  Value* Lvalue = GetOperandValue(src, src.size);
+  if (isSigned) { // do this in a prettier way
+    Lvalue = builder.CreateSExt(Lvalue, Type::getIntNTy(context, src.size * 2));
+
+    Rvalue = builder.CreateSExtOrTrunc(
+        Rvalue, Type::getIntNTy(context,
+                                src.size)); // make sure the size is correct,
+                                            // 1 byte, GetRegisterValue doesnt
+                                            // ensure we have the correct size
+    Rvalue = builder.CreateSExtOrTrunc(Rvalue, Lvalue->getType());
+  } else {
+    Lvalue = createZExtFolder(builder, Lvalue,
+                              Type::getIntNTy(context, src.size * 2));
+
+    Rvalue = createZExtOrTruncFolder(
+        builder, Rvalue,
+        Type::getIntNTy(context,
+                        src.size)); // make sure the size is correct, 1
+                                    // byte, GetRegisterValue doesnt
+                                    // ensure we have the correct size
+    Rvalue = createZExtOrTruncFolder(builder, Rvalue, Lvalue->getType());
+  }
+  Value* result = builder.CreateMul(Rvalue, Lvalue);
+  Value* lowerresult = builder.CreateTrunc(
+      result, Type::getIntNTy(context, src.size), "lowerResult");
+  Value* of;
+  Value* cf;
+  if (isSigned) {
+    of = builder.CreateICmpNE(
+        result, builder.CreateSExt(lowerresult, result->getType()));
+    cf = of;
+  } else {
+    Value* highPart = builder.CreateLShr(result, src.size, "highPart");
+    Value* highPartTruncated = builder.CreateTrunc(
+        highPart, Type::getIntNTy(context, src.size), "truncatedHighPart");
+    cf = builder.CreateICmpNE(highPartTruncated,
+                              ConstantInt::get(result->getType(), 0), "cf");
+    of = cf;
+  }
+
+  setFlag(FLAG_CF, cf);
+  setFlag(FLAG_OF, of);
+  printvalue(cf);
+  printvalue(of);
+  SetRegisterValue(ZYDIS_REGISTER_AX, result);
+  printvalue(Lvalue);
+  printvalue(Rvalue);
+  printvalue(result);
+  // if imul modify cf and of flags
+  // if not, dont do anything else
+}
+
+// TODO rewrite this
+void lifterClass::lift_imul(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+
+  auto dest = instruction.operands[0]; // dest ?
+  if (dest.size == 8 && instruction.info.operand_count_visible == 1) {
+    lift_imul2(instruction, 1);
+    return;
+  }
+  auto src = instruction.operands[1];
+  auto src2 = (instruction.info.operand_count_visible == 3)
+                  ? instruction.operands[2]
+                  : dest; // if exists third operand
+
+  Value* Rvalue = GetOperandValue(src, src.size);
+  Value* Lvalue = GetOperandValue(src2, src2.size);
+  uint8_t initialSize = src.size;
+  printvalue2(initialSize);
+  printvalue(Rvalue);
+  printvalue(Lvalue);
+  Rvalue =
+      builder.CreateSExt(Rvalue, Type::getIntNTy(context, initialSize * 2));
+  Lvalue =
+      builder.CreateSExt(Lvalue, Type::getIntNTy(context, initialSize * 2));
+
+  Value* result = builder.CreateMul(Lvalue, Rvalue, "intmul");
+
+  // Flags
+
+  Value* highPart = builder.CreateLShr(result, initialSize, "highPart");
+  Value* highPartTruncated = builder.CreateTrunc(
+      highPart, Type::getIntNTy(context, initialSize), "truncatedHighPart");
+
+  /*
+  For the one operand form of the instruction, the CF and OF flags are set
+  when significant bits are carried into the upper half of the result and
+  cleared when the result fits exactly in the lower half of the result.
+  For the two- and three-operand forms of the instruction, the CF and OF
+  flags are set when the result must be truncated to fit in the
+  destination operand size and cleared when the result fits exactly in the
+  destination operand size. The SF, ZF, AF, and PF flags are undefined.
+  */
+
+  /*
+  DEST := TruncateToOperandSize(TMP_XP);
+  IF SignExtend(DEST) ≠ TMP_XP
+  THEN CF := 1; OF := 1;
+          ELSE CF := 0; OF := 0; FI;
+  */
+
+  Value* truncresult = builder.CreateTrunc(
+      result, Type::getIntNTy(context, initialSize), "truncRes");
+
+  Value* cf = builder.CreateICmpNE(
+      result, builder.CreateSExt(truncresult, result->getType()), "cf");
+  Value* of = cf;
+
+  if (instruction.info.operand_count_visible == 3) {
+    SetOperandValue(dest, truncresult);
+  } else if (instruction.info.operand_count_visible == 2) {
+    SetOperandValue(instruction.operands[0], truncresult);
+  } else { // For one operand, result goes into ?dx:?ax if not a byte
+           // operation
+    auto splitResult = builder.CreateTruncOrBitCast(
+        result, Type::getIntNTy(context, initialSize), "splitResult");
+    Value* SEsplitResult = builder.CreateSExt(splitResult, result->getType());
+    printvalue(splitResult);
+    printvalue(result);
+    cf = builder.CreateICmpNE(SEsplitResult, result);
+    of = cf;
+    printvalue(of);
+    printvalue(result);
+    printvalue(SEsplitResult);
+
+    if (initialSize == 8) {
+      SetOperandValue(instruction.operands[1], result);
+    } else {
+
+      SetOperandValue(instruction.operands[1], splitResult);
+      SetOperandValue(instruction.operands[2], highPartTruncated);
+    }
+  }
+
+  setFlag(FLAG_CF, cf);
+  setFlag(FLAG_OF, of);
+  printvalue(Lvalue) printvalue(Rvalue) printvalue(result)
+      printvalue(highPartTruncated) printvalue(of) printvalue(cf)
+}
+// rewrite this too
+void lifterClass::lift_mul(ZydisDisassembledInstruction& instruction) {
+  /*
+  mul rdx
+  [0] rdx
+  [1] rax
+  [2] rdx
+  [3] flags
+  */
+  /*
+  IF (Byte operation)
+          THEN
+                  AX := AL ∗ SRC;
+          ELSE (* Word or doubleword operation *)
+                  IF OperandSize = 16
+                          THEN
+                                  DX:AX := AX ∗ SRC;
+                          ELSE IF OperandSize = 32
+                                  THEN EDX:EAX := EAX ∗ SRC; FI;
+                          ELSE (* OperandSize = 64 *)
+                                  RDX:RAX := RAX ∗ SRC;
+                  FI;
+  FI;
+  */
+
+  LLVMContext& context = builder.getContext();
+  auto src = instruction.operands[0];
+
+  if (src.size == 8 && instruction.info.operand_count_visible == 1) {
+    lift_imul2(instruction, 0);
+    return;
+  }
+  auto dest1 = instruction.operands[1]; // ax
+  auto dest2 = instruction.operands[2];
+
+  Value* Rvalue = GetOperandValue(src, dest1.size);
+  Value* Lvalue = GetOperandValue(dest1, dest1.size);
+
+  uint8_t initialSize = Rvalue->getType()->getIntegerBitWidth();
+  printvalue2(initialSize);
+  Rvalue = createZExtFolder(builder, Rvalue,
+                            Type::getIntNTy(context, initialSize * 2));
+  Lvalue = createZExtFolder(builder, Lvalue,
+                            Type::getIntNTy(context, initialSize * 2));
+
+  Value* result = builder.CreateMul(Lvalue, Rvalue, "intmul");
+
+  // Flags
+  auto resultType = Type::getIntNTy(context, initialSize);
+
+  Value* highPart = builder.CreateLShr(result, initialSize, "highPart");
+  Value* highPartTruncated = builder.CreateTrunc(
+      highPart, Type::getIntNTy(context, initialSize), "truncatedHighPart");
+
+  /* The OF and CF flags are set to 0 if the upper half of the result is
+   * 0; otherwise, they are set to 1. The SF, ZF, AF, and PF flags are
+   * undefined.
+   */
+  Value* cf = builder.CreateICmpNE(highPartTruncated,
+                                   ConstantInt::get(resultType, 0), "cf");
+  Value* of = cf;
+  setFlag(FLAG_CF, cf);
+  setFlag(FLAG_OF, of);
+
+  auto splitResult = builder.CreateTruncOrBitCast(
+      result, Type::getIntNTy(context, initialSize), "splitResult");
+  // if not byte operation, result goes into ?dx:?ax
+
+  SetOperandValue(dest1, splitResult);
+  SetOperandValue(dest2, highPartTruncated);
+
+  printvalue(Lvalue) printvalue(Rvalue) printvalue(result) printvalue(highPart)
+      printvalue(highPartTruncated) printvalue(splitResult) printvalue(of)
+          printvalue(cf)
+}
+
+void lifterClass::lift_div2(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto src = instruction.operands[0];
+  auto dividend = GetRegisterValue(ZYDIS_REGISTER_AX);
+
+  Value* divisor = GetOperandValue(src, src.size);
+  divisor = createZExtFolder(builder, divisor,
+                             Type::getIntNTy(context, src.size * 2));
+  dividend = createZExtOrTruncFolder(builder, dividend, divisor->getType());
+  Value* remainder = builder.CreateURem(dividend, divisor);
+  Value* quotient = builder.CreateUDiv(dividend, divisor);
+
+  SetRegisterValue(ZYDIS_REGISTER_AL,
+                   createZExtOrTruncFolder(builder, quotient,
+                                           Type::getIntNTy(context, src.size)));
+
+  SetRegisterValue(ZYDIS_REGISTER_AH,
+                   createZExtOrTruncFolder(builder, remainder,
+                                           Type::getIntNTy(context, src.size)));
+
+  printvalue(remainder);
+  printvalue(quotient);
+  printvalue(divisor);
+  printvalue(dividend);
+}
+
+void lifterClass::lift_idiv2(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto src = instruction.operands[0];
+  auto dividend = GetRegisterValue(ZYDIS_REGISTER_AX);
+
+  Value* divisor = GetOperandValue(src, src.size);
+  divisor = builder.CreateSExt(divisor, Type::getIntNTy(context, src.size * 2));
+  dividend = builder.CreateSExtOrTrunc(dividend, divisor->getType());
+  Value* remainder = builder.CreateSRem(dividend, divisor);
+  Value* quotient = builder.CreateSDiv(dividend, divisor);
+
+  SetRegisterValue(ZYDIS_REGISTER_AL,
+                   createZExtOrTruncFolder(builder, quotient,
+                                           Type::getIntNTy(context, src.size)));
+
+  SetRegisterValue(ZYDIS_REGISTER_AH,
+                   createZExtOrTruncFolder(builder, remainder,
+                                           Type::getIntNTy(context, src.size)));
+
+  printvalue(remainder);
+  printvalue(quotient);
+  printvalue(divisor);
+  printvalue(dividend);
+}
+
+void lifterClass::lift_div(ZydisDisassembledInstruction& instruction) {
+
+  LLVMContext& context = builder.getContext();
+  auto src = instruction.operands[0];
+  if (src.size == 8) {
+    lift_div2(instruction);
+    return;
+  }
+  auto dividendLowop = instruction.operands[1];  // eax
+  auto dividendHighop = instruction.operands[2]; // edx
+
+  auto Rvalue = GetOperandValue(src, src.size);
+
+  Value *dividendLow, *dividendHigh, *dividend;
+
+  dividendLow = GetOperandValue(dividendLowop, src.size);
+  dividendHigh = GetOperandValue(dividendHighop, src.size);
+
+  dividendLow = createZExtFolder(builder, dividendLow,
+                                 Type::getIntNTy(context, src.size * 2));
+  dividendHigh =
+      createZExtFolder(builder, dividendHigh, dividendLow->getType());
+  uint8_t bitWidth = src.size;
+
+  dividendHigh = builder.CreateShl(dividendHigh, bitWidth);
+  printvalue2(bitWidth);
+  printvalue(dividendLow);
+  printvalue(dividendHigh);
+
+  dividend = builder.CreateOr(dividendHigh, dividendLow);
+  printvalue(dividend);
+  Value* divide = createZExtFolder(builder, Rvalue, dividend->getType());
+  Value *quotient, *remainder;
+  if (isa<ConstantInt>(divide) && isa<ConstantInt>(dividend)) {
+
+    APInt divideCI = cast<ConstantInt>(divide)->getValue();
+    APInt dividendCI = cast<ConstantInt>(dividend)->getValue();
+
+    APInt quotientCI = dividendCI.udiv(divideCI);
+    APInt remainderCI = dividendCI.urem(divideCI);
+
+    printvalue2(divideCI);
+    printvalue2(dividendCI);
+    printvalue2(quotientCI);
+    printvalue2(remainderCI);
+    quotient = ConstantInt::get(Rvalue->getType(), quotientCI);
+    remainder = ConstantInt::get(Rvalue->getType(), remainderCI);
+  } else {
+    quotient = builder.CreateUDiv(dividend, divide);
+    remainder = builder.CreateURem(dividend, divide);
+  }
+  SetOperandValue(dividendLowop, createZExtOrTruncFolder(builder, quotient,
+                                                         Rvalue->getType()));
+
+  SetOperandValue(dividendHighop, createZExtOrTruncFolder(builder, remainder,
+                                                          Rvalue->getType()));
+
+  printvalue(Rvalue) printvalue(dividend) printvalue(remainder)
+      printvalue(quotient)
+}
+
+void lifterClass::lift_idiv(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto src = instruction.operands[0];
+  if (src.size == 8) {
+    lift_idiv2(instruction);
+    return;
+  }
+  auto dividendLowop = instruction.operands[1];  // eax
+  auto dividendHighop = instruction.operands[2]; // edx
+
+  auto Rvalue = GetOperandValue(src, src.size);
+
+  Value *dividendLow, *dividendHigh, *dividend;
+
+  dividendLow = GetOperandValue(dividendLowop, src.size);
+  dividendHigh = GetOperandValue(dividendHighop, src.size);
+
+  dividendLow = createZExtFolder(builder, dividendLow,
+                                 Type::getIntNTy(context, src.size * 2));
+  dividendHigh =
+      createZExtFolder(builder, dividendHigh, dividendLow->getType());
+  uint8_t bitWidth = src.size;
+
+  dividendHigh = builder.CreateShl(dividendHigh, bitWidth);
+  printvalue2(bitWidth);
+  printvalue(dividendLow);
+  printvalue(dividendHigh);
+
+  dividend = builder.CreateOr(dividendHigh, dividendLow);
+  printvalue(dividend);
+  Value* divide = builder.CreateSExt(Rvalue, dividend->getType());
+  Value *quotient, *remainder;
+  if (isa<ConstantInt>(divide) && isa<ConstantInt>(dividend)) {
+
+    APInt divideCI = cast<ConstantInt>(divide)->getValue();
+    APInt dividendCI = cast<ConstantInt>(dividend)->getValue();
+
+    APInt quotientCI = dividendCI.sdiv(divideCI);
+    APInt remainderCI = dividendCI.srem(divideCI);
+
+    printvalue2(divideCI);
+    printvalue2(dividendCI);
+    printvalue2(quotientCI);
+    printvalue2(remainderCI);
+    quotient = ConstantInt::get(Rvalue->getType(), quotientCI);
+    remainder = ConstantInt::get(Rvalue->getType(), remainderCI);
+  } else {
+    quotient = builder.CreateSDiv(dividend, divide);
+    remainder = builder.CreateSRem(dividend, divide);
+  }
+  SetOperandValue(dividendLowop, createZExtOrTruncFolder(builder, quotient,
+                                                         Rvalue->getType()));
+
+  SetOperandValue(dividendHighop, createZExtOrTruncFolder(builder, remainder,
+                                                          Rvalue->getType()));
+
+  printvalue(Rvalue) printvalue(dividend) printvalue(remainder)
+      printvalue(quotient)
+}
+
+void lifterClass::lift_xor(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+  auto Rvalue = GetOperandValue(src, dest.size);
+  auto Lvalue = GetOperandValue(dest, dest.size);
+  auto result = createXorFolder(
+      builder, Lvalue, Rvalue,
+      "realxor-" + to_string(instruction.runtime_address) + "-");
+
+  printvalue(Lvalue) printvalue(Rvalue) printvalue(result)
+
+      auto sf = computeSignFlag(builder, result);
+  auto zf = computeZeroFlag(builder, result);
+  auto pf = computeParityFlag(builder, result);
+  //  The OF and CF flags are cleared; the SF, ZF, and PF flags are set
+  //  according to the result. The state of the AF flag is undefined.
+
+  setFlag(FLAG_SF, sf);
+  setFlag(FLAG_ZF, zf);
+  setFlag(FLAG_PF, pf);
+
+  setFlag(FLAG_OF, ConstantInt::getSigned(Type::getInt1Ty(context), 0));
+  setFlag(FLAG_CF, ConstantInt::getSigned(Type::getInt1Ty(context), 0));
+
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_or(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+  auto Rvalue = GetOperandValue(src, dest.size);
+  auto Lvalue = GetOperandValue(dest, dest.size);
+  auto result =
+      createOrFolder(builder, Lvalue, Rvalue,
+                     "realor-" + to_string(instruction.runtime_address) + "-");
+
+  printvalue(Lvalue);
+  printvalue(Rvalue);
+  printvalue(result);
+
+  auto sf = computeSignFlag(builder, result);
+  auto zf = computeZeroFlag(builder, result);
+  auto pf = computeParityFlag(builder, result);
+  printvalue(sf);
+  // The OF and CF flags are cleared; the SF, ZF, and PF flags are set
+  // according to the result. The state of the AF flag is undefined.
+
+  setFlag(FLAG_SF, sf);
+  setFlag(FLAG_ZF, zf);
+  setFlag(FLAG_PF, pf);
+
+  setFlag(FLAG_OF, ConstantInt::getSigned(Type::getInt1Ty(context), 0));
+  setFlag(FLAG_CF, ConstantInt::getSigned(Type::getInt1Ty(context), 0));
+
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_and(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+  auto Rvalue = GetOperandValue(src, dest.size);
+  auto Lvalue = GetOperandValue(dest, dest.size);
+
+  auto result = createAndFolder(
+      builder, Lvalue, Rvalue,
+      "realand-" + to_string(instruction.runtime_address) + "-");
+
+  auto sf = computeSignFlag(builder, result);
+  auto zf = computeZeroFlag(builder, result);
+  auto pf = computeParityFlag(builder, result);
+
+  // The OF and CF flags are cleared; the SF, ZF, and PF flags are set
+  // according to the result. The state of the AF flag is undefined.
+  setFlag(FLAG_SF, sf);
+  setFlag(FLAG_ZF, zf);
+  setFlag(FLAG_PF, pf);
+
+  setFlag(FLAG_OF, ConstantInt::getSigned(Type::getInt1Ty(context), 0));
+  setFlag(FLAG_CF, ConstantInt::getSigned(Type::getInt1Ty(context), 0));
+
+  printvalue(Lvalue) printvalue(Rvalue) printvalue(result);
+
+  SetOperandValue(dest, result, "and" + to_string(instruction.runtime_address));
+}
+
+/*
+
+tempCOUNT := (COUNT & COUNTMASK) MOD SIZE
+WHILE (tempCOUNT ≠ 0)
+        DO
+        tempCF := MSB(DEST);
+        DEST := (DEST ∗ 2) + tempCF;
+        tempCOUNT := tempCOUNT – 1;
+        OD;
+ELIHW;
+IF (COUNT & COUNTMASK) ≠ 0
+        THEN CF := LSB(DEST);
+FI;
+IF (COUNT & COUNTMASK) = 1
+        THEN OF := MSB(DEST) XOR CF;
+        ELSE OF is undefined;
+FI
+*/
+void lifterClass::lift_rol(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+  auto Lvalue = GetOperandValue(dest, dest.size);
+  auto Rvalue = GetOperandValue(src, dest.size);
+
+  unsigned bitWidth = Lvalue->getType()->getIntegerBitWidth();
+  Rvalue = createAndFolder(builder, Rvalue,
+                           ConstantInt::get(Rvalue->getType(), bitWidth - 1),
+                           "maskRvalue");
+
+  Value* shiftedLeft = createShlFolder(builder, Lvalue, Rvalue);
+  Value* shiftedRight = createLShrFolder(
+      builder, Lvalue,
+      createSubFolder(builder, ConstantInt::get(Rvalue->getType(), bitWidth),
+                      Rvalue),
+      "rol");
+  Value* result = createOrFolder(builder, shiftedLeft, shiftedRight);
+
+  Value* lastBit =
+      createAndFolder(builder, shiftedRight,
+                      ConstantInt::get(Lvalue->getType(), 1), "rollastbit");
+  Value* cf =
+      createZExtOrTruncFolder(builder, lastBit, Type::getInt1Ty(context));
+
+  Value* zero = ConstantInt::get(Rvalue->getType(), 0);
+  Value* isNotZero = createICMPFolder(builder, CmpInst::ICMP_NE, Rvalue, zero);
+  Value* oldcf = getFlag(FLAG_CF);
+  cf = createSelectFolder(builder, isNotZero, cf, oldcf);
+  result = createSelectFolder(builder, isNotZero, result, Lvalue);
+
+  // of = cf ^ MSB
+  Value* newMSB = createLShrFolder(builder, result, bitWidth - 1, "rolmsb");
+  Value* of = createXorFolder(
+      builder, cf,
+      createZExtOrTruncFolder(builder, newMSB, Type::getInt1Ty(context)));
+
+  // Use Select to conditionally update OF based on whether the shift
+  // amount is 1
+  Value* isOneBitRotation =
+      createICMPFolder(builder, CmpInst::ICMP_EQ, Rvalue,
+                       ConstantInt::get(Rvalue->getType(), 1));
+  Value* ofCurrent = getFlag(FLAG_OF);
+
+  of = createSelectFolder(builder, isOneBitRotation, of, ofCurrent);
+
+  setFlag(FLAG_CF, cf);
+  setFlag(FLAG_OF, of);
+
+  printvalue(Lvalue) printvalue(Rvalue) printvalue(result)
+      SetOperandValue(dest, result);
+}
+
+/*
+
+tempCOUNT := (COUNT & COUNTMASK) MOD SIZE
+WHILE (tempCOUNT ≠ 0)
+        DO
+        tempCF := LSB(SRC);
+        DEST := (DEST / 2) + (tempCF ∗ 2SIZE);
+        tempCOUNT := tempCOUNT – 1;
+        OD;
+ELIHW;
+IF (COUNT & COUNTMASK) ≠ 0
+        THEN CF := MSB(DEST);
+FI;
+IF (COUNT & COUNTMASK) = 1
+        THEN OF := MSB(DEST) XOR MSB − 1(DEST);
+        ELSE OF is undefined;
+FI
+
+*/
+void lifterClass::lift_ror(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+  auto Lvalue = GetOperandValue(dest, dest.size);
+  auto Rvalue = GetOperandValue(src, dest.size);
+
+  auto size = ConstantInt::getSigned(Lvalue->getType(),
+                                     Lvalue->getType()->getIntegerBitWidth());
+  Rvalue = builder.CreateURem(Rvalue, size);
+
+  Value* result = createOrFolder(
+      builder, createLShrFolder(builder, Lvalue, Rvalue),
+      createShlFolder(builder, Lvalue, createSubFolder(builder, size, Rvalue)),
+      "ror-" + std::to_string(instruction.runtime_address) + "-");
+
+  Value* msb = createLShrFolder(
+      builder, result,
+      createSubFolder(
+          builder, size,
+          ConstantInt::get(context,
+                           APInt(Rvalue->getType()->getIntegerBitWidth(), 1))));
+  Value* cf =
+      createZExtOrTruncFolder(builder, msb, Type::getInt1Ty(context), "ror-cf");
+
+  Value* secondMsb = createLShrFolder(
+      builder, result,
+      createSubFolder(
+          builder, size,
+          ConstantInt::get(context,
+                           APInt(Rvalue->getType()->getIntegerBitWidth(), 2))),
+      "ror2ndmsb");
+  auto ofDefined = createZExtOrTruncFolder(
+      builder, createXorFolder(builder, msb, secondMsb), cf->getType());
+  auto isOneBitRotation = createICMPFolder(
+      builder, CmpInst::ICMP_EQ, Rvalue,
+      ConstantInt::get(context,
+                       APInt(Rvalue->getType()->getIntegerBitWidth(), 1)));
+  Value* ofCurrent = getFlag(FLAG_OF);
+  Value* of = createSelectFolder(builder, isOneBitRotation, ofDefined,
+                                 ofCurrent, "ror-of");
+
+  setFlag(FLAG_CF, cf);
+  setFlag(FLAG_OF, of);
+
+  auto isZeroBitRotation = createICMPFolder(
+      builder, CmpInst::ICMP_EQ, Rvalue,
+      ConstantInt::get(context,
+                       APInt(Rvalue->getType()->getIntegerBitWidth(), 0)),
+      "iszerobit");
+  result = createSelectFolder(builder, isZeroBitRotation, Lvalue, result,
+                              "ror-result");
+
+  printvalue(Lvalue) printvalue(Rvalue) printvalue(result)
+
+      SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_inc_dec(ZydisDisassembledInstruction& instruction) {
+  auto operand = instruction.operands[0];
+
+  Value* Lvalue = GetOperandValue(operand, operand.size);
+
+  Value* one = ConstantInt::get(Lvalue->getType(), 1, true);
+  Value* result;
+  Value* of;
+  // The CF flag is not affected. The OF, SF, ZF, AF, and PF flags are set
+  // according to the result.
+  if (instruction.info.mnemonic == ZYDIS_MNEMONIC_INC) {
+    // treat it as add r, 1 for flags
+    result =
+        createAddFolder(builder, Lvalue, one,
+                        "inc-" + to_string(instruction.runtime_address) + "-");
+    of = computeOverflowFlagAdd(builder, Lvalue, one, result);
+
+  } else {
+    // treat it as sub r, 1 for flags
+    result =
+        createSubFolder(builder, Lvalue, one,
+                        "dec-" + to_string(instruction.runtime_address) + "-");
+    of = computeOverflowFlagSub(builder, Lvalue, one, result);
+  }
+
+  printvalue(Lvalue) printvalue(result)
+
+      Value* sf = computeSignFlag(builder, result);
+  Value* zf = computeZeroFlag(builder, result);
+  Value* pf = computeParityFlag(builder, result);
+
+  printvalue(sf)
+
+      setFlag(FLAG_OF, of);
+  setFlag(FLAG_SF, sf);
+  setFlag(FLAG_ZF, zf);
+  setFlag(FLAG_PF, pf);
+  SetOperandValue(operand, result);
+}
+
+void lifterClass::lift_push(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto src = instruction.operands[0]; // value that we are pushing
+  auto dest = instruction.operands[2];
+  auto rsp = instruction.operands[1];
+
+  auto Rvalue = GetOperandValue(src, dest.size);
+  auto RspValue = GetOperandValue(rsp, rsp.size); // ?
+  auto val = ConstantInt::getSigned(
+      Type::getInt64Ty(context),
+      dest.size / 8); // jokes on me apparently this is not a fixed value
+  auto result = createSubFolder(
+      builder, RspValue, val,
+      "pushing_newrsp-" + to_string(instruction.runtime_address) + "-");
+
+  printvalue(RspValue) printvalue(result)
+      SetOperandValue(rsp, result, to_string(instruction.runtime_address));
+  ; // sub rsp 8 first,
+
+  SetOperandValue(dest, Rvalue, to_string(instruction.runtime_address));
+  ; // then mov rsp, val
+}
+
+void lifterClass::lift_pushfq(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto src = instruction.operands[2];  // value that we are pushing rflags
+  auto dest = instruction.operands[1]; // [rsp]
+  auto rsp = instruction.operands[0];  // rsp
+
+  auto Rvalue = GetOperandValue(src, dest.size);
+  // auto Rvalue = GetRFLAGS(builder);
+  auto RspValue = GetOperandValue(rsp, rsp.size);
+
+  auto val = ConstantInt::get(Type::getInt64Ty(context), 8);
+  auto result = createSubFolder(builder, RspValue, val);
+
+  SetOperandValue(rsp, result, to_string(instruction.runtime_address));
+  ; // sub rsp 8 first,
+
+  // pushFlags( dest, Rvalue,
+  // to_string(instruction.runtime_address));;
+  SetOperandValue(dest, Rvalue, to_string(instruction.runtime_address));
+  ; // then mov rsp, val
+}
+
+void lifterClass::lift_pop(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0]; // value that we are pushing
+  auto src = instruction.operands[2];
+  auto rsp = instruction.operands[1];
+
+  auto Rvalue =
+      GetOperandValue(src, dest.size, to_string(instruction.runtime_address));
+  ;
+  auto RspValue =
+      GetOperandValue(rsp, rsp.size, to_string(instruction.runtime_address));
+  ;
+
+  auto val = ConstantInt::getSigned(Type::getInt64Ty(context),
+                                    dest.size / 8); // assuming its x64
+  auto result = createAddFolder(
+      builder, RspValue, val,
+      "popping_new_rsp-" + to_string(instruction.runtime_address) + "-");
+
+  printvalue(Rvalue) printvalue(RspValue) printvalue(result)
+
+      SetOperandValue(rsp, result); // then add rsp 8
+
+  SetOperandValue(dest, Rvalue, to_string(instruction.runtime_address));
+  ; // mov val, rsp first
+}
+
+void lifterClass::lift_popfq(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[2]; // value that we are pushing
+  auto src = instruction.operands[1];  // [rsp]
+  auto rsp = instruction.operands[0];  // rsp
+
+  auto Rvalue =
+      GetOperandValue(src, dest.size, to_string(instruction.runtime_address));
+  ;
+  auto RspValue =
+      GetOperandValue(rsp, rsp.size, to_string(instruction.runtime_address));
+  ;
+
+  auto val = ConstantInt::getSigned(Type::getInt64Ty(context),
+                                    8); // assuming its x64
+  auto result =
+      createAddFolder(builder, RspValue, val,
+                      "popfq-" + to_string(instruction.runtime_address) + "-");
+
+  SetOperandValue(dest, Rvalue, to_string(instruction.runtime_address));
+  ; // mov val, rsp first
+  SetOperandValue(rsp, result, to_string(instruction.runtime_address));
+  ; // then add rsp 8
+}
+
+void lifterClass::lift_adc(ZydisDisassembledInstruction& instruction) {
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* Lvalue = GetOperandValue(dest, dest.size);
+  Value* Rvalue = GetOperandValue(src, dest.size);
+
+  Value* cf = getFlag(FLAG_CF);
+  cf = createZExtFolder(builder, cf, Lvalue->getType());
+
+  Value* tempResult = createAddFolder(
+      builder, Lvalue, Rvalue,
+      "adc-temp-" + to_string(instruction.runtime_address) + "-");
+  Value* result = createAddFolder(
+      builder, tempResult, cf,
+      "adc-result-" + to_string(instruction.runtime_address) + "-");
+  // The OF, SF, ZF, AF, CF, and PF flags are set according to the result.
+
+  printvalue(Lvalue) printvalue(Rvalue) printvalue(tempResult)
+      printvalue(result)
+
+          auto cfAfterFirstAdd = createOrFolder(
+              builder,
+              createICMPFolder(builder, CmpInst::ICMP_ULT, tempResult, Lvalue),
+              createICMPFolder(builder, CmpInst::ICMP_ULT, tempResult, Rvalue));
+  auto cfFinal =
+      createOrFolder(builder, cfAfterFirstAdd,
+                     createICMPFolder(builder, CmpInst::ICMP_ULT, result, cf));
+
+  auto lowerNibbleMask = ConstantInt::get(Lvalue->getType(), 0xF);
+  auto destLowerNibble =
+      createAndFolder(builder, Lvalue, lowerNibbleMask, "adcdst");
+  auto srcLowerNibble =
+      createAndFolder(builder, Rvalue, lowerNibbleMask, "adcsrc");
+  auto sumLowerNibble =
+      createAddFolder(builder, destLowerNibble, srcLowerNibble);
+  auto af = createICMPFolder(builder, CmpInst::ICMP_UGT, sumLowerNibble,
+                             lowerNibbleMask);
+
+  auto of = computeOverflowFlagAdc(builder, Lvalue, Rvalue, cf, result);
+
+  Value* sf = computeSignFlag(builder, result);
+  Value* zf = computeZeroFlag(builder, result);
+  Value* pf = computeParityFlag(builder, result);
+
+  setFlag(FLAG_OF, of);
+  setFlag(FLAG_AF, af);
+  setFlag(FLAG_CF, cfFinal);
+  setFlag(FLAG_SF, sf);
+  setFlag(FLAG_ZF, zf);
+  setFlag(FLAG_PF, pf);
+
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_xadd(ZydisDisassembledInstruction& instruction) {
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  auto Lvalue = GetOperandValue(dest, dest.size);
+  auto Rvalue = GetOperandValue(src, src.size);
+
+  Value* sumValue = createAddFolder(
+      builder, Lvalue, Rvalue,
+      "xadd_sum-" + to_string(instruction.runtime_address) + "-");
+
+  SetOperandValue(dest, sumValue, to_string(instruction.runtime_address));
+  ;
+
+  SetOperandValue(src, Lvalue, to_string(instruction.runtime_address));
+  ;
+  /*
+  TEMP := SRC + DEST;
+  SRC := DEST;
+  DEST := TEMP;
+  */
+  printvalue(Lvalue) printvalue(Rvalue) printvalue(sumValue)
+
+      auto cf = createOrFolder(
+          builder,
+          createICMPFolder(builder, CmpInst::ICMP_ULT, sumValue, Lvalue),
+          createICMPFolder(builder, CmpInst::ICMP_ULT, sumValue, Rvalue));
+
+  auto lowerNibbleMask = ConstantInt::get(Lvalue->getType(), 0xF);
+  auto destLowerNibble =
+      createAndFolder(builder, Lvalue, lowerNibbleMask, "xadddst");
+  auto srcLowerNibble =
+      createAndFolder(builder, Rvalue, lowerNibbleMask, "xaddsrc");
+  auto sumLowerNibble =
+      createAddFolder(builder, destLowerNibble, srcLowerNibble);
+  auto af = createICMPFolder(builder, CmpInst::ICMP_UGT, sumLowerNibble,
+                             lowerNibbleMask);
+
+  auto resultSign = createICMPFolder(builder, CmpInst::ICMP_SLT, sumValue,
+                                     ConstantInt::get(Lvalue->getType(), 0));
+  auto destSign = createICMPFolder(builder, CmpInst::ICMP_SLT, Lvalue,
+                                   ConstantInt::get(Lvalue->getType(), 0));
+  auto srcSign = createICMPFolder(builder, CmpInst::ICMP_SLT, Rvalue,
+                                  ConstantInt::get(Rvalue->getType(), 0));
+  auto inputSameSign =
+      createICMPFolder(builder, CmpInst::ICMP_EQ, destSign, srcSign);
+  auto of = createAndFolder(
+      builder, inputSameSign,
+      createICMPFolder(builder, CmpInst::ICMP_NE, destSign, resultSign),
+      "xaddof");
+
+  Value* sf = computeSignFlag(builder, sumValue);
+  Value* zf = computeZeroFlag(builder, sumValue);
+  Value* pf = computeParityFlag(builder, sumValue);
+
+  setFlag(FLAG_OF, of);
+  setFlag(FLAG_AF, af);
+  setFlag(FLAG_CF, cf);
+  setFlag(FLAG_SF, sf);
+  setFlag(FLAG_ZF, zf);
+  setFlag(FLAG_PF, pf);
+
+  // The CF, PF, AF, SF, ZF, and OF flags are set according to the result
+  // of the addition, which is stored in the destination operand.
+}
+
+void lifterClass::lift_test(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  Value* Lvalue =
+      GetOperandValue(instruction.operands[0], instruction.operands[0].size);
+  Value* Rvalue =
+      GetOperandValue(instruction.operands[1], instruction.operands[0].size);
+
+  Value* testResult = createAndFolder(builder, Lvalue, Rvalue, "testAnd");
+
+  Value* of = ConstantInt::get(Type::getInt64Ty(context), 0, "of");
+  Value* cf = ConstantInt::get(Type::getInt64Ty(context), 0, "cf");
+
+  Value* sf =
+      createICMPFolder(builder, CmpInst::ICMP_SLT, testResult,
+                       ConstantInt::get(testResult->getType(), 0), "sf");
+  Value* zf =
+      createICMPFolder(builder, CmpInst::ICMP_EQ, testResult,
+                       ConstantInt::get(testResult->getType(), 0), "zf");
+  Value* pf = computeParityFlag(builder, testResult);
+
+  setFlag(FLAG_OF, of);
+  setFlag(FLAG_CF, cf);
+  setFlag(FLAG_SF, sf);
+  setFlag(FLAG_ZF, zf);
+  setFlag(FLAG_PF, pf);
+}
+
+void lifterClass::lift_cmp(ZydisDisassembledInstruction& instruction) {
+
+  Value* Lvalue =
+      GetOperandValue(instruction.operands[0], instruction.operands[0].size);
+  Value* Rvalue =
+      GetOperandValue(instruction.operands[1], instruction.operands[0].size);
+
+  Value* cmpResult = createSubFolder(builder, Lvalue, Rvalue);
+
+  Value* signL = createICMPFolder(builder, CmpInst::ICMP_SLT, Lvalue,
+                                  ConstantInt::get(Lvalue->getType(), 0));
+  Value* signR = createICMPFolder(builder, CmpInst::ICMP_SLT, Rvalue,
+                                  ConstantInt::get(Rvalue->getType(), 0));
+  Value* signResult =
+      createICMPFolder(builder, CmpInst::ICMP_SLT, cmpResult,
+                       ConstantInt::get(cmpResult->getType(), 0));
+
+  Value* of = createOrFolder(
+      builder,
+      createAndFolder(builder, signL,
+                      createAndFolder(builder, builder.CreateNot(signR),
+                                      builder.CreateNot(signResult),
+                                      "cmp-and1-")),
+      createAndFolder(builder, builder.CreateNot(signL),
+                      createAndFolder(builder, signR, signResult), "cmp-and2-"),
+      "cmp-OF-or");
+
+  Value* cf = createICMPFolder(builder, CmpInst::ICMP_ULT, Lvalue, Rvalue);
+  Value* zf = createICMPFolder(builder, CmpInst::ICMP_EQ, cmpResult,
+                               ConstantInt::get(cmpResult->getType(), 0));
+  Value* sf = createICMPFolder(builder, CmpInst::ICMP_SLT, cmpResult,
+                               ConstantInt::get(cmpResult->getType(), 0));
+  Value* pf = computeParityFlag(builder, cmpResult);
+
+  setFlag(FLAG_OF, of);
+  setFlag(FLAG_CF, cf);
+  setFlag(FLAG_SF, sf);
+  setFlag(FLAG_ZF, zf);
+  setFlag(FLAG_PF, pf);
+}
+
+void lifterClass::lift_rdtsc() {
+  // cout << instruction.runtime_address << "\n";
+  LLVMContext& context = builder.getContext();
+  auto rdtscCall = builder.CreateIntrinsic(Intrinsic::readcyclecounter, {}, {});
+  auto edxPart = createLShrFolder(builder, rdtscCall, 32, "to_edx");
+  auto eaxPart = createZExtOrTruncFolder(builder, rdtscCall,
+                                         Type::getInt32Ty(context), "to_eax");
+  SetRegisterValue(ZYDIS_REGISTER_EDX, edxPart);
+  SetRegisterValue(ZYDIS_REGISTER_EAX, eaxPart);
+}
+
+void lifterClass::lift_cpuid(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  // instruction.operands[0] = eax
+  // instruction.operands[1] = ebx
+  // instruction.operands[2] = ecx
+  // instruction.operands[3] = edx
+  /*
+
+  c++
+  #include <intrin.h>
+
+  int getcpuid() {
+          int cpuInfo[4];
+          __cpuid(cpuInfo, 1);
+          return cpuInfo[0] + cpuInfo[1];
+  }
+
+  ir
+  define dso_local noundef i32 @getcpuid() #0 {
+    %1 = alloca [4 x i32], align 16
+    %2 = getelementptr inbounds [4 x i32], ptr %1, i64 0, i64 0
+    %3 = call { i32, i32, i32, i32 } asm "xchgq %rbx,
+  ${1:q}\0Acpuid\0Axchgq %rbx, ${1:q}", "={ax},=r,={cx},={dx},0,2"(i32 1,
+  i32 0) %4 = getelementptr inbounds [4 x i32], ptr %1, i64 0, i64 0 %5 =
+  extractvalue { i32, i32, i32, i32 } %3, 0 %6 = getelementptr inbounds
+  i32, ptr %4, i32 0 store i32 %5, ptr %6, align 4 %7 = extractvalue {
+  i32, i32, i32, i32 } %3, 1 %8 = getelementptr inbounds i32, ptr %4, i32
+  1 store i32 %7, ptr %8, align 4 %9 = extractvalue { i32, i32, i32, i32 }
+  %3, 2 %10 = getelementptr inbounds i32, ptr %4, i32 2 store i32 %9, ptr
+  %10, align 4 %11 = extractvalue { i32, i32, i32, i32 } %3, 3 %12 =
+  getelementptr inbounds i32, ptr %4, i32 3 store i32 %11, ptr %12, align
+  4
+
+    %13 = getelementptr inbounds [4 x i32], ptr %1, i64 0, i64 0
+    %14 = load i32, ptr %13, align 16
+
+    %15 = getelementptr inbounds [4 x i32], ptr %1, i64 0, i64 1
+    %16 = load i32, ptr %15, align 4
+    %17 = add nsw i32 %14, %16
+    ret i32 %17
+  }
+  opt
+  define dso_local noundef i32 @getcpuid() local_unnamed_addr {
+    %1 = tail call { i32, i32, i32, i32 } asm "xchgq %rbx,
+  ${1:q}\0Acpuid\0Axchgq %rbx, ${1:q}", "={ax},=r,={cx},={dx},0,2"(i32 1,
+  i32 0) #0 %2 = extractvalue { i32, i32, i32, i32 } %1, 1 ret i32 %2
+  }
+
+  */
+  // int cpuInfo[4];
+  // ArrayType* CpuInfoTy = ArrayType::get(Type::getInt32Ty(context), 4);
+
+  Value* eax =
+      GetOperandValue(instruction.operands[0], instruction.operands[0].size);
+  // one is eax, other is always 0?
+  std::vector<Type*> AsmOutputs = {
+      Type::getInt32Ty(context), Type::getInt32Ty(context),
+      Type::getInt32Ty(context), Type::getInt32Ty(context)};
+  StructType* AsmStructType = StructType::get(context, AsmOutputs);
+
+  std::vector<Type*> ArgTypes = {Type::getInt32Ty(context),
+                                 Type::getInt32Ty(context)};
+
+  // this is probably incorrect
+  InlineAsm* IA =
+      InlineAsm::get(FunctionType::get(AsmStructType, ArgTypes, false),
+                     "xchgq %rbx, ${1:q}\ncpuid\nxchgq %rbx, ${1:q}",
+                     "={ax},=r,={cx},={dx},0,2", true);
+
+  std::vector<Value*> Args{eax, ConstantInt::get(eax->getType(), 0)};
+
+  Value* cpuidCall = builder.CreateCall(IA, Args);
+
+  Value* eaxv = builder.CreateExtractValue(cpuidCall, 0, "eax");
+  Value* ebx = builder.CreateExtractValue(cpuidCall, 1, "ebx");
+  Value* ecx = builder.CreateExtractValue(cpuidCall, 2, "ecx");
+  Value* edx = builder.CreateExtractValue(cpuidCall, 3, "edx");
+
+  SetOperandValue(instruction.operands[0], eaxv);
+  SetOperandValue(instruction.operands[1], ebx);
+  SetOperandValue(instruction.operands[2], ecx);
+  SetOperandValue(instruction.operands[3], edx);
+}
+
+void lifterClass::lift_setnz(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+
+  auto dest = instruction.operands[0];
+
+  Value* zf = getFlag(FLAG_ZF);
+
+  Value* result = createZExtFolder(builder, builder.CreateNot(zf),
+                                   Type::getInt8Ty(context));
+
+  SetOperandValue(dest, result);
+}
+void lifterClass::lift_seto(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+
+  auto dest = instruction.operands[0];
+
+  Value* of = getFlag(FLAG_OF);
+
+  Value* result = createZExtFolder(builder, of, Type::getInt8Ty(context));
+
+  SetOperandValue(dest, result);
+}
+void lifterClass::lift_setno(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+
+  auto dest = instruction.operands[0];
+
+  Value* of = getFlag(FLAG_OF);
+
+  Value* notOf = builder.CreateNot(of, "notOF");
+
+  Value* result = createZExtFolder(builder, notOf, Type::getInt8Ty(context));
+
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_setnb(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+
+  auto dest = instruction.operands[0];
+
+  Value* cf = getFlag(FLAG_CF);
+
+  Value* result =
+      createICMPFolder(builder, CmpInst::ICMP_EQ, cf,
+                       ConstantInt::get(Type::getInt1Ty(context), 0));
+
+  Value* byteResult =
+      createZExtFolder(builder, result, Type::getInt8Ty(context));
+
+  SetOperandValue(dest, byteResult);
+}
+
+void lifterClass::lift_setbe(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+
+  Value* cf = getFlag(FLAG_CF);
+  Value* zf = getFlag(FLAG_ZF);
+
+  Value* condition = createOrFolder(builder, cf, zf, "setbe-or");
+
+  Value* result =
+      createZExtFolder(builder, condition, Type::getInt8Ty(context));
+
+  auto dest = instruction.operands[0];
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_setnbe(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+
+  Value* cf = getFlag(FLAG_CF);
+  Value* zf = getFlag(FLAG_ZF);
+
+  Value* condition = createAndFolder(builder, builder.CreateNot(cf),
+                                     builder.CreateNot(zf), "setnbe-and");
+
+  Value* result =
+      createZExtFolder(builder, condition, Type::getInt8Ty(context));
+
+  auto dest = instruction.operands[0];
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_setns(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+
+  auto dest = instruction.operands[0];
+
+  Value* sf = getFlag(FLAG_SF);
+
+  Value* result =
+      createICMPFolder(builder, CmpInst::ICMP_EQ, sf,
+                       ConstantInt::get(Type::getInt1Ty(context), 0));
+
+  Value* byteResult =
+      createZExtFolder(builder, result, Type::getInt8Ty(context));
+
+  SetOperandValue(dest, byteResult);
+}
+
+void lifterClass::lift_setp(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+
+  Value* pf = getFlag(FLAG_PF);
+
+  Value* result = createZExtFolder(builder, pf, Type::getInt8Ty(context));
+
+  auto dest = instruction.operands[0];
+
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_setnp(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
+
+  Value* pf = getFlag(FLAG_PF);
+
+  Value* resultValue = createZExtFolder(builder, builder.CreateNot(pf),
+                                        Type::getInt8Ty(context));
+
+  SetOperandValue(dest, resultValue, to_string(instruction.runtime_address));
+}
+
+void lifterClass::lift_setb(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+
+  auto dest = instruction.operands[0];
+
+  Value* cf = getFlag(FLAG_CF);
+
+  Value* result = createZExtFolder(builder, cf, Type::getInt8Ty(context));
+
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_sets(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  Value* sf = getFlag(FLAG_SF);
+
+  Value* result = createZExtFolder(builder, sf, Type::getInt8Ty(context));
+
+  auto dest = instruction.operands[0];
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_stosx(ZydisDisassembledInstruction& instruction) {
+
+  auto dest = instruction.operands[0]; // xdi
+  Value* destValue = GetOperandValue(dest, dest.size);
+  Value* DF = getFlag(FLAG_DF);
+  // if df is 1, +
+  // else -
+  auto destbitwidth = dest.size;
+
+  auto one = ConstantInt::get(DF->getType(), 1);
+  Value* Direction =
+      builder.CreateSub(builder.CreateMul(DF, builder.CreateAdd(DF, one)), one);
+
+  Value* result = createAddFolder(
+      builder, destValue,
+      builder.CreateMul(Direction,
+                        ConstantInt::get(DF->getType(), destbitwidth)));
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_setz(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
+
+  Value* zf = getFlag(FLAG_ZF);
+
+  Value* extendedZF =
+      createZExtFolder(builder, zf, Type::getInt8Ty(context), "setz_extend");
+
+  SetOperandValue(dest, extendedZF);
+}
+
+void lifterClass::lift_setnle(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
+
+  Value* zf = getFlag(FLAG_ZF);
+  Value* sf = getFlag(FLAG_SF);
+  Value* of = getFlag(FLAG_OF);
+
+  Value* zfNotSet =
+      createICMPFolder(builder, CmpInst::ICMP_EQ, zf,
+                       ConstantInt::get(Type::getInt1Ty(context), 0));
+
+  Value* sfEqualsOf = createICMPFolder(builder, CmpInst::ICMP_EQ, sf, of);
+
+  printvalue(zf) printvalue(sf) printvalue(of)
+
+      Value* combinedCondition =
+          createAndFolder(builder, zfNotSet, sfEqualsOf, "setnle-and");
+
+  Value* byteResult =
+      createZExtFolder(builder, combinedCondition, Type::getInt8Ty(context));
+
+  SetOperandValue(dest, byteResult);
+}
+
+void lifterClass::lift_setle(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  Value* zf = getFlag(FLAG_ZF);
+  Value* sf = getFlag(FLAG_SF);
+  Value* of = getFlag(FLAG_OF);
+
+  Value* sf_ne_of = createICMPFolder(builder, CmpInst::ICMP_NE, sf, of);
+  Value* condition = createOrFolder(builder, zf, sf_ne_of, "setle-or");
+
+  Value* result =
+      createZExtFolder(builder, condition, Type::getInt8Ty(context));
+
+  auto dest = instruction.operands[0];
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_setnl(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  Value* sf = getFlag(FLAG_SF);
+  Value* of = getFlag(FLAG_OF);
+
+  Value* condition = createICMPFolder(builder, CmpInst::ICMP_EQ, sf, of);
+
+  Value* result =
+      createZExtFolder(builder, condition, Type::getInt8Ty(context));
+
+  auto dest = instruction.operands[0];
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_setl(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  Value* sf = getFlag(FLAG_SF);
+  Value* of = getFlag(FLAG_OF);
+
+  Value* condition = createICMPFolder(builder, CmpInst::ICMP_NE, sf, of);
+
+  Value* result =
+      createZExtFolder(builder, condition, Type::getInt8Ty(context));
+
+  auto dest = instruction.operands[0];
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_bt(ZydisDisassembledInstruction& instruction) {
+
+  auto dest = instruction.operands[0];
+  auto bitIndex = instruction.operands[1];
+
+  // If the bit base operand specifies a register, the instruction takes
+  // the modulo 16, 32, or 64 of the bit offset operand (modulo size
+  // depends on the mode and register size; 64-bit operands are available
+  // only in 64-bit mode). If the bit base operand specifies a memory
+  // location, the operand represents the address of the byte in memory
+  // that contains the bit base (bit 0 of the specified byte) of the bit
+  // string. The range of the bit position that can be referenced by the
+  // offset operand depends on the operand size. CF := Bit(BitBase,
+  // BitOffset);
+
+  auto Lvalue = GetOperandValue(dest, dest.size);
+  auto bitIndexValue = GetOperandValue(bitIndex, dest.size);
+
+  unsigned LvalueBitW = cast<IntegerType>(Lvalue->getType())->getBitWidth();
+
+  auto Rvalue = createAndFolder(
+      builder, bitIndexValue,
+      ConstantInt::get(bitIndexValue->getType(), LvalueBitW - 1));
+
+  auto shl = createShlFolder(
+      builder, ConstantInt::get(bitIndexValue->getType(), 1), Rvalue);
+
+  auto andd = createAndFolder(builder, shl, Lvalue);
+
+  auto cf = createICMPFolder(builder, CmpInst::ICMP_NE, andd,
+                             ConstantInt::get(andd->getType(), 0));
+
+  setFlag(FLAG_CF, cf);
+  printvalue(Rvalue);
+  printvalue(Lvalue);
+  printvalue(shl);
+  printvalue(andd);
+  printvalue(cf);
+}
+
+void lifterClass::lift_btr(ZydisDisassembledInstruction& instruction) {
+  auto base = instruction.operands[0];
+  auto offset = instruction.operands[1];
+
+  unsigned baseBitWidth = base.size;
+
+  Value* bitOffset = GetOperandValue(offset, base.size);
+
+  Value* bitOffsetMasked =
+      createAndFolder(builder, bitOffset,
+                      ConstantInt::get(bitOffset->getType(), baseBitWidth - 1),
+                      "bitOffsetMasked");
+
+  Value* baseVal = GetOperandValue(base, base.size);
+
+  Value* bit = createLShrFolder(
+      builder, baseVal, bitOffsetMasked,
+      "btr-lshr-" + to_string(instruction.runtime_address) + "-");
+
+  Value* one = ConstantInt::get(bit->getType(), 1);
+
+  bit = createAndFolder(builder, bit, one, "btr-and");
+
+  setFlag(FLAG_CF, bit);
+
+  Value* mask =
+      createShlFolder(builder, ConstantInt::get(baseVal->getType(), 1),
+                      bitOffsetMasked, "btr-shl");
+
+  mask = builder.CreateNot(mask); // invert mask
+  baseVal = createAndFolder(builder, baseVal, mask,
+                            "btr-and-" +
+                                to_string(instruction.runtime_address) + "-");
+
+  SetOperandValue(base, baseVal);
+  printvalue(bitOffset);
+  printvalue(baseVal);
+  printvalue(mask);
+}
+
+void lifterClass::lift_bsr(ZydisDisassembledInstruction& instruction) {
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* Rvalue = GetOperandValue(src, src.size);
+  Value* isZero = createICMPFolder(builder, CmpInst::ICMP_EQ, Rvalue,
+                                   ConstantInt::get(Rvalue->getType(), 0));
+  setFlag(FLAG_ZF, isZero);
+
+  unsigned bitWidth = Rvalue->getType()->getIntegerBitWidth();
+
+  Value* index = ConstantInt::get(Rvalue->getType(), bitWidth - 1);
+  Value* zeroVal = ConstantInt::get(Rvalue->getType(), 0);
+  Value* oneVal = ConstantInt::get(Rvalue->getType(), 1);
+
+  Value* bitPosition = ConstantInt::get(Rvalue->getType(), -1);
+
+  for (unsigned i = 0; i < bitWidth; ++i) {
+
+    Value* mask = createShlFolder(builder, oneVal, index);
+
+    Value* test = createAndFolder(builder, Rvalue, mask, "bsrtest");
+    Value* isBitSet =
+        createICMPFolder(builder, CmpInst::ICMP_NE, test, zeroVal);
+
+    Value* tmpPosition =
+        createSelectFolder(builder, isBitSet, index, bitPosition);
+
+    Value* isPositionUnset =
+        createICMPFolder(builder, CmpInst::ICMP_EQ, bitPosition,
+                         ConstantInt::get(Rvalue->getType(), -1));
+    bitPosition =
+        createSelectFolder(builder, isPositionUnset, tmpPosition, bitPosition);
+
+    index = createSubFolder(builder, index, oneVal);
+  }
+
+  SetOperandValue(dest, bitPosition);
+}
+
+void lifterClass::lift_bsf(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  auto dest = instruction.operands[0];
+  auto src = instruction.operands[1];
+
+  Value* Rvalue = GetOperandValue(src, src.size);
+
+  Value* isZero = createICMPFolder(builder, CmpInst::ICMP_EQ, Rvalue,
+                                   ConstantInt::get(Rvalue->getType(), 0));
+  setFlag(FLAG_ZF, isZero);
+
+  Type* intType = Rvalue->getType();
+  uint64_t intWidth = intType->getIntegerBitWidth();
+
+  Value* result = ConstantInt::get(intType, intWidth);
+  Value* one = ConstantInt::get(intType, 1);
+
+  Value* continuecounting = ConstantInt::get(Type::getInt1Ty(context), 1);
+  for (uint64_t i = 0; i < intWidth; ++i) {
+    Value* bitMask =
+        createShlFolder(builder, one, ConstantInt::get(intType, i));
+    Value* bitSet = createAndFolder(builder, Rvalue, bitMask, "bsfbitset");
+    Value* isBitZero = createICMPFolder(builder, CmpInst::ICMP_EQ, bitSet,
+                                        ConstantInt::get(intType, 0));
+    // continue until isBitZero is 1
+    // 0010
+    // if continuecounting, select
+    Value* possibleResult = ConstantInt::get(intType, i);
+    Value* condition =
+        createAndFolder(builder, continuecounting, isBitZero, "bsfcondition");
+    continuecounting = builder.CreateNot(isBitZero);
+    result = createSelectFolder(builder, condition, result, possibleResult,
+                                "updateResultOnFirstNonZeroBit");
+  }
+
+  SetOperandValue(dest, result);
+}
+
+void lifterClass::lift_btc(ZydisDisassembledInstruction& instruction) {
+  auto base = instruction.operands[0];
+  auto offset = instruction.operands[1];
+
+  unsigned baseBitWidth = base.size;
+
+  Value* bitOffset = GetOperandValue(offset, base.size);
+
+  Value* bitOffsetMasked =
+      createAndFolder(builder, bitOffset,
+                      ConstantInt::get(bitOffset->getType(), baseBitWidth - 1),
+                      "bitOffsetMasked");
+
+  Value* baseVal = GetOperandValue(base, base.size);
+
+  Value* bit = createLShrFolder(
+      builder, baseVal, bitOffsetMasked,
+      "btc-lshr-" + to_string(instruction.runtime_address) + "-");
+
+  Value* one = ConstantInt::get(bit->getType(), 1);
+
+  bit = createAndFolder(builder, bit, one, "btc-and");
+
+  setFlag(FLAG_CF, bit);
+
+  Value* mask =
+      createShlFolder(builder, ConstantInt::get(baseVal->getType(), 1),
+                      bitOffsetMasked, "btc-shl");
+
+  baseVal = createXorFolder(builder, baseVal, mask,
+                            "btc-and-" +
+                                to_string(instruction.runtime_address) + "-");
+
+  SetOperandValue(base, baseVal);
+  printvalue(bitOffset);
+  printvalue(baseVal);
+  printvalue(mask);
+}
+
+void lifterClass::lift_lahf() {
+
+  LLVMContext& context = builder.getContext();
+
+  auto sf = getFlag(FLAG_SF);
+  auto zf = getFlag(FLAG_ZF);
+  auto af = getFlag(FLAG_AF);
+  auto pf = getFlag(FLAG_PF);
+  auto cf = getFlag(FLAG_CF);
+
+  printvalue(sf) printvalue(zf) printvalue(af) printvalue(pf) printvalue(cf);
+
+  cf = createZExtFolder(builder, cf, Type::getInt8Ty(context));
+  pf = createShlFolder(builder,
+                       createZExtFolder(builder, pf, Type::getInt8Ty(context)),
+                       FLAG_PF);
+  af = createShlFolder(builder,
+                       createZExtFolder(builder, af, Type::getInt8Ty(context)),
+                       FLAG_AF);
+  zf = createShlFolder(builder,
+                       createZExtFolder(builder, zf, Type::getInt8Ty(context)),
+                       FLAG_ZF);
+  sf = createShlFolder(builder,
+                       createZExtFolder(builder, sf, Type::getInt8Ty(context)),
+                       FLAG_SF);
+  Value* Rvalue =
+      createOrFolder(builder,
+                     createOrFolder(builder, createOrFolder(builder, cf, pf),
+                                    createOrFolder(builder, af, sf)),
+                     sf);
+
+  printvalue(sf) printvalue(zf) printvalue(af) printvalue(pf) printvalue(cf);
+
+  SetRegisterValue(ZYDIS_REGISTER_AH, Rvalue);
+}
+
+void lifterClass::lift_stc() {
+  LLVMContext& context = builder.getContext();
+
+  setFlag(FLAG_CF, ConstantInt::get(Type::getInt1Ty(context), 1));
+}
+
+void lifterClass::lift_cmc() {
+
+  Value* cf = getFlag(FLAG_CF);
+
+  Value* one = ConstantInt::get(cf->getType(), 1);
+
+  setFlag(FLAG_CF, createXorFolder(builder, cf, one));
+}
+
+void lifterClass::lift_clc() {
+
+  LLVMContext& context = builder.getContext();
+
+  Value* clearedCF = ConstantInt::get(Type::getInt1Ty(context), 0);
+
+  setFlag(FLAG_CF, clearedCF);
+}
+
+void lifterClass::lift_cld() {
+
+  LLVMContext& context = builder.getContext();
+
+  Value* clearedDF = ConstantInt::get(Type::getInt1Ty(context), 0);
+
+  setFlag(FLAG_DF, clearedDF);
+}
+
+void lifterClass::lift_cli() {
+
+  LLVMContext& context = builder.getContext();
+
+  Value* resetIF = ConstantInt::get(Type::getInt1Ty(context), 0);
+
+  setFlag(FLAG_IF, resetIF);
+}
+
+void lifterClass::lift_bts(ZydisDisassembledInstruction& instruction) {
+  auto base = instruction.operands[0];
+  auto offset = instruction.operands[1];
+
+  unsigned baseBitWidth = base.size;
+
+  Value* bitOffset = GetOperandValue(offset, base.size);
+
+  Value* bitOffsetMasked =
+      createAndFolder(builder, bitOffset,
+                      ConstantInt::get(bitOffset->getType(), baseBitWidth - 1),
+                      "bitOffsetMasked");
+
+  Value* baseVal = GetOperandValue(base, base.size);
+
+  Value* bit = createLShrFolder(
+      builder, baseVal, bitOffsetMasked,
+      "bts-lshr-" + to_string(instruction.runtime_address) + "-");
+
+  Value* one = ConstantInt::get(bit->getType(), 1);
+
+  bit = createAndFolder(builder, bit, one, "bts-and");
+
+  setFlag(FLAG_CF, bit);
+
+  Value* mask =
+      createShlFolder(builder, ConstantInt::get(baseVal->getType(), 1),
+                      bitOffsetMasked, "bts-shl");
+
+  baseVal =
+      createOrFolder(builder, baseVal, mask,
+                     "bts-or-" + to_string(instruction.runtime_address) + "-");
+
+  SetOperandValue(base, baseVal);
+  printvalue(bitOffset);
+  printvalue(baseVal);
+  printvalue(mask);
+}
+
+void lifterClass::lift_cwd(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+
+  Value* ax = createZExtOrTruncFolder(
+      builder,
+      GetOperandValue(instruction.operands[1], instruction.operands[1].size),
+      Type::getInt16Ty(context));
+
+  Value* signBit = computeSignFlag(builder, ax);
+
+  Value* dx = createSelectFolder(
+      builder,
+      createICMPFolder(builder, CmpInst::ICMP_EQ, signBit,
+                       ConstantInt::get(signBit->getType(), 0)),
+      ConstantInt::get(Type::getInt16Ty(context), 0),
+      ConstantInt::get(Type::getInt16Ty(context), 0xFFFF), "setDX");
+
+  SetOperandValue(instruction.operands[0], dx);
+}
+
+void lifterClass::lift_cdq(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  // if eax is -, then edx is filled with ones FFFF_FFFF
+  Value* eax = createZExtOrTruncFolder(
+      builder,
+      GetOperandValue(instruction.operands[1], instruction.operands[1].size),
+      Type::getInt32Ty(context));
+
+  Value* signBit = computeSignFlag(builder, eax);
+
+  Value* edx = createSelectFolder(
+      builder,
+      createICMPFolder(builder, CmpInst::ICMP_EQ, signBit,
+                       ConstantInt::get(signBit->getType(), 0)),
+      ConstantInt::get(Type::getInt32Ty(context), 0),
+      ConstantInt::get(Type::getInt32Ty(context), 0xFFFFFFFF), "setEDX");
+
+  SetOperandValue(instruction.operands[0], edx);
+}
+
+void lifterClass::lift_cqo(ZydisDisassembledInstruction& instruction) {
+
+  LLVMContext& context = builder.getContext();
+  // if rax is -, then rdx is filled with ones FFFF_FFFF_FFFF_FFFF
+  Value* rax = createZExtOrTruncFolder(
+      builder,
+      GetOperandValue(instruction.operands[1], instruction.operands[1].size),
+      Type::getInt64Ty(context));
+
+  Value* signBit = computeSignFlag(builder, rax);
+
+  Value* rdx = createSelectFolder(
+      builder,
+      createICMPFolder(builder, CmpInst::ICMP_EQ, signBit,
+                       ConstantInt::get(signBit->getType(), 0)),
+      ConstantInt::get(Type::getInt64Ty(context), 0),
+      ConstantInt::get(Type::getInt64Ty(context), 0xFFFFFFFFFFFFFFFF),
+      "setRDX");
+  printvalue(rax) printvalue(signBit) printvalue(rdx)
+      SetOperandValue(instruction.operands[0], rdx);
+}
+
+void lifterClass::lift_cbw(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  Value* al = createZExtOrTruncFolder(
+      builder,
+      GetOperandValue(instruction.operands[1], instruction.operands[1].size),
+      Type::getInt8Ty(context));
+
+  Value* ax = createSExtFolder(builder, al, Type::getInt16Ty(context), "cbw");
+
+  SetOperandValue(instruction.operands[0], ax);
+}
+
+void lifterClass::lift_cwde(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+  Value* ax = createZExtOrTruncFolder(
+      builder,
+      GetOperandValue(instruction.operands[1], instruction.operands[1].size),
+      Type::getInt16Ty(context));
+  printvalue(ax);
+  Value* eax = createSExtFolder(builder, ax, Type::getInt32Ty(context), "cwde");
+  printvalue(eax);
+  SetOperandValue(instruction.operands[0], eax);
+}
+
+void lifterClass::lift_cdqe(ZydisDisassembledInstruction& instruction) {
+  LLVMContext& context = builder.getContext();
+
+  Value* eax = createZExtOrTruncFolder(
+      builder,
+      GetOperandValue(instruction.operands[1], instruction.operands[1].size),
+      Type::getInt32Ty(context), "cdqe-trunc");
+
+  Value* rax =
+      createSExtFolder(builder, eax, Type::getInt64Ty(context), "cdqe");
+
+  SetOperandValue(instruction.operands[0], rax);
+}
+
+void lifterClass::liftInstructionSemantics(
+    ZydisDisassembledInstruction& instruction) {
+
+  switch (instruction.info.mnemonic) {
+  // movs
+  case ZYDIS_MNEMONIC_MOVAPS: {
+    lift_movaps(instruction);
+    break;
+  }
+  case ZYDIS_MNEMONIC_MOVUPS:
   case ZYDIS_MNEMONIC_MOVZX:
   case ZYDIS_MNEMONIC_MOVSX:
   case ZYDIS_MNEMONIC_MOVSXD:
   case ZYDIS_MNEMONIC_MOV: {
-    mov::lift_mov(builder, instruction);
+    lift_mov(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_MOVSB: {
-    mov::lift_movsb(builder, instruction);
+    lift_movsb(instruction);
     break;
   }
 
     // cmov
   case ZYDIS_MNEMONIC_CMOVZ: {
-    cmov::lift_cmovz(builder, instruction);
+    lift_cmovz(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CMOVNZ: {
-    cmov::lift_cmovnz(builder, instruction);
+    lift_cmovnz(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CMOVL: {
-    cmov::lift_cmovl(builder, instruction);
+    lift_cmovl(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CMOVB: {
-    cmov::lift_cmovb(builder, instruction);
+    lift_cmovb(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CMOVNB: {
-    cmov::lift_cmovnb(builder, instruction);
+    lift_cmovnb(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CMOVNS: {
-    cmov::lift_cmovns(builder, instruction);
+    lift_cmovns(instruction);
     break;
   }
 
   case ZYDIS_MNEMONIC_CMOVBE: {
-    cmov::lift_cmovbz(builder, instruction);
+    lift_cmovbz(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CMOVNBE: {
-    cmov::lift_cmovnbz(builder, instruction);
+    lift_cmovnbz(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CMOVNL: {
-    cmov::lift_cmovnl(builder, instruction);
+    lift_cmovnl(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CMOVS: {
-    cmov::lift_cmovs(builder, instruction);
+    lift_cmovs(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CMOVNLE: {
-    cmov::lift_cmovnle(builder, instruction);
+    lift_cmovnle(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CMOVLE: {
-    cmov::lift_cmovle(builder, instruction);
+    lift_cmovle(instruction);
     break;
   }
 
   case ZYDIS_MNEMONIC_CMOVO: {
-    cmov::lift_cmovo(builder, instruction);
+    lift_cmovo(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CMOVNO: {
-    cmov::lift_cmovno(builder, instruction);
+    lift_cmovno(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CMOVP: {
-    cmov::lift_cmovp(builder, instruction);
+    lift_cmovp(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CMOVNP: {
-    cmov::lift_cmovnp(builder, instruction);
+    lift_cmovnp(instruction);
     break;
   }
     // branches
 
   case ZYDIS_MNEMONIC_RET: {
-    branches::lift_ret(builder, instruction, blockAddresses, run);
+    lift_ret(instruction);
     break;
   }
 
   case ZYDIS_MNEMONIC_JMP: {
-    branches::lift_jmp(builder, instruction, blockAddresses, run);
+    lift_jmp(instruction);
     break;
   }
 
   case ZYDIS_MNEMONIC_JNZ: {
-    branches::lift_jnz(builder, instruction, blockAddresses);
+    lift_jnz(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_JZ: {
-    branches::lift_jz(builder, instruction, blockAddresses);
+    lift_jz(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_JS: {
-    branches::lift_js(builder, instruction, blockAddresses);
+    lift_js(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_JNS: {
-    branches::lift_jns(builder, instruction, blockAddresses);
+    lift_jns(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_JNBE: {
 
-    branches::lift_jnbe(builder, instruction, blockAddresses);
+    lift_jnbe(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_JNB: {
-    branches::lift_jnb(builder, instruction, blockAddresses);
+    lift_jnb(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_JB: {
-    branches::lift_jb(builder, instruction, blockAddresses);
+    lift_jb(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_JBE: {
 
-    branches::lift_jbe(builder, instruction, blockAddresses);
+    lift_jbe(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_JNLE: {
-    branches::lift_jnle(builder, instruction, blockAddresses);
+    lift_jnle(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_JLE: {
 
-    branches::lift_jle(builder, instruction, blockAddresses);
+    lift_jle(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_JNL: {
 
-    branches::lift_jnl(builder, instruction, blockAddresses);
+    lift_jnl(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_JL: {
 
-    branches::lift_jl(builder, instruction, blockAddresses);
+    lift_jl(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_JO: {
 
-    branches::lift_jo(builder, instruction, blockAddresses);
+    lift_jo(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_JNO: {
 
-    branches::lift_jno(builder, instruction, blockAddresses);
+    lift_jno(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_JP: {
 
-    branches::lift_jp(builder, instruction, blockAddresses);
+    lift_jp(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_JNP: {
 
-    branches::lift_jnp(builder, instruction, blockAddresses);
+    lift_jnp(instruction);
     break;
   }
     // arithmetics and logical operations
 
   case ZYDIS_MNEMONIC_XCHG: {
-    arithmeticsAndLogical::lift_xchg(builder, instruction);
+    lift_xchg(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CMPXCHG: {
-    arithmeticsAndLogical::lift_cmpxchg(builder, instruction);
+    lift_cmpxchg(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_NOT: {
-    arithmeticsAndLogical::lift_not(builder, instruction);
+    lift_not(instruction);
     break;
   }
 
   case ZYDIS_MNEMONIC_BSWAP: {
-    arithmeticsAndLogical::lift_bswap(builder, instruction);
+    lift_bswap(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_NEG: {
-    arithmeticsAndLogical::lift_neg(builder, instruction);
+    lift_neg(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SAR: {
-    arithmeticsAndLogical::lift_sar(builder, instruction);
+    lift_sar(instruction);
     break;
   }
 
   case ZYDIS_MNEMONIC_SHL: {
-    arithmeticsAndLogical::lift_shl(builder, instruction);
+    lift_shl(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SHLD: {
-    arithmeticsAndLogical::lift_shld(builder, instruction);
+    lift_shld(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SHRD: {
-    arithmeticsAndLogical::lift_shrd(builder, instruction);
+    lift_shrd(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SHR: {
-    arithmeticsAndLogical::lift_shr(builder, instruction);
+    lift_shr(instruction);
     break;
   }
 
   case ZYDIS_MNEMONIC_RCR: {
-    arithmeticsAndLogical::lift_rcr(builder, instruction);
+    lift_rcr(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_RCL: {
-    arithmeticsAndLogical::lift_rcl(builder, instruction);
+    lift_rcl(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SBB: {
-    arithmeticsAndLogical::lift_sbb(builder, instruction);
+    lift_sbb(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_ADC: {
-    arithmeticsAndLogical::lift_adc(builder, instruction);
+    lift_adc(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_XADD: {
-    arithmeticsAndLogical::lift_xadd(builder, instruction);
+    lift_xadd(instruction);
     break;
   }
 
   case ZYDIS_MNEMONIC_LEA: {
-    arithmeticsAndLogical::lift_lea(builder, instruction);
+    lift_lea(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_INC:
   case ZYDIS_MNEMONIC_DEC: {
-    arithmeticsAndLogical::lift_inc_dec(builder, instruction);
+    lift_inc_dec(instruction);
     break;
   }
 
   case ZYDIS_MNEMONIC_MUL: {
-    arithmeticsAndLogical::lift_mul(builder, instruction);
+    lift_mul(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_IMUL: {
-    arithmeticsAndLogical::lift_imul(builder, instruction);
+    lift_imul(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_DIV: {
-    arithmeticsAndLogical::lift_div(builder, instruction);
+    lift_div(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_IDIV: {
-    arithmeticsAndLogical::lift_idiv(builder, instruction);
+    lift_idiv(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SUB:
   case ZYDIS_MNEMONIC_ADD: {
-    arithmeticsAndLogical::lift_add_sub(builder, instruction);
+    lift_add_sub(instruction);
 
     break;
   }
 
   case ZYDIS_MNEMONIC_XOR: {
-    arithmeticsAndLogical::lift_xor(builder, instruction);
+    lift_xor(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_OR: {
-    arithmeticsAndLogical::lift_or(builder, instruction);
+    lift_or(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_AND: {
-    arithmeticsAndLogical::lift_and(builder, instruction);
+    lift_and(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_ROR: {
-    arithmeticsAndLogical::lift_ror(builder, instruction);
+    lift_ror(instruction);
 
     break;
   }
   case ZYDIS_MNEMONIC_ROL: {
-    arithmeticsAndLogical::lift_rol(builder, instruction);
+    lift_rol(instruction);
 
     break;
   }
 
   case ZYDIS_MNEMONIC_PUSH: {
-    arithmeticsAndLogical::lift_push(builder, instruction);
+    lift_push(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_PUSHF:
   case ZYDIS_MNEMONIC_PUSHFQ: {
-    arithmeticsAndLogical::lift_pushfq(builder, instruction);
+    lift_pushfq(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_POP: {
-    arithmeticsAndLogical::lift_pop(builder, instruction);
+    lift_pop(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_POPF:
   case ZYDIS_MNEMONIC_POPFQ: {
-    arithmeticsAndLogical::lift_popfq(builder, instruction);
+    lift_popfq(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_TEST: {
-    arithmeticsAndLogical::lift_test(builder, instruction);
+    lift_test(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CMP: {
-    arithmeticsAndLogical::lift_cmp(builder, instruction);
+    lift_cmp(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_RDTSC: {
-    arithmeticsAndLogical::lift_rdtsc(builder);
+    lift_rdtsc();
     break;
   }
   case ZYDIS_MNEMONIC_CPUID: {
-    arithmeticsAndLogical::lift_cpuid(builder, instruction);
+    lift_cpuid(instruction);
     break;
   }
 
   case ZYDIS_MNEMONIC_CALL: {
-    branches::lift_call(builder, instruction, blockAddresses);
+    lift_call(instruction);
     break;
   }
 
@@ -4362,145 +4179,145 @@ void liftInstructionSemantics(IRBuilder<>& builder,
   case ZYDIS_MNEMONIC_STOSW:
   case ZYDIS_MNEMONIC_STOSD:
   case ZYDIS_MNEMONIC_STOSQ: {
-    flagOperation::lift_stosx(builder, instruction);
+    lift_stosx(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SETZ: {
-    flagOperation::lift_setz(builder, instruction);
+    lift_setz(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SETNZ: {
-    flagOperation::lift_setnz(builder, instruction);
+    lift_setnz(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SETO: {
-    flagOperation::lift_seto(builder, instruction);
+    lift_seto(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SETNO: {
-    flagOperation::lift_setno(builder, instruction);
+    lift_setno(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SETNB: {
-    flagOperation::lift_setnb(builder, instruction);
+    lift_setnb(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SETNBE: {
-    flagOperation::lift_setnbe(builder, instruction);
+    lift_setnbe(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SETBE: {
-    flagOperation::lift_setbe(builder, instruction);
+    lift_setbe(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SETNS: {
-    flagOperation::lift_setns(builder, instruction);
+    lift_setns(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SETP: {
-    flagOperation::lift_setp(builder, instruction);
+    lift_setp(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SETNP: {
-    flagOperation::lift_setnp(builder, instruction);
+    lift_setnp(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SETB: {
-    flagOperation::lift_setb(builder, instruction);
+    lift_setb(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SETS: {
-    flagOperation::lift_sets(builder, instruction);
+    lift_sets(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SETNLE: {
-    flagOperation::lift_setnle(builder, instruction);
+    lift_setnle(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SETLE: {
-    flagOperation::lift_setle(builder, instruction);
+    lift_setle(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SETNL: {
-    flagOperation::lift_setnl(builder, instruction);
+    lift_setnl(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_SETL: {
-    flagOperation::lift_setl(builder, instruction);
+    lift_setl(instruction);
     break;
   }
 
   case ZYDIS_MNEMONIC_BTR: {
-    flagOperation::lift_btr(builder, instruction);
+    lift_btr(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_BSR: {
-    flagOperation::lift_bsr(builder, instruction);
+    lift_bsr(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_BSF: {
-    flagOperation::lift_bsf(builder, instruction);
+    lift_bsf(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_BTC: {
-    flagOperation::lift_btc(builder, instruction);
+    lift_btc(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_LAHF: {
-    flagOperation::lift_lahf(builder);
+    lift_lahf();
     break;
   }
   case ZYDIS_MNEMONIC_STC: {
-    flagOperation::lift_stc(builder);
+    lift_stc();
     break;
   }
   case ZYDIS_MNEMONIC_CMC: {
-    flagOperation::lift_cmc(builder);
+    lift_cmc();
     break;
   }
   case ZYDIS_MNEMONIC_CLC: {
-    flagOperation::lift_clc(builder);
+    lift_clc();
     break;
   }
   case ZYDIS_MNEMONIC_CLD: {
-    flagOperation::lift_cld(builder);
+    lift_cld();
     break;
   }
   case ZYDIS_MNEMONIC_CLI: {
-    flagOperation::lift_cli(builder);
+    lift_cli();
     break;
   }
   case ZYDIS_MNEMONIC_BTS: {
-    flagOperation::lift_bts(builder, instruction);
+    lift_bts(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_BT: {
-    flagOperation::lift_bt(builder, instruction);
+    lift_bt(instruction);
     break;
   }
 
   case ZYDIS_MNEMONIC_CDQ: { // these are not related to flags at all
-    flagOperation::lift_cdq(builder, instruction);
+    lift_cdq(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CWDE: {
-    flagOperation::lift_cwde(builder, instruction);
+    lift_cwde(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CWD: {
-    flagOperation::lift_cwd(builder, instruction);
+    lift_cwd(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CQO: {
-    flagOperation::lift_cqo(builder, instruction);
+    lift_cqo(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CDQE: {
-    flagOperation::lift_cdqe(builder, instruction);
+    lift_cdqe(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_CBW: {
-    flagOperation::lift_cbw(builder, instruction);
+    lift_cbw(instruction);
     break;
   }
   case ZYDIS_MNEMONIC_PAUSE:
@@ -4524,23 +4341,21 @@ void liftInstructionSemantics(IRBuilder<>& builder,
   }
 }
 
-void liftInstruction(IRBuilder<>& builder,
-                     ZydisDisassembledInstruction& instruction,
-                     shared_ptr<vector<BBInfo>> blockAddresses, bool& run) {
+void lifterClass::liftInstruction(ZydisDisassembledInstruction& instruction) {
   LLVMContext& context = builder.getContext();
   // RIP gets updated before execution of the instruction.
   auto val = ConstantInt::getSigned(Type::getInt64Ty(context),
                                     instruction.runtime_address +
                                         instruction.info.length);
-  SetRegisterValue(builder, ZYDIS_REGISTER_RIP, val);
-  auto rsp = GetRegisterValue(builder, ZYDIS_REGISTER_RSP);
+  SetRegisterValue(ZYDIS_REGISTER_RIP, val);
+  auto rsp = GetRegisterValue(ZYDIS_REGISTER_RSP);
   printvalue(rsp);
 
   if (auto funcInfo =
           funcsignatures::getFunctionInfo(instruction.runtime_address)) {
-    callFunctionIR(funcInfo->name.c_str(), builder, funcInfo);
+    callFunctionIR(funcInfo->name.c_str(), funcInfo);
     cout << "calling: " << funcInfo->name.c_str() << "\n";
-    auto next_jump = popStack(builder);
+    auto next_jump = popStack();
 
     // get [rsp], jump there
     auto RIP_value = cast<ConstantInt>(next_jump);
@@ -4550,7 +4365,7 @@ void liftInstruction(IRBuilder<>& builder,
                                  builder.GetInsertBlock()->getParent());
     builder.CreateBr(bb);
 
-    blockAddresses->push_back(make_tuple(jump_address, bb, getRegisters()));
+    blockInfo = (make_tuple(jump_address, bb, getRegisters()));
     run = 0;
     return;
   }
@@ -4571,9 +4386,9 @@ void liftInstruction(IRBuilder<>& builder,
     cout << "calling : " << functionName << " addr: " << (uint64_t)jump_address
          << endl;
 
-    callFunctionIR(functionName, builder, nullptr);
+    callFunctionIR(functionName, nullptr);
 
-    auto next_jump = popStack(builder);
+    auto next_jump = popStack();
 
     // get [rsp], jump there
     auto RIP_value = cast<ConstantInt>(next_jump);
@@ -4581,7 +4396,7 @@ void liftInstruction(IRBuilder<>& builder,
 
     builder.CreateBr(bb);
 
-    blockAddresses->push_back(make_tuple(jump_address, bb, getRegisters()));
+    blockInfo = (make_tuple(jump_address, bb, getRegisters()));
     run = 0;
     return;
   }
@@ -4591,5 +4406,5 @@ void liftInstruction(IRBuilder<>& builder,
   }
 
   // do something for prefixes like rep here
-  liftInstructionSemantics(builder, instruction, blockAddresses, run);
+  liftInstructionSemantics(instruction);
 }

--- a/lifter/Semantics.cpp
+++ b/lifter/Semantics.cpp
@@ -286,13 +286,18 @@ void lifterClass::branchHelper(Value* condition, string instname,
 
     auto BR = builder.CreateCondBr(condition, bb_true, bb_false);
     GetSimplifyQuery::RegisterBranch(BR);
-    /*
-    blockAddresses->push_back(
-        make_tuple(true_jump_addr, bb_true, getRegisters()));
 
-    blockAddresses->push_back(
-        make_tuple(false_jump_addr, bb_false, getRegisters()));
-    */
+    blockInfo = make_tuple(true_jump_addr, bb_true, getRegisters());
+
+    lifterClass* newlifter = new lifterClass(builder);
+
+    auto RegisterList = newlifter->InitRegisters(function, false_jump_addr);
+
+    newlifter->blockInfo = make_tuple(false_jump_addr, bb_false, RegisterList);
+
+    lifters.push_back(newlifter);
+
+    run = 0;
   }
 }
 
@@ -841,7 +846,6 @@ void lifterClass::lift_ret() {
 
     // function->print(outs());
 
-    final_optpass(originalFunc_finalnopt);
     debugging::doIfDebug([&]() {
       std::string Filename = "output_finalopt.ll";
       std::error_code EC;

--- a/lifter/Semantics.cpp
+++ b/lifter/Semantics.cpp
@@ -976,8 +976,6 @@ int branchnumber = 0;
 // jnz and jne
 void lifterClass::lift_jnz() {
 
-  LLVMContext& context = builder.getContext();
-
   auto zf = getFlag(FLAG_ZF);
 
   // auto dest = instruction->operands[0];
@@ -3673,8 +3671,6 @@ void lifterClass::lift_lahf() {
   SetRegisterValue(ZYDIS_REGISTER_AH, Rvalue);
 }
 void lifterClass::lift_sahf() {
-
-  LLVMContext& context = builder.getContext();
 
   auto ah = GetRegisterValue(ZYDIS_REGISTER_AH);
   // RFLAGS(SF:ZF:0:AF:0:PF:1:CF) := AH;

--- a/lifter/Semantics.cpp
+++ b/lifter/Semantics.cpp
@@ -267,46 +267,6 @@ void lifterClass::branchHelper(Value* condition, string instname, int numbered,
   block->setName("previousjmp_block-" + to_string(destination) + "-");
   // cout << "pathInfo:" << pathInfo << " dest: " << destination  <<
   // "\n";
-  if (pathInfo == PATH_solved) {
-
-    string block_name = "jmp-" + to_string(destination) + "-";
-    auto bb = BasicBlock::Create(context, block_name.c_str(),
-                                 builder.GetInsertBlock()->getParent());
-
-    builder.CreateBr(bb);
-
-    blockInfo = (make_tuple(destination, bb, getRegisters()));
-    run = 0;
-  }
-
-  if (pathInfo == PATH_unsolved) {
-
-    // auto cinst = cast<ICmpInst>(condition);
-    auto bb_true = BasicBlock::Create(context, "bb_true",
-                                      builder.GetInsertBlock()->getParent());
-
-    auto bb_false = BasicBlock::Create(context, "bb_false",
-                                       builder.GetInsertBlock()->getParent());
-
-    BranchInst* BR = nullptr;
-    if (!reverse)
-      BR = builder.CreateCondBr(condition, bb_true, bb_false);
-    else
-      BR = builder.CreateCondBr(condition, bb_false, bb_true);
-
-    GetSimplifyQuery::RegisterBranch(BR);
-
-    blockInfo = make_tuple(true_jump_addr, bb_true, getRegisters());
-
-    lifterClass* newlifter = new lifterClass(builder);
-
-    newlifter->blockInfo =
-        make_tuple(false_jump_addr, bb_false, getRegisters());
-
-    lifters.push_back(newlifter);
-
-    run = 0;
-  }
 }
 
 void lifterClass::lift_movsb() {
@@ -865,18 +825,12 @@ void lifterClass::lift_ret() {
     return;
   }
 
-  PATH_info pathInfo = solvePath(function, destination, realval);
-
   block->setName("previousret_block");
 
-  if (pathInfo == PATH_solved) {
+  {
 
     lastinst->eraseFromParent();
     block->setName("fake_ret");
-
-    string block_name = "jmp_ret-" + to_string(destination) + "-";
-    auto bb = BasicBlock::Create(context, block_name.c_str(),
-                                 builder.GetInsertBlock()->getParent());
 
     auto val = ConstantInt::getSigned(Type::getInt64Ty(context),
                                       8); // assuming its x64
@@ -893,12 +847,9 @@ void lifterClass::lift_ret() {
     }
 
     SetRegisterValue(rsp, result); // then add rsp 8
-
-    builder.CreateBr(bb);
-
-    blockInfo = (make_tuple(destination, bb, getRegisters()));
-    run = 0;
   }
+
+  PATH_info pathInfo = solvePath(function, destination, realval);
 }
 
 int jmpcount = 0;
@@ -913,63 +864,17 @@ void lifterClass::lift_jmp() {
       "jump-xd-" + to_string(instruction->runtime_address) + "-");
 
   jmpcount++;
-  if (dest.type == ZYDIS_OPERAND_TYPE_REGISTER ||
-      dest.type == ZYDIS_OPERAND_TYPE_MEMORY) {
-    auto rspvalue = GetOperandValue(dest, 64);
-    auto trunc = createZExtOrTruncFolder(
-        builder, rspvalue, Type::getInt64Ty(context), "jmp-register");
-
-    auto block = builder.GetInsertBlock();
-    block->setName("jmp_check" + to_string(ret_count));
-    auto function = block->getParent();
-
-    auto lastinst = builder.CreateRet(trunc);
-    debugging::doIfDebug([&]() {
-      std::string Filename = "output_beforeJMP.ll";
-      std::error_code EC;
-      raw_fd_ostream OS(Filename, EC);
-      function->print(OS);
-    });
-
-    uint64_t destination = 0;
-    PATH_info pathInfo = solvePath(function, destination, trunc);
-
-    ValueToValueMapTy VMap_test;
-
-    block->setName("previousjmp_block-" + to_string(destination) + "-");
-    // cout << "pathInfo:" << pathInfo << " dest: " << destination  <<
-    // "\n";
-    if (pathInfo == PATH_solved) {
-
-      lastinst->eraseFromParent();
-      string block_name = "jmp-" + to_string(destination) + "-";
-      auto bb = BasicBlock::Create(context, block_name.c_str(),
-                                   builder.GetInsertBlock()->getParent());
-
-      builder.CreateBr(bb);
-
-      blockInfo = (make_tuple(destination, bb, getRegisters()));
-      run = 0;
-    }
-    run = 0;
-
-    // if ROP is not JOP_jmp, then its bugged
-    return;
+  auto targetv = GetOperandValue(dest, 64);
+  auto trunc = createZExtOrTruncFolder(
+      builder, targetv, Type::getInt64Ty(context), "jmp-register");
+  printvalue(trunc);
+  uint64_t destination = 0;
+  auto function = builder.GetInsertBlock()->getParent();
+  if (dest.type == ZYDIS_OPERAND_TYPE_IMMEDIATE) {
+    trunc = createAddFolder(builder, trunc, ripval);
   }
-
+  PATH_info pathInfo = solvePath(function, destination, trunc);
   SetRegisterValue(ZYDIS_REGISTER_RIP, newRip);
-
-  uint64_t test = dest.imm.value.s + instruction->runtime_address +
-                  instruction->info.length;
-
-  string block_name = "jmp-" + to_string(test) + "-";
-  auto bb = BasicBlock::Create(context, block_name.c_str(),
-                               builder.GetInsertBlock()->getParent());
-
-  builder.CreateBr(bb);
-
-  blockInfo = (make_tuple(test, bb, getRegisters()));
-  run = 0;
 }
 
 int branchnumber = 0;
@@ -1482,8 +1387,9 @@ void lifterClass::lift_not() {
   auto dest = instruction->operands[0];
 
   auto Rvalue = GetOperandValue(dest, dest.size);
-  Rvalue = builder.CreateNot(
-      Rvalue, "realnot-" + to_string(instruction->runtime_address) + "-");
+  Rvalue = createXorFolder(
+      builder, Rvalue, Constant::getAllOnesValue(Rvalue->getType()),
+      "realnot-" + to_string(instruction->runtime_address) + "-");
   SetOperandValue(dest, Rvalue, to_string(instruction->runtime_address));
 
   printvalue(Rvalue);
@@ -1498,7 +1404,9 @@ void lifterClass::lift_neg() {
 
   auto cf = createICMPFolder(builder, CmpInst::ICMP_NE, Rvalue,
                              ConstantInt::get(Rvalue->getType(), 0), "cf");
-  auto result = builder.CreateNeg(Rvalue, "neg");
+  auto result = createSubFolder(
+      builder, builder.getIntN(Rvalue->getType()->getIntegerBitWidth(), 0),
+      Rvalue, "neg");
   SetOperandValue(dest, result);
 
   auto sf = computeSignFlag(builder, result);

--- a/lifter/includes.h
+++ b/lifter/includes.h
@@ -279,8 +279,8 @@ inline llvm::raw_ostream& operator<<(llvm::raw_ostream& OS,
 #define RIP 0x007FFFFFFF400000
 #define STACKP_VALUE 0x14FF28
 
-using ReverseRegisterMap = unordered_map<Value*, int>;
-using RegisterMap = unordered_map<int, Value*>;
+using ReverseRegisterMap = DenseMap<Value*, int>;
+using RegisterMap = DenseMap<int, Value*>;
 // BB start address, BB pointer, Final registers in that RegisterMap so we can
 // use it later
 using BBInfo = tuple<uint64_t, BasicBlock*, RegisterMap>;

--- a/lifter/lifter.cpp
+++ b/lifter/lifter.cpp
@@ -23,7 +23,6 @@ void asm_to_zydis_to_lift(ZyanU8* data, ZyanU64 runtime_address,
     runtime_address = get<0>(lifter->blockInfo);
     uint64_t offset = FileHelper::address_to_mapped_address((void*)file_base,
                                                             runtime_address);
-
     debugging::doIfDebug([&]() {
       cout << "runtime_addr: " << runtime_address << " offset:" << offset
            << " byte there: 0x" << (int)*(uint8_t*)(file_base + offset) << endl;
@@ -65,6 +64,8 @@ void asm_to_zydis_to_lift(ZyanU8* data, ZyanU64 runtime_address,
 
         lifter->run = 0;
         lifters.pop_back();
+
+        outs() << "next lifter instance\n";
       }
 
       offset += instruction.info.length;

--- a/lifter/lifter.cpp
+++ b/lifter/lifter.cpp
@@ -128,6 +128,12 @@ void InitFunction_and_LiftInstructions(ZyanU64 runtime_address,
 
   asm_to_zydis_to_lift((uint8_t*)file_base, runtime_address, file_base);
 
+  long long ms = timer::stopTimer();
+  timer::startTimer();
+
+  cout << "\nlifting complete, " << dec << ms << " milliseconds has past"
+       << endl;
+
   final_optpass(function);
   string Filename = "output.ll";
   error_code EC;

--- a/lifter/lifter.cpp
+++ b/lifter/lifter.cpp
@@ -55,14 +55,14 @@ void asm_to_zydis_to_lift(ZyanU8* data, ZyanU64 runtime_address,
       ZydisDisassembledInstruction instruction;
       ZydisDisassembleIntel(ZYDIS_MACHINE_MODE_LONG_64, runtime_address,
                             data + offset, 15, &instruction);
-
+      lifter->instruction = &instruction;
       auto counter = debugging::increaseInstCounter() - 1;
       debugging::doIfDebug([&]() {
         cout << hex << counter << ":" << instruction.text << "\n";
         cout << "runtime: " << instruction.runtime_address << endl;
       });
 
-      lifter->liftInstruction(instruction);
+      lifter->liftInstruction();
       if (lifter->finished) {
 
         lifter->run = 0;

--- a/lifter/lifter.cpp
+++ b/lifter/lifter.cpp
@@ -4,12 +4,10 @@
 #include "GEPTracker.h"
 #include "OperandUtils.h"
 #include "PathSolver.h"
-#include "Semantics.h"
 #include "includes.h"
 #include "lifterClass.h"
 #include "nt/nt_headers.hpp"
 #include "utils.h"
-#include <cstdlib>
 #include <fstream>
 
 vector<lifterClass*> lifters;
@@ -39,7 +37,6 @@ void asm_to_zydis_to_lift(ZyanU8* data, ZyanU64 runtime_address,
 
     // will use this for exploring multiple branches
     lifter->setRegisters(get<2>(lifter->blockInfo));
-    //
 
     BinaryOperations::initBases((void*)file_base, data);
 

--- a/lifter/lifterClass.h
+++ b/lifter/lifterClass.h
@@ -1,0 +1,179 @@
+#ifndef LIFTERCLASS_H
+#define LIFTERCLASS_H
+#include "FunctionSignatures.h"
+#include "GEPTracker.h"
+#include "includes.h"
+
+#define DEFINE_FUNCTION(name)                                                  \
+  void lift_##name(ZydisDisassembledInstruction& instruction);
+
+#define DEFINE_FUNCTION2(name) void lift_##name();
+
+class lifterClass {
+public:
+  lifterClass(IRBuilder<>& irbuilder) : builder(irbuilder) {};
+  IRBuilder<>& builder;
+  bool run = 0;
+  bool finished = 0; // finished, unfinished, unreachable
+  lifterMemoryBuffer buffer;
+  BBInfo blockInfo;
+
+  unordered_map<Flag, Value*> FlagList;
+  RegisterMap Registers;
+
+  Value* memory;
+  Value* TEB;
+
+  void liftInstruction(ZydisDisassembledInstruction& instruction);
+  void liftInstructionSemantics(ZydisDisassembledInstruction& instruction);
+  void branchHelper(ZydisDisassembledInstruction& instruction, Value* condition,
+                    string instname, int numbered);
+  void Init_Flags();
+  Value* setFlag(Flag flag, Value* newValue = nullptr);
+  Value* getFlag(Flag flag);
+  RegisterMap getRegisters();
+  void setRegisters(RegisterMap newRegisters);
+  ReverseRegisterMap flipRegisterMap();
+  RegisterMap InitRegisters(Function* function, ZyanU64 rip);
+  Value* GetValueFromHighByteRegister(int reg);
+  Value* GetRegisterValue(int key);
+  Value* SetValueToHighByteRegister(int reg, Value* value);
+  Value* SetValueToSubRegister_8b(int reg, Value* value);
+  Value* SetValueToSubRegister_16b(int reg, Value* value);
+  void SetRegisterValue(int key, Value* value);
+  void SetRFLAGSValue(Value* value);
+  PATH_info solvePath(Function* function, uint64_t& dest, Value* simplifyValue);
+  void replaceAllUsesWithandReplaceRMap(Value* v, Value* nv,
+                                        ReverseRegisterMap rVMap);
+  void simplifyUsers(Value* newValue, DataLayout& DL,
+                     ReverseRegisterMap flippedRegisterMap);
+  Value* popStack();
+  void pushFlags(vector<Value*> value, string address);
+  vector<Value*> GetRFLAGS();
+  Value* GetOperandValue(ZydisDecodedOperand& op, int possiblesize,
+                         string address = "");
+  Value* SetOperandValue(ZydisDecodedOperand& op, Value* value,
+                         string address = "");
+  void callFunctionIR(string functionName,
+                      funcsignatures::functioninfo* funcInfo);
+  Value* GetEffectiveAddress(ZydisDecodedOperand& op, int possiblesize);
+  vector<Value*> parseArgs(funcsignatures::functioninfo* funcInfo);
+  FunctionType* parseArgsType(funcsignatures::functioninfo* funcInfo,
+                              LLVMContext& context);
+  Value* GetRFLAGSValue();
+  DEFINE_FUNCTION(movsb);
+  DEFINE_FUNCTION(movaps);
+  DEFINE_FUNCTION(mov);
+  DEFINE_FUNCTION(cmovbz);
+  DEFINE_FUNCTION(cmovnbz);
+  DEFINE_FUNCTION(cmovz);
+  DEFINE_FUNCTION(cmovnz);
+  DEFINE_FUNCTION(cmovl);
+  DEFINE_FUNCTION(cmovnl);
+  DEFINE_FUNCTION(cmovb);
+  DEFINE_FUNCTION(cmovnb);
+  DEFINE_FUNCTION(cmovns);
+  DEFINE_FUNCTION(cmovs);
+  DEFINE_FUNCTION(cmovnle);
+  DEFINE_FUNCTION(cmovle);
+  DEFINE_FUNCTION(cmovo);
+  DEFINE_FUNCTION(cmovno);
+  DEFINE_FUNCTION(cmovp);
+  DEFINE_FUNCTION(cmovnp);
+  //
+  DEFINE_FUNCTION(call);
+  DEFINE_FUNCTION(ret);
+  DEFINE_FUNCTION(jmp);
+  DEFINE_FUNCTION(jnz);
+  DEFINE_FUNCTION(jz);
+  DEFINE_FUNCTION(js);
+  DEFINE_FUNCTION(jns);
+  DEFINE_FUNCTION(jle);
+  DEFINE_FUNCTION(jl);
+  DEFINE_FUNCTION(jnl);
+  DEFINE_FUNCTION(jnle);
+  DEFINE_FUNCTION(jbe);
+  DEFINE_FUNCTION(jb);
+  DEFINE_FUNCTION(jnb);
+  DEFINE_FUNCTION(jnbe);
+  DEFINE_FUNCTION(jo);
+  DEFINE_FUNCTION(jno);
+  DEFINE_FUNCTION(jp);
+  DEFINE_FUNCTION(jnp);
+  //
+  DEFINE_FUNCTION(sbb);
+  DEFINE_FUNCTION(rcl);
+  DEFINE_FUNCTION(rcr);
+  DEFINE_FUNCTION(not );
+  DEFINE_FUNCTION(neg);
+  DEFINE_FUNCTION(sar);
+  DEFINE_FUNCTION(shr);
+  DEFINE_FUNCTION(shl);
+  DEFINE_FUNCTION(bswap);
+  DEFINE_FUNCTION(cmpxchg);
+  DEFINE_FUNCTION(xchg);
+  DEFINE_FUNCTION(shld);
+  DEFINE_FUNCTION(shrd);
+  DEFINE_FUNCTION(lea);
+  DEFINE_FUNCTION(add_sub);
+  void lift_imul2(ZydisDisassembledInstruction& instruction, bool isSigned);
+  DEFINE_FUNCTION(imul);
+  DEFINE_FUNCTION(mul);
+  DEFINE_FUNCTION(div2);
+  DEFINE_FUNCTION(div);
+  DEFINE_FUNCTION(idiv2);
+  DEFINE_FUNCTION(idiv);
+  DEFINE_FUNCTION(xor);
+  DEFINE_FUNCTION(or);
+  DEFINE_FUNCTION(and);
+  DEFINE_FUNCTION(rol);
+  DEFINE_FUNCTION(ror);
+  DEFINE_FUNCTION(inc_dec);
+  DEFINE_FUNCTION(push);
+  DEFINE_FUNCTION(pushfq);
+  DEFINE_FUNCTION(pop);
+  DEFINE_FUNCTION(popfq);
+  DEFINE_FUNCTION(adc);
+  DEFINE_FUNCTION(xadd);
+  DEFINE_FUNCTION(test);
+  DEFINE_FUNCTION(cmp);
+  DEFINE_FUNCTION2(rdtsc);
+  DEFINE_FUNCTION(cpuid);
+  //
+  DEFINE_FUNCTION(setnz);
+  DEFINE_FUNCTION(seto);
+  DEFINE_FUNCTION(setno);
+  DEFINE_FUNCTION(setnb);
+  DEFINE_FUNCTION(setbe);
+  DEFINE_FUNCTION(setnbe);
+  DEFINE_FUNCTION(setns);
+  DEFINE_FUNCTION(setp);
+  DEFINE_FUNCTION(setnp);
+  DEFINE_FUNCTION(setb);
+  DEFINE_FUNCTION(sets);
+  DEFINE_FUNCTION(stosx);
+  DEFINE_FUNCTION(setz);
+  DEFINE_FUNCTION(setnle);
+  DEFINE_FUNCTION(setle);
+  DEFINE_FUNCTION(setnl);
+  DEFINE_FUNCTION(setl);
+  DEFINE_FUNCTION(bt);
+  DEFINE_FUNCTION(btr);
+  DEFINE_FUNCTION(bts);
+  DEFINE_FUNCTION(bsr);
+  DEFINE_FUNCTION(bsf);
+  DEFINE_FUNCTION(btc);
+  DEFINE_FUNCTION2(lahf);
+  DEFINE_FUNCTION2(stc);
+  DEFINE_FUNCTION2(cmc);
+  DEFINE_FUNCTION2(clc);
+  DEFINE_FUNCTION2(cld);
+  DEFINE_FUNCTION2(cli);
+  DEFINE_FUNCTION(cwd);
+  DEFINE_FUNCTION(cdq);
+  DEFINE_FUNCTION(cqo);
+  DEFINE_FUNCTION(cbw);
+  DEFINE_FUNCTION(cwde);
+  DEFINE_FUNCTION(cdqe);
+};
+#endif // LIFTERCLASS_H

--- a/lifter/lifterClass.h
+++ b/lifter/lifterClass.h
@@ -6,8 +6,6 @@
 
 #define DEFINE_FUNCTION(name) void lift_##name()
 
-#define DEFINE_FUNCTION2(name) void lift_##name()
-
 class lifterClass {
 public:
   lifterClass(IRBuilder<>& irbuilder) : builder(irbuilder) {};
@@ -136,7 +134,7 @@ public:
   DEFINE_FUNCTION(xadd);
   DEFINE_FUNCTION(test);
   DEFINE_FUNCTION(cmp);
-  DEFINE_FUNCTION2(rdtsc);
+  DEFINE_FUNCTION(rdtsc);
   DEFINE_FUNCTION(cpuid);
   //
   DEFINE_FUNCTION(setnz);
@@ -162,12 +160,14 @@ public:
   DEFINE_FUNCTION(bsr);
   DEFINE_FUNCTION(bsf);
   DEFINE_FUNCTION(btc);
-  DEFINE_FUNCTION2(lahf);
-  DEFINE_FUNCTION2(stc);
-  DEFINE_FUNCTION2(cmc);
-  DEFINE_FUNCTION2(clc);
-  DEFINE_FUNCTION2(cld);
-  DEFINE_FUNCTION2(cli);
+  DEFINE_FUNCTION(lahf);
+  DEFINE_FUNCTION(sahf);
+  DEFINE_FUNCTION(std);
+  DEFINE_FUNCTION(stc);
+  DEFINE_FUNCTION(cmc);
+  DEFINE_FUNCTION(clc);
+  DEFINE_FUNCTION(cld);
+  DEFINE_FUNCTION(cli);
   DEFINE_FUNCTION(cwd);
   DEFINE_FUNCTION(cdq);
   DEFINE_FUNCTION(cqo);

--- a/lifter/lifterClass.h
+++ b/lifter/lifterClass.h
@@ -14,7 +14,7 @@ public:
   bool run = 0;      // we may set 0 so to trigger jumping to next basic block
   bool finished = 0; // finished, unfinished, unreachable
   bool isUnreachable = 0;
-
+  DenseMap<Instruction*, APInt> assumptions;
   ZydisDisassembledInstruction* instruction = nullptr;
   lifterMemoryBuffer buffer;
   BBInfo blockInfo;

--- a/lifter/lifterClass.h
+++ b/lifter/lifterClass.h
@@ -4,10 +4,9 @@
 #include "GEPTracker.h"
 #include "includes.h"
 
-#define DEFINE_FUNCTION(name)                                                  \
-  void lift_##name(ZydisDisassembledInstruction& instruction);
+#define DEFINE_FUNCTION(name) void lift_##name()
 
-#define DEFINE_FUNCTION2(name) void lift_##name();
+#define DEFINE_FUNCTION2(name) void lift_##name()
 
 class lifterClass {
 public:
@@ -15,6 +14,7 @@ public:
   IRBuilder<>& builder;
   bool run = 0;
   bool finished = 0; // finished, unfinished, unreachable
+  ZydisDisassembledInstruction* instruction = nullptr;
   lifterMemoryBuffer buffer;
   BBInfo blockInfo;
 
@@ -24,10 +24,9 @@ public:
   Value* memory;
   Value* TEB;
 
-  void liftInstruction(ZydisDisassembledInstruction& instruction);
-  void liftInstructionSemantics(ZydisDisassembledInstruction& instruction);
-  void branchHelper(ZydisDisassembledInstruction& instruction, Value* condition,
-                    string instname, int numbered);
+  void liftInstruction();
+  void liftInstructionSemantics();
+  void branchHelper(Value* condition, string instname, int numbered);
   void Init_Flags();
   Value* setFlag(Flag flag, Value* newValue = nullptr);
   Value* getFlag(Flag flag);
@@ -116,7 +115,7 @@ public:
   DEFINE_FUNCTION(shrd);
   DEFINE_FUNCTION(lea);
   DEFINE_FUNCTION(add_sub);
-  void lift_imul2(ZydisDisassembledInstruction& instruction, bool isSigned);
+  void lift_imul2(bool isSigned);
   DEFINE_FUNCTION(imul);
   DEFINE_FUNCTION(mul);
   DEFINE_FUNCTION(div2);

--- a/lifter/lifterClass.h
+++ b/lifter/lifterClass.h
@@ -27,7 +27,8 @@ public:
 
   void liftInstruction();
   void liftInstructionSemantics();
-  void branchHelper(Value* condition, string instname, int numbered);
+  void branchHelper(Value* condition, string instname, int numbered,
+                    bool reverse = false);
   void Init_Flags();
   Value* setFlag(Flag flag, Value* newValue = nullptr);
   Value* getFlag(Flag flag);

--- a/lifter/lifterClass.h
+++ b/lifter/lifterClass.h
@@ -10,8 +10,11 @@ class lifterClass {
 public:
   lifterClass(IRBuilder<>& irbuilder) : builder(irbuilder) {};
   IRBuilder<>& builder;
-  bool run = 0;
+
+  bool run = 0;      // we may set 0 so to trigger jumping to next basic block
   bool finished = 0; // finished, unfinished, unreachable
+  bool isUnreachable = 0;
+
   ZydisDisassembledInstruction* instruction = nullptr;
   lifterMemoryBuffer buffer;
   BBInfo blockInfo;
@@ -175,4 +178,5 @@ public:
   DEFINE_FUNCTION(cwde);
   DEFINE_FUNCTION(cdqe);
 };
+extern vector<lifterClass*> lifters;
 #endif // LIFTERCLASS_H

--- a/lifter/utils.cpp
+++ b/lifter/utils.cpp
@@ -135,6 +135,8 @@ namespace debugging {
   template void printValue<KnownBits>(const KnownBits& v, const char* name);
   template void printValue<APInt>(const APInt& v, const char* name);
   template void printValue<ROP_info>(const ROP_info& v, const char* name);
+  template void printValue<ConstantRange>(const ConstantRange& v,
+                                          const char* name);
 
 } // namespace debugging
 

--- a/lifter/utils.cpp
+++ b/lifter/utils.cpp
@@ -182,7 +182,10 @@ namespace timer {
     running = true;
   }
 
-  double getTimer() { return elapsedTime.count(); }
+  double getTimer() {
+    elapsedTime += clock::now() - startTime;
+    return elapsedTime.count();
+  }
 
   double stopTimer() {
     if (running) {

--- a/testcases/pushf.asm
+++ b/testcases/pushf.asm
@@ -1,0 +1,13 @@
+section .text
+
+global main
+main:
+or rax, 1
+shl rax, 1
+shr rax, 1
+cmp rax, 0
+pushf
+mov rax, qword [rsp]
+and rax, 0x40
+add rsp, 8
+ret

--- a/testcases/test_branch_mem.asm
+++ b/testcases/test_branch_mem.asm
@@ -1,0 +1,18 @@
+section .text
+
+global main
+main:
+cmp rax, 1
+push rax
+jz condition_taken_zf
+pop rax
+push rcx
+pop rax
+ret
+
+condition_taken_zf:
+pop rax
+inc rax
+cond_not_taken_zf:      
+ret		
+

--- a/testcases/test_branch_meme.asm
+++ b/testcases/test_branch_meme.asm
@@ -1,0 +1,25 @@
+section .text
+
+%define SF 0x80
+
+global main
+main:
+and rsi, 1
+lea rcx, [rel jtable]
+mov rax, [rcx+rsi*4]
+lea rax, [rcx+rax]
+jmp rax
+
+
+jtable: dd      test1 - jtable
+		dd      test2 - jtable
+
+test1:
+xor rax, rax
+or rax, rsi
+ret
+test2:
+xor rax, rax
+or rax, rsi
+inc rax
+ret

--- a/testcases/test_branch_zf.asm
+++ b/testcases/test_branch_zf.asm
@@ -2,10 +2,10 @@ section .text
 
 global main
 main:
-cmp rax, 0 				; zf = rax-0 == 0 ; sf = rax-0 < 0; of = (rax ^ 0) < 0; ....
+cmp rax, 1 				; zf = rax-0 == 0 ; sf = rax-0 < 0; of = (rax ^ 0) < 0; ....
 
-jnz cond_not_taken_zf   ; zf == 0; if not taken, we can say rax is 0 for this branch, we can do this by rax & 0.
-
+jz condition_taken_zf   ; zf == 0; if not taken, we can say rax is 0 for this branch, we can do this by rax & 0.
+ret
 condition_taken_zf: 	; so the basic block here will assume rax is 0
 
 inc rax    				; rax will be 1
@@ -14,3 +14,39 @@ cond_not_taken_zf:      ; but this basicblock wont assume rax is 0
 
 ret		
 
+
+main2:
+lea rcx, [rcx+rax]      
+cmp rax, 0              
+condition_taken_zf2: 	; so the basic block here will assume rax is 0
+inc rax    				; rax will be 1
+add rax, rcx			; rcx + 1, not rcx+rax+1
+cond_not_taken_zf2:      ; but this basicblock wont assume rax is 0
+ret		
+
+; %a = rcx + rax
+; %zf = rax == 0
+; rax_zero.bb:
+; %inc = 0 + 1   ; simplified to 1
+; %b = %a + %inc ; %a can be simplified to %rcx
+; ret %b
+
+; rax_nonzero.bb
+; ret %rax
+
+; we can only say something sure about what generates the flag, in this case, its cmp rax, 0
+; so 
+; %zf0 = %v - 0 
+; %zf1 = %zf0 == 0
+; we can only assume the value of %zf0 because we check %zf1
+; so %zf0 should be 0
+; by extension %v should be 0
+;
+
+; if it was
+; cmp rax, rcx
+; then
+; %zf0 = %rax - %rcx
+; %zf1 = %zf0 == 0
+; we can only assume %zf0 is 0 (if true)
+;

--- a/testcases/test_indirect_mem.asm
+++ b/testcases/test_indirect_mem.asm
@@ -1,0 +1,10 @@
+section .text
+
+global main
+main:
+push rax
+push rcx
+and rcx, 1
+mov rax, [rsp+rcx*8]
+add rsp, 16
+ret		

--- a/testcases/test_indirect_mem2.asm
+++ b/testcases/test_indirect_mem2.asm
@@ -1,0 +1,10 @@
+section .text
+
+global main
+main:
+push rcx
+push rcx
+and rcx, 1
+mov rax, [rsp+rcx*8]
+add rsp, 16
+ret		

--- a/testcases/test_invalid_mem.asm
+++ b/testcases/test_invalid_mem.asm
@@ -1,0 +1,8 @@
+section .text
+
+global main
+main:
+mov rax, 10
+push rax
+call [rsp]
+ret

--- a/testcases/test_jumptable.asm
+++ b/testcases/test_jumptable.asm
@@ -1,0 +1,30 @@
+section .text
+
+%define SF 0x80
+
+global main
+main:
+sub rcx, 0 ; turn SF if rcx is -
+pushfq
+pop rsi
+and rsi, SF ; check if SF is turned on
+shr rsi, 7
+lea rcx, [rel jtable]
+mov eax, [rcx+rsi*4]
+lea rax, [rcx+rax]
+push rax
+ret
+
+
+jtable: dd      test1 - jtable
+		dd      test2 - jtable
+
+test1:
+xor rax, rax
+or rax, rsi
+ret
+test2:
+xor rax, rax
+or rax, rsi
+inc rax
+ret

--- a/testcases/test_partial_mem.asm
+++ b/testcases/test_partial_mem.asm
@@ -1,0 +1,10 @@
+section .text
+
+global main
+main:
+push rax
+mov dword [rsp+4], ecx
+and rcx, 1
+mov rax, [rsp]
+add rsp, 8
+ret		


### PR DESCRIPTION
On top of lifter-is-a-class (explanation of changes in experimental) :  

1- 
```
x = select z, a, b
y = add x, 1
```
will be "simplified" to
```
x = select z, a, b
y = select z, a+1, b+1
```
, so we can track values easier
2- `(a & b ) | (~a & c)` will be simplified to `select a, b, c`

3- calculate possible values with brute forcing