### PR TITLE
feat: review automation toolkit with full cutover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ check_*.py
 .tmp*
 =*
 scriptsdev/
+
+# review automation
+/artifacts/
+tmp_*.json

--- a/docs/REVIEWER_RULES.md
+++ b/docs/REVIEWER_RULES.md
@@ -1,0 +1,154 @@
+# Mergen Reviewer Rules
+
+These rules are for PR review of this repository. They are intentionally strict and optimized for catching semantic regressions, flaky test artifacts, and false-green rewrite gates.
+
+## 1) Review Contract
+
+1. Review only the files in the PR scope. No drive-by changes.
+2. Always inspect the real diff first (`git diff` / `git show`) before reading full files.
+3. For every non-trivial changed symbol, review its direct consumers before concluding correctness.
+4. Prefer correctness over style. Do not block on formatting-only nits.
+5. Do not accept compatibility shims for refactors unless explicitly requested; prefer full cutover.
+
+## 2) Required Workflow
+
+1. **Map the change**
+   - `git diff --name-status <base>...<head>`
+2. **Review by subsystem bucket** (core, disasm/semantics, rewrite scripts, vectors, build scripts, docs)
+3. **Inspect each bucket deeply**
+   - `git diff -- <files>`
+   - read surrounding context for changed hunks
+4. **Run targeted verification** (see matrix below)
+5. **Report findings with evidence**
+   - file path + line range
+   - failure condition
+   - user-visible/system-visible impact
+   - concrete fix direction
+
+## 3) Severity Rubric
+
+- **P0**: silent miscompile/mislift, memory corruption, security-sensitive path traversal/execution bug.
+- **P1**: incorrect semantics/results, wrong oracle outcomes, false-green gate, broken build lane.
+- **P2**: deterministic/reliability regressions, incorrect fallback behavior, brittle tooling contracts.
+- **P3**: docs drift, maintainability concerns without immediate correctness impact.
+
+Default: request changes for any P0/P1. P2 is usually request changes unless clearly non-blocking.
+
+## 4) Repo-Specific Invariants (Block if violated)
+
+### 4.1 Backend selection (CMake/dev scripts)
+
+- Exactly one backend state should be active (`ICED_FOUND` xor `ICED_NOT_FOUND`).
+- Do not regress explicit toolchain overrides (e.g., `CARGO_EXECUTABLE`).
+- Reconfigure scripts must prevent stale cache contamination between iced/zydis lanes.
+
+### 4.2 Runtime image context and PE mapping
+
+- Runtime address validation must reject invalid ranges but preserve valid header-backed RVAs.
+- RVA->file offset mapping must distinguish unmapped virtual tails vs valid file-backed bytes.
+- Errors must be explicit; avoid silent fallback to plausible-but-wrong context.
+
+### 4.3 Cross-language operand model consistency
+
+- `OperandType` ordering/meaning must stay consistent across:
+  - `icpped_rust/src/lib.rs`
+  - `lifter/disasm/CommonDisassembler.hpp`
+  - downstream semantics helpers
+- New register widths (e.g., 128-bit XMM) must be wired through conversion + size helpers + operand readers/writers.
+
+### 4.4 Semantics/opcode table coherence
+
+- New opcode entries in `lifter/semantics/x86_64_opcodes.x` must have a concrete handler implementation.
+- Handler operand-form restrictions must match intent (e.g., XMM-only SSE2 integer ops).
+- Flag behavior must match instruction semantics where flags are expected/validated.
+
+### 4.5 Oracle vectors and test artifacts
+
+- Oracle schema/version fields must remain valid.
+- `skip` fields must be boolean where schema expects boolean.
+- Case names should be unique and stable.
+- XMM register snapshots must be fixed-width 128-bit hex (32 hex digits after `0x`).
+- Do not accept timestamp-only churn that hides inconsistent case payloads.
+
+### 4.6 Rewrite manifest safety
+
+- Manifest must validate as strict JSON object with `samples`.
+- Sample names must reject traversal/path separators.
+- `run.ps1` must enforce source↔manifest parity (no missing/extra/duplicate sample names).
+- `verify.ps1` pattern descriptors must reject malformed entries and empty required content.
+
+## 5) Verification Matrix (Run what matches changed files)
+
+| Changed area | Minimum verification |
+|---|---|
+| `lifter/core/**`, `lifter/disasm/**`, `lifter/semantics/**`, `lifter/test/**` | `python test.py micro --check-flags` (add focused filters if needed) |
+| `scripts/rewrite/**` (validation/oracle/verify/run) | `python test.py negative` and `python test.py baseline` |
+| opcode coverage/vector plumbing (`x86_64_opcodes.x`, coverage scripts, vector manifests) | `python test.py coverage --full` and `python test.py report --json` |
+| `cmake/**`, `scripts/dev/**` | affected lane configure+build (`scripts\dev\configure_iced.cmd` + `build_iced.cmd`, and/or `configure_zydis.cmd` + `build_zydis.cmd`) |
+| docs-only | consistency review; no runtime gate required |
+
+If an expected command cannot run (missing env/toolchain), report the exact blocker and do not claim verification passed.
+
+## 6) Finding Quality Bar
+
+A finding is valid only if it includes all of:
+
+1. **Where**: exact file and line(s)
+2. **When it breaks**: concrete condition/input
+3. **Why it matters**: correctness/reliability/security impact
+4. **How to fix**: direct, minimal remediation path
+
+Reject vague findings like “might break” without a concrete failure path.
+
+## 7) Review Output Template
+
+```text
+Verdict: approve | comment | request_changes
+
+Summary:
+- <1-3 lines>
+
+Findings:
+- [P1] <title>
+  - File: <path>:<line-range>
+  - Failure: <specific scenario>
+  - Impact: <observable consequence>
+  - Fix: <actionable change>
+
+Verification run:
+- <command>: PASS/FAIL/BLOCKED
+- <command>: PASS/FAIL/BLOCKED
+```
+
+## 8) Quick Commands
+
+```bat
+git diff --name-status main...<branch>
+git diff -- main...<branch> -- <path>
+python test.py negative
+python test.py baseline
+python test.py micro --check-flags
+python test.py coverage --full
+python test.py report --json
+```
+
+## 9) Review Automation Shortcuts
+
+Use these helpers for faster, repeatable review setup before manual deep-dive:
+
+```bat
+python scripts/review/risk_map.py --base main --head HEAD
+python scripts/review/shard_pr.py --base main --head HEAD
+python scripts/review/verify_plan.py --base main --head HEAD
+python scripts/review/verify_plan.py --base main --head HEAD --run
+python scripts/review/invariant_guard.py --base main --head HEAD
+```
+
+For local iteration without a branch diff, pass explicit files:
+
+```bat
+python scripts/review/risk_map.py --paths <file1> <file2> ...
+python scripts/review/verify_plan.py --paths <file1> <file2> ... --run
+```
+
+Use this document as the default reviewer policy unless a PR explicitly narrows scope.

--- a/lifter/analysis/PathSolver.ipp
+++ b/lifter/analysis/PathSolver.ipp
@@ -82,7 +82,7 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(PATH_info)::solvePath(
     auto firstcase = pv[0];
     auto secondcase = pv[1];
 
-    static auto try_simplify = [&](APInt c1,
+    auto try_simplify = [&](APInt c1,
                                    Value* simplifyv) -> std::optional<Value*> {
       if (auto si = dyn_cast<SelectInst>(simplifyv)) {
         auto firstcase_v = builder->getIntN(
@@ -152,12 +152,20 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(PATH_info)::solvePath(
     addUnvisitedAddr(blockInfo);
     addUnvisitedAddr(newblock);
 
-    // fix this later, is ugly
-    assumptions[cast<Instruction>(condition)] = 0;
-    branch_backup(blockInfo.block);
+    // Constant conditions are already resolved — only track assumptions
+    // for instruction-produced conditions that need runtime disambiguation.
+    if (auto* condInst = dyn_cast<Instruction>(condition)) {
+      assumptions[condInst] = 0;
+      branch_backup(blockInfo.block);
 
-    this->assumptions[cast<Instruction>(condition)] = 1;
-    branch_backup(newblock.block);
+      this->assumptions[condInst] = 1;
+      branch_backup(newblock.block);
+    } else {
+      // Condition is a constant (e.g., from folded ICMP). Both branches
+      // are statically determined — back them up without assumption state.
+      branch_backup(blockInfo.block);
+      branch_backup(newblock.block);
+    }
 
     debugging::doIfDebug([&]() {
       std::string Filename = "output_newpath.ll";
@@ -202,7 +210,7 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(PATH_info)::solvePath(
 
     // Destination remains unknown for multi-target switches.
     dest = 0;
-    result = PATH_unsolved;
+    result = PATH_multi_solved;
 
     debugging::doIfDebug([&]() {
       std::string Filename = "output_switch.ll";
@@ -213,6 +221,13 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(PATH_info)::solvePath(
     std::cout << "created multi-target switch with " << pv.size()
               << " targets\n"
               << std::flush;
+  }
+
+  if (pv.empty()) {
+    // computePossibleValues exhausted its budget without finding any concrete
+    // targets. Terminate the block with unreachable to satisfy the LLVM
+    // verifier — an unterminated basic block is invalid IR.
+    builder->CreateUnreachable();
   }
 
   return result;

--- a/lifter/memory/FileReader.hpp
+++ b/lifter/memory/FileReader.hpp
@@ -152,6 +152,11 @@ public:
   }
 
   bool readMemory_impl(uint64_t addr, unsigned byteSize, uint64_t& value) {
+    // Guard against buffer overflow: memcpy into uint64_t is only safe for
+    // reads up to 8 bytes. Wider loads (SSE/AVX 128/256/512-bit) must not
+    // reach this path — they require vector-aware memory handling.
+    if (byteSize > sizeof(uint64_t))
+      return 0;
     uint64_t mappedAddr = address_to_mapped_address(addr);
     if (mappedAddr > 0) {
       uint64_t tempValue = 0;
@@ -309,6 +314,11 @@ public:
   }
 
   bool readMemory_impl(uint64_t addr, unsigned byteSize, uint64_t& value) {
+    // Guard against buffer overflow: memcpy into uint64_t is only safe for
+    // reads up to 8 bytes. Wider loads (SSE/AVX 128/256/512-bit) must not
+    // reach this path — they require vector-aware memory handling.
+    if (byteSize > sizeof(uint64_t))
+      return 0;
     uint64_t mappedAddr = address_to_mapped_address(addr);
     if (mappedAddr > 0) {
       uint64_t tempValue = 0;

--- a/lifter/memory/GEPTracker.ipp
+++ b/lifter/memory/GEPTracker.ipp
@@ -137,29 +137,32 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(Value*)::retrieveCombinedValue(
   for (auto v : values) {
     Value* byteValue = nullptr;
     uint8_t bytesize = v.end - v.start;
-
-    uint64_t mem_value;
     printvalue2(v.isRef);
 
-    auto read_mem = file.readMemory(v.memoryAddress, bytesize, mem_value);
-    printvalue2(read_mem);
-    printvalue2(mem_value);
-    if (!v.isRef && memoryPolicy.isSymbolic(v.memoryAddress)) {
-      // Symbolic address: preserve symbolic fallback when concrete mapping
-      // is not proven.
-      if (read_mem) {
-        byteValue = builder->getIntN(bytesize * 8, mem_value);
-      } else {
-        byteValue = extractBytes(orgLoad.get(), m, m + bytesize);
-      }
-    } else if (v.isRef) {
+    if (v.isRef) {
+      // Active union member is ref — do not access memoryAddress (UB).
       byteValue = extractBytes(v.ref.value, v.ref.byteOffset,
                                v.ref.byteOffset + bytesize);
-    } else if (!v.isRef && read_mem) {
-      byteValue = builder->getIntN(bytesize * 8, mem_value);
-    } else if (!v.isRef) {
-      // Concrete read is unresolved when file mapping is unavailable.
-      byteValue = extractBytes(orgLoad.get(), m, m + bytesize);
+    } else {
+      // Active union member is memoryAddress — safe to read.
+      uint64_t mem_value;
+      auto read_mem = file.readMemory(v.memoryAddress, bytesize, mem_value);
+      printvalue2(read_mem);
+      printvalue2(mem_value);
+      if (memoryPolicy.isSymbolic(v.memoryAddress)) {
+        // Symbolic address: preserve symbolic fallback when concrete mapping
+        // is not proven.
+        if (read_mem) {
+          byteValue = builder->getIntN(bytesize * 8, mem_value);
+        } else {
+          byteValue = extractBytes(orgLoad.get(), m, m + bytesize);
+        }
+      } else if (read_mem) {
+        byteValue = builder->getIntN(bytesize * 8, mem_value);
+      } else {
+        // Concrete read is unresolved when file mapping is unavailable.
+        byteValue = extractBytes(orgLoad.get(), m, m + bytesize);
+      }
     }
     if (byteValue) {
       printvalue(byteValue);

--- a/scripts/review/format_comment.py
+++ b/scripts/review/format_comment.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+_SEVERITY_ORDER = {"P0": 0, "P1": 1, "P2": 2, "P3": 3}
+
+_STATUS_ICON = {"PASS": "\u2705", "FAIL": "\u274c", "SKIP": "\u23ed\ufe0f"}
+
+
+def _verdict(payload: dict[str, Any]) -> str:
+    """Determine review verdict from invariant results and verification runs.
+
+    FAIL in either → request_changes.  Otherwise → approve.
+    """
+    for result in payload.get("invariant_results", []):
+        if str(result.get("status", "")).upper() == "FAIL":
+            return "request_changes"
+    for run in payload.get("verification_runs", []):
+        if str(run.get("status", "")).upper() == "FAIL":
+            return "request_changes"
+    return "approve"
+
+
+def build_markdown(payload: dict[str, Any]) -> str:
+    """Render a full PR review comment from the orchestrator payload."""
+    base = payload.get("base", "main")
+    head = payload.get("head", "HEAD")
+    changed_files: list[str] = payload.get("changed_files", [])
+    diff_stat: str = payload.get("diff_stat", "")
+
+    risk_map: dict[str, Any] = payload.get("risk_map", {})
+    shards: dict[str, Any] = payload.get("shards", {})
+    invariant_results: list[dict[str, Any]] = payload.get("invariant_results", [])
+    verification_plan: list[dict[str, Any]] = payload.get("verification_plan", [])
+    verification_runs: list[dict[str, Any]] = payload.get("verification_runs", [])
+
+    overall_risk = risk_map.get("overall_risk", "P3")
+    docs_only = risk_map.get("docs_only", False)
+    verdict = _verdict(payload)
+
+    lines: list[str] = []
+
+    # -- Summary --
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(f"Automated review for `{base}...{head}`")
+    lines.append("")
+    lines.append(f"- **Verdict:** {verdict}")
+    lines.append(f"- **Changed files:** {len(changed_files)}")
+    lines.append(f"- **Overall risk:** {overall_risk}")
+    if diff_stat:
+        lines.append(f"- **Diff stat:** `{diff_stat}`")
+    if docs_only:
+        lines.append("- **Docs-only PR** — no verification needed.")
+    lines.append("")
+
+    # -- Risk Map --
+    buckets: list[dict[str, Any]] = risk_map.get("buckets", [])
+    if buckets:
+        sorted_buckets = sorted(
+            buckets,
+            key=lambda b: (_SEVERITY_ORDER.get(b.get("risk", "P3"), 9), b.get("name", "")),
+        )
+        lines.append("## Risk Map")
+        lines.append("")
+        lines.append("| Bucket | Risk | Files |")
+        lines.append("|--------|------|------:|")
+        for b in sorted_buckets:
+            lines.append(f"| {b.get('name', '?')} | {b.get('risk', '?')} | {b.get('file_count', 0)} |")
+        lines.append("")
+
+    # -- Invariant Checks --
+    if invariant_results:
+        lines.append("## Invariant Checks")
+        lines.append("")
+        for res in invariant_results:
+            status = str(res.get("status", "SKIP")).upper()
+            icon = _STATUS_ICON.get(status, "\u2753")
+            check_id = res.get("id", "unknown")
+            lines.append(f"- {icon} **{check_id}**: {status}")
+            for detail in res.get("details", []):
+                lines.append(f"  - {detail}")
+            for f in res.get("files", []):
+                lines.append(f"  - `{f}`")
+        lines.append("")
+
+    # -- Verification Plan --
+    if verification_plan:
+        lines.append("## Verification Plan")
+        lines.append("")
+        for check in verification_plan:
+            check_id = check.get("id", "?")
+            desc = check.get("description", "")
+            cmd = check.get("command", "")
+            bucket_list = ", ".join(check.get("buckets", []))
+            label = f"{check_id}: {desc}" if desc else check_id
+            line = f"- **{label}** — `{cmd}`"
+            if bucket_list:
+                line += f" (buckets: {bucket_list})"
+            lines.append(line)
+        lines.append("")
+
+    # -- Verification Execution --
+    if verification_runs:
+        lines.append("## Verification Execution")
+        lines.append("")
+        for run in verification_runs:
+            status = str(run.get("status", "unknown")).upper()
+            icon = _STATUS_ICON.get(status, "\u2753")
+            cmd = run.get("command", "")
+            run_id = run.get("id", "?")
+            exit_code = run.get("exit_code")
+            line = f"- {icon} **{run_id}**: {status}"
+            if exit_code is not None:
+                line += f" (exit {exit_code})"
+            line += f" — `{cmd}`"
+            lines.append(line)
+        lines.append("")
+
+    # -- Shards --
+    shard_list: list[dict[str, Any]] = shards.get("shards", [])
+    if shard_list:
+        lines.append("## Shards")
+        lines.append("")
+        lines.append(f"Total shards: {shards.get('total_shards', len(shard_list))}")
+        lines.append("")
+        for s in shard_list:
+            name = s.get("name", "?")
+            risk = s.get("risk", "?")
+            file_count = len(s.get("files", []))
+            lines.append(f"- **{name}** ({risk}, {file_count} files): {s.get('description', '')}")
+        lines.append("")
+
+    # -- Artifacts --
+    lines.append("## Artifacts")
+    lines.append("")
+    lines.append("- `artifacts/review/risk_map.json`")
+    lines.append("- `artifacts/review/shards.json`")
+    lines.append("- `artifacts/review/verification_plan.json`")
+    lines.append("- `artifacts/review/invariants.json`")
+    lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render markdown review comment from review payload JSON",
+    )
+    parser.add_argument("--input", type=Path, required=True, help="Input review payload JSON")
+    parser.add_argument("--out", type=Path, default=None, help="Optional output markdown path")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    payload = json.loads(args.input.read_text(encoding="utf-8"))
+    markdown = build_markdown(payload)
+    if args.out is not None:
+        out_path = args.out.resolve()
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(markdown, encoding="utf-8")
+        print(f"Wrote formatted comment to {out_path}")
+    else:
+        print(markdown)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/review/invariant_guard.py
+++ b/scripts/review/invariant_guard.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+THIS_DIR = Path(__file__).resolve().parent
+if str(THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(THIS_DIR))
+
+from review_buckets import load_changed_paths, normalize_path
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    id: str
+    status: str
+    files: list[str]
+    details: list[str]
+
+
+_XMM_HEX_RE = re.compile(r"^0x[0-9a-fA-F]{32}$")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run high-signal invariant checks for review")
+    parser.add_argument("--base", default="main", help="Base revision")
+    parser.add_argument("--head", default="HEAD", help="Head revision")
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[2])
+    parser.add_argument(
+        "--paths",
+        nargs="*",
+        default=None,
+        help="Optional explicit changed paths (bypasses git diff)",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Run all invariant checks regardless of changed paths",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON output",
+    )
+    return parser.parse_args()
+
+
+def _read_text(repo_root: Path, rel_path: str) -> str:
+    return (repo_root / rel_path).read_text(encoding="utf-8")
+
+
+def _load_json(repo_root: Path, rel_path: str) -> object:
+    raw = _read_text(repo_root, rel_path)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"{rel_path} is not valid JSON: {exc.msg} (line {exc.lineno}, column {exc.colno})"
+        ) from exc
+
+
+def _contains_all(text: str, tokens: Iterable[str]) -> list[str]:
+    missing: list[str] = []
+    for token in tokens:
+        if token not in text:
+            missing.append(token)
+    return missing
+
+
+def _check_backend_invariants(repo_root: Path) -> CheckResult:
+    files = ["cmake/FindIced-Wrapper.cmake", "scripts/dev/configure_zydis.cmd"]
+    details: list[str] = []
+
+    try:
+        find_iced = _read_text(repo_root, files[0])
+        configure_zydis = _read_text(repo_root, files[1])
+    except OSError as exc:
+        return CheckResult(
+            id="backend_invariants",
+            status="FAIL",
+            files=files,
+            details=[f"failed to read backend files: {exc}"],
+        )
+
+    missing_find_iced = _contains_all(
+        find_iced,
+        (
+            "remove_definitions(-DICED_FOUND -DICED_NOT_FOUND)",
+            "if (BUILD_WITH_ZYDIS)",
+            "set(ICED_NOT_FOUND TRUE CACHE BOOL",
+            "set(ICED_FOUND FALSE CACHE BOOL",
+            "add_compile_definitions(ICED_NOT_FOUND)",
+            "if (DEFINED CARGO_EXECUTABLE AND NOT \"${CARGO_EXECUTABLE}\" STREQUAL \"\")",
+            "if (EXISTS \"${CARGO_EXECUTABLE}\")",
+            "set(_MERGEN_CARGO_EXECUTABLE \"${CARGO_EXECUTABLE}\")",
+            "set(ICED_FOUND TRUE CACHE BOOL",
+            "set(ICED_NOT_FOUND FALSE CACHE BOOL",
+            "add_compile_definitions(ICED_FOUND)",
+        ),
+    )
+    if missing_find_iced:
+        details.append(
+            "cmake/FindIced-Wrapper.cmake is missing required backend/cargo guard tokens: "
+            + ", ".join(missing_find_iced)
+        )
+
+    missing_configure_zydis = _contains_all(
+        configure_zydis,
+        (
+            "-UICED_*",
+            "-UCARGO_EXECUTABLE",
+            "-DBUILD_WITH_ZYDIS=ON",
+            "if exist \"%BUILD_DIR%\\CMakeCache.txt\"",
+        ),
+    )
+    if missing_configure_zydis:
+        details.append(
+            "scripts/dev/configure_zydis.cmd is missing backend cache hygiene tokens: "
+            + ", ".join(missing_configure_zydis)
+        )
+
+    status = "PASS" if not details else "FAIL"
+    if status == "PASS":
+        details.append("Backend cache/cargo invariants satisfied")
+
+    return CheckResult(id="backend_invariants", status=status, files=files, details=details)
+
+
+def _validate_case_name(case_name: object, *, path: str, index: int) -> str:
+    if not isinstance(case_name, str) or not case_name.strip():
+        raise ValueError(f"{path} case[{index}] has invalid name {case_name!r}; expected non-empty string")
+    return case_name.strip()
+
+
+def _validate_skip(skip_value: object, *, path: str, index: int) -> bool:
+    if not isinstance(skip_value, bool):
+        raise ValueError(
+            f"{path} case[{index}] has invalid 'skip' value {skip_value!r}; expected boolean"
+        )
+    return skip_value
+
+
+def _validate_register_value(path: str, case_name: str, reg_name: str, value: object) -> list[str]:
+    errors: list[str] = []
+
+    if value is None:
+        return errors
+
+    if not isinstance(value, str):
+        errors.append(
+            f"{path} case '{case_name}' register '{reg_name}' has non-string value {value!r}; expected hex string"
+        )
+        return errors
+
+    if reg_name.upper().startswith("XMM") and not _XMM_HEX_RE.fullmatch(value):
+        errors.append(
+            f"{path} case '{case_name}' register '{reg_name}' has non-128-bit value {value!r}; expected 0x + 32 hex digits"
+        )
+
+    return errors
+
+
+def _extract_register_maps(case: dict) -> list[dict[str, object]]:
+    maps: list[dict[str, object]] = []
+
+    for section in ("initial", "expected"):
+        payload = case.get(section)
+        if isinstance(payload, dict):
+            regs = payload.get("registers")
+            if isinstance(regs, dict):
+                maps.append(regs)
+
+    oracle_observations = case.get("oracle_observations")
+    if isinstance(oracle_observations, dict):
+        for provider_payload in oracle_observations.values():
+            if not isinstance(provider_payload, dict):
+                continue
+            regs = provider_payload.get("registers")
+            if isinstance(regs, dict):
+                maps.append(regs)
+
+    return maps
+
+
+def _check_vector_file(repo_root: Path, rel_path: str) -> CheckResult:
+    details: list[str] = []
+    try:
+        payload = _load_json(repo_root, rel_path)
+    except ValueError as exc:
+        return CheckResult(id=f"vector_file:{rel_path}", status="FAIL", files=[rel_path], details=[str(exc)])
+    except OSError as exc:
+        return CheckResult(id=f"vector_file:{rel_path}", status="FAIL", files=[rel_path], details=[str(exc)])
+
+    if not isinstance(payload, dict):
+        return CheckResult(
+            id=f"vector_file:{rel_path}",
+            status="FAIL",
+            files=[rel_path],
+            details=[f"{rel_path} must be a JSON object"],
+        )
+
+    schema = payload.get("schema")
+    filename = Path(rel_path).name
+    if filename.startswith("oracle_vectors") and schema != "mergen-oracle-v1":
+        details.append(
+            f"{rel_path} has schema {schema!r}; expected 'mergen-oracle-v1'"
+        )
+    if filename == "oracle_seed_vectors.json" and schema != "mergen-oracle-seed-v1":
+        details.append(
+            f"{rel_path} has schema {schema!r}; expected 'mergen-oracle-seed-v1'"
+        )
+
+    cases = payload.get("cases")
+    if not isinstance(cases, list):
+        details.append(f"{rel_path} has invalid 'cases' field; expected array")
+        return CheckResult(
+            id=f"vector_file:{rel_path}",
+            status="FAIL",
+            files=[rel_path],
+            details=details,
+        )
+
+    seen_names: set[str] = set()
+    for index, case in enumerate(cases):
+        if not isinstance(case, dict):
+            details.append(f"{rel_path} case[{index}] must be an object")
+            continue
+
+        try:
+            case_name = _validate_case_name(case.get("name"), path=rel_path, index=index)
+        except ValueError as exc:
+            details.append(str(exc))
+            case_name = f"case_{index}"
+
+        if case_name in seen_names:
+            details.append(f"{rel_path} duplicate case name '{case_name}'")
+        else:
+            seen_names.add(case_name)
+
+        if "skip" in case:
+            try:
+                _validate_skip(case.get("skip"), path=rel_path, index=index)
+            except ValueError as exc:
+                details.append(str(exc))
+
+        handler_value = case.get("handler")
+        if handler_value is not None and not isinstance(handler_value, str):
+            details.append(
+                f"{rel_path} case '{case_name}' has invalid handler {handler_value!r}; expected string"
+            )
+
+        for register_map in _extract_register_maps(case):
+            for reg_name, value in register_map.items():
+                details.extend(_validate_register_value(rel_path, case_name, str(reg_name), value))
+
+    status = "PASS" if not details else "FAIL"
+    if status == "PASS":
+        details.append(f"{rel_path} passed schema/shape/register-width checks")
+
+    return CheckResult(id=f"vector_file:{rel_path}", status=status, files=[rel_path], details=details)
+
+
+def _validate_pattern_descriptor(sample_name: str, descriptor: object, rel_path: str, details: list[str]) -> None:
+    if isinstance(descriptor, str):
+        if not descriptor.strip():
+            details.append(
+                f"{rel_path} sample '{sample_name}' has empty string pattern descriptor"
+            )
+        return
+
+    if isinstance(descriptor, dict) and "line_all" in descriptor:
+        tokens = descriptor.get("line_all")
+        if not isinstance(tokens, list) or not tokens:
+            details.append(
+                f"{rel_path} sample '{sample_name}' line_all descriptor must be a non-empty array"
+            )
+            return
+
+        bad = [token for token in tokens if not isinstance(token, str) or not token.strip()]
+        if bad:
+            details.append(
+                f"{rel_path} sample '{sample_name}' line_all descriptor contains empty/non-string token"
+            )
+        return
+
+    details.append(
+        f"{rel_path} sample '{sample_name}' has unsupported pattern descriptor {descriptor!r}"
+    )
+
+
+def _check_microtest_manifest(repo_root: Path, rel_path: str) -> CheckResult:
+    details: list[str] = []
+    try:
+        payload = _load_json(repo_root, rel_path)
+    except ValueError as exc:
+        return CheckResult(id="microtest_manifest", status="FAIL", files=[rel_path], details=[str(exc)])
+    except OSError as exc:
+        return CheckResult(id="microtest_manifest", status="FAIL", files=[rel_path], details=[str(exc)])
+
+    if not isinstance(payload, dict):
+        return CheckResult(
+            id="microtest_manifest",
+            status="FAIL",
+            files=[rel_path],
+            details=[f"{rel_path} must be a JSON object with top-level 'samples' field"],
+        )
+
+    samples = payload.get("samples")
+    if not isinstance(samples, list) or not samples:
+        return CheckResult(
+            id="microtest_manifest",
+            status="FAIL",
+            files=[rel_path],
+            details=[f"{rel_path} must contain non-empty 'samples' array"],
+        )
+
+    seen_names: set[str] = set()
+    for index, sample in enumerate(samples):
+        if not isinstance(sample, dict):
+            details.append(f"{rel_path} sample[{index}] must be an object")
+            continue
+
+        name = sample.get("name")
+        if not isinstance(name, str) or not name.strip() or ".." in name or "/" in name or "\\" in name:
+            details.append(
+                f"{rel_path} sample[{index}] has invalid name {name!r}; expected safe non-empty basename"
+            )
+            sample_name = f"sample_{index}"
+        else:
+            sample_name = name.strip()
+
+        if sample_name in seen_names:
+            details.append(f"{rel_path} duplicate sample name '{sample_name}'")
+        else:
+            seen_names.add(sample_name)
+
+        skip_value = sample.get("skip", False)
+        if not isinstance(skip_value, bool):
+            details.append(
+                f"{rel_path} sample '{sample_name}' has invalid skip value {skip_value!r}; expected boolean"
+            )
+            is_skipped = False
+        else:
+            is_skipped = skip_value
+
+        if "patterns" in sample:
+            patterns = sample.get("patterns")
+            if isinstance(patterns, str):
+                details.append(
+                    f"{rel_path} sample '{sample_name}' patterns must be an array; got string"
+                )
+            elif not isinstance(patterns, list):
+                details.append(
+                    f"{rel_path} sample '{sample_name}' patterns must be an array"
+                )
+            elif not patterns:
+                if not is_skipped:
+                    details.append(
+                        f"{rel_path} sample '{sample_name}' patterns must not be empty unless skip=true"
+                    )
+            else:
+                for descriptor in patterns:
+                    _validate_pattern_descriptor(sample_name, descriptor, rel_path, details)
+
+    status = "PASS" if not details else "FAIL"
+    if status == "PASS":
+        details.append(f"{rel_path} passed manifest shape and descriptor checks")
+
+    return CheckResult(id="microtest_manifest", status=status, files=[rel_path], details=details)
+
+
+def _collect_vector_targets(changed_paths: list[str], run_all: bool) -> list[str]:
+    targets: set[str] = set()
+    if run_all:
+        targets.add("lifter/test/test_vectors/oracle_vectors.json")
+        targets.add("lifter/test/test_vectors/oracle_vectors_full_handlers.json")
+        targets.add("scripts/rewrite/oracle_seed_vectors.json")
+
+    for path in changed_paths:
+        normalized = normalize_path(path)
+        if normalized.startswith("lifter/test/test_vectors/") and Path(normalized).name in {
+            "oracle_vectors.json",
+            "oracle_vectors_full_handlers.json",
+        }:
+            targets.add(normalized)
+        if normalized == "scripts/rewrite/oracle_seed_vectors.json":
+            targets.add(normalized)
+
+    return sorted(targets)
+
+
+def _should_run_backend(changed_paths: list[str], run_all: bool) -> bool:
+    if run_all:
+        return True
+    for path in changed_paths:
+        normalized = normalize_path(path)
+        if normalized in {
+            "cmake/FindIced-Wrapper.cmake",
+            "scripts/dev/configure_zydis.cmd",
+            "scripts/dev/configure_iced.cmd",
+        }:
+            return True
+    return False
+
+
+def _should_run_manifest(changed_paths: list[str], run_all: bool) -> bool:
+    if run_all:
+        return True
+    return any(
+        normalize_path(path) == "scripts/rewrite/instruction_microtests.json"
+        for path in changed_paths
+    )
+
+
+def run_invariant_guard(repo_root: Path, changed_paths: list[str], run_all: bool) -> list[CheckResult]:
+    results: list[CheckResult] = []
+
+    if _should_run_backend(changed_paths, run_all):
+        results.append(_check_backend_invariants(repo_root))
+
+    for target in _collect_vector_targets(changed_paths, run_all):
+        results.append(_check_vector_file(repo_root, target))
+
+    if _should_run_manifest(changed_paths, run_all):
+        results.append(_check_microtest_manifest(repo_root, "scripts/rewrite/instruction_microtests.json"))
+
+    if not results:
+        results.append(
+            CheckResult(
+                id="no_checks_selected",
+                status="SKIP",
+                files=[],
+                details=["No invariant checks selected for changed files"],
+            )
+        )
+
+    return results
+
+
+def _payload(results: list[CheckResult]) -> dict:
+    return {
+        "total_checks": len(results),
+        "failed": [result.id for result in results if result.status == "FAIL"],
+        "results": [
+            {
+                "id": result.id,
+                "status": result.status,
+                "files": result.files,
+                "details": result.details,
+            }
+            for result in results
+        ],
+    }
+
+
+def _render_text(results: list[CheckResult]) -> str:
+    lines: list[str] = []
+    for result in results:
+        lines.append(f"[{result.status}] {result.id}")
+        if result.files:
+            lines.append(f"  files: {', '.join(result.files)}")
+        for detail in result.details:
+            lines.append(f"  - {detail}")
+
+    failed = [result.id for result in results if result.status == "FAIL"]
+    lines.append("")
+    if failed:
+        lines.append(f"Invariant guard FAILED ({len(failed)} checks failed): {', '.join(failed)}")
+    else:
+        lines.append("Invariant guard passed")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    args = _parse_args()
+    repo_root = args.repo_root.resolve()
+
+    if args.paths:
+        changed_paths = [normalize_path(path) for path in args.paths]
+    else:
+        changed_paths = load_changed_paths(repo_root, args.base, args.head)
+
+    results = run_invariant_guard(repo_root, changed_paths, args.all)
+    failures = [result for result in results if result.status == "FAIL"]
+
+    if args.json:
+        print(json.dumps(_payload(results), indent=2))
+    else:
+        print(_render_text(results))
+
+    if failures:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/review/review_buckets.py
+++ b/scripts/review/review_buckets.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+@dataclass(frozen=True)
+class CheckCommand:
+    id: str
+    description: str
+    argv: tuple[str, ...]
+
+    @property
+    def shell_preview(self) -> str:
+        return subprocess.list2cmdline(list(self.argv))
+
+
+@dataclass(frozen=True)
+class BucketSpec:
+    name: str
+    description: str
+    patterns: tuple[re.Pattern[str], ...]
+    default_risk: str
+    required_check_ids: tuple[str, ...]
+
+
+_RISK_RANK = {
+    "P0": 0,
+    "P1": 1,
+    "P2": 2,
+    "P3": 3,
+}
+
+
+_CHECK_SPECS: tuple[tuple[str, str, tuple[str, ...]], ...] = (
+    (
+        "micro_flags",
+        "Run microtests with strict flag checks",
+        ("python", "test.py", "micro", "--check-flags"),
+    ),
+    (
+        "negative",
+        "Run explicit negative contract checks",
+        ("python", "test.py", "negative"),
+    ),
+    (
+        "baseline",
+        "Run rewrite baseline gate",
+        ("python", "test.py", "baseline"),
+    ),
+    (
+        "coverage_full",
+        "Run handler coverage collection",
+        ("python", "test.py", "coverage", "--full"),
+    ),
+    (
+        "report_json",
+        "Emit coverage report JSON",
+        ("python", "test.py", "report", "--json"),
+    ),
+    (
+        "configure_iced",
+        "Configure iced backend lane",
+        ("cmd", "/c", "scripts\\dev\\configure_iced.cmd"),
+    ),
+    (
+        "build_iced",
+        "Build iced backend lane",
+        ("cmd", "/c", "scripts\\dev\\build_iced.cmd"),
+    ),
+    (
+        "configure_zydis",
+        "Configure zydis backend lane",
+        ("cmd", "/c", "scripts\\dev\\configure_zydis.cmd"),
+    ),
+    (
+        "build_zydis",
+        "Build zydis backend lane",
+        ("cmd", "/c", "scripts\\dev\\build_zydis.cmd"),
+    ),
+    (
+        "review_py_compile",
+        "Compile review automation scripts",
+        (
+            "python",
+            "-m",
+            "compileall",
+            "scripts/review",
+        ),
+    ),
+)
+
+
+_BUCKET_SPECS: tuple[tuple[str, str, str, tuple[str, ...], tuple[str, ...]], ...] = (
+    (
+        "build_and_scope",
+        "CMake/backend selection, dev scripts, and scope docs",
+        "P1",
+        ("configure_iced", "build_iced", "configure_zydis", "build_zydis"),
+        (
+            r"^cmake/",
+            r"^scripts/dev/",
+            r"^docs/SCOPE\.md$",
+            r"^\.github/workflows/",
+        ),
+    ),
+    (
+        "rewrite_ops_baseline",
+        "Rewrite gate orchestration, baseline docs, and test runner",
+        "P1",
+        ("negative", "baseline"),
+        (
+            r"^docs/REWRITE_BASELINE\.md$",
+            r"^scripts/rewrite/(run\.ps1|verify\.ps1|manifest_validation\.ps1)$",
+            r"^test\.py$",
+        ),
+    ),
+    (
+        "core_orchestration",
+        "Lifter entrypoint/stage/pipeline orchestration",
+        "P1",
+        ("micro_flags",),
+        (
+            r"^lifter/core/(Lifter\.cpp|LifterApplication\.hpp|LifterStages\.hpp|MergenPB\.hpp|FunctionSignatures\.hpp)$",
+        ),
+    ),
+    (
+        "runtime_context_utils",
+        "Runtime image mapping, utility helpers, and concolic register model",
+        "P1",
+        ("micro_flags",),
+        (
+            r"^lifter/core/(RuntimeImageContext\.hpp|Utils\.cpp|Utils\.h|LifterClass\.hpp|LifterClass_Concolic\.hpp)$",
+        ),
+    ),
+    (
+        "disasm_operand_types",
+        "Operand type plumbing across Rust/C++ disassembler layers",
+        "P1",
+        ("micro_flags",),
+        (
+            r"^icpped_rust/src/lib\.rs$",
+            r"^lifter/disasm/",
+            r"^lifter/semantics/OperandUtils\.ipp$",
+        ),
+    ),
+    (
+        "semantics_and_tests",
+        "Opcode/semantics handlers and in-process lifter tests",
+        "P1",
+        ("micro_flags",),
+        (
+            r"^lifter/semantics/(?!OperandUtils\.ipp).+",
+            r"^lifter/test/(TestInstructions\.cpp|Tester\.hpp)$",
+        ),
+    ),
+    (
+        "rewrite_generation_python",
+        "Oracle/coverage generation Python pipeline",
+        "P1",
+        ("negative", "baseline"),
+        (
+            r"^scripts/rewrite/(generate_oracle_vectors\.py|sleigh_oracle\.py)$",
+        ),
+    ),
+    (
+        "coverage_pipeline",
+        "Opcode coverage plumbing and coverage/report scripts",
+        "P1",
+        ("coverage_full", "report_json"),
+        (
+            r"^lifter/semantics/x86_64_opcodes\.x$",
+            r"^scripts/rewrite/(collect_instruction_tests\.py|report_coverage\.py)$",
+        ),
+    ),
+    (
+        "vector_artifacts",
+        "Oracle vectors, microtest manifests, and golden hashes",
+        "P1",
+        ("coverage_full", "report_json"),
+        (
+            r"^lifter/test/test_vectors/",
+            r"^scripts/rewrite/(instruction_microtests\.json|oracle_seed_vectors\.json)$",
+        ),
+    ),
+    (
+        "review_tooling",
+        "Review automation and PR sharding scripts",
+        "P2",
+        ("review_py_compile",),
+        (
+            r"^scripts/review/",
+        ),
+    ),
+    (
+        "docs_general",
+        "Documentation-only changes outside scoped buckets",
+        "P3",
+        tuple(),
+        (
+            r"^docs/.+\.md$",
+        ),
+    ),
+)
+
+
+CHECKS: tuple[CheckCommand, ...] = tuple(
+    CheckCommand(id=check_id, description=description, argv=argv)
+    for check_id, description, argv in _CHECK_SPECS
+)
+CHECKS_BY_ID = {check.id: check for check in CHECKS}
+
+BUCKETS: tuple[BucketSpec, ...] = tuple(
+    BucketSpec(
+        name=name,
+        description=description,
+        patterns=tuple(re.compile(spec) for spec in patterns),
+        default_risk=default_risk,
+        required_check_ids=required_check_ids,
+    )
+    for name, description, default_risk, required_check_ids, patterns in _BUCKET_SPECS
+)
+BUCKETS_BY_NAME = {bucket.name: bucket for bucket in BUCKETS}
+
+
+def normalize_path(path: str) -> str:
+    return path.replace("\\", "/")
+
+
+def load_changed_paths(repo_root: Path, base: str, head: str) -> list[str]:
+    cmd = [
+        "git",
+        "diff",
+        "--name-status",
+        "--no-color",
+        f"{base}...{head}",
+    ]
+    result = subprocess.run(
+        cmd,
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "git diff failed")
+
+    paths: list[str] = []
+    for raw_line in result.stdout.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        paths.append(normalize_path(parts[-1]))
+    return paths
+
+
+def bucket_for_path(path: str) -> str:
+    normalized = normalize_path(path)
+    for bucket in BUCKETS:
+        if any(pattern.search(normalized) for pattern in bucket.patterns):
+            return bucket.name
+    return "unassigned"
+
+
+def bucket_paths(paths: Iterable[str]) -> dict[str, list[str]]:
+    grouped: dict[str, list[str]] = {}
+    for raw in paths:
+        path = normalize_path(raw)
+        grouped.setdefault(bucket_for_path(path), []).append(path)
+
+    deduped: dict[str, list[str]] = {}
+    for bucket, entries in grouped.items():
+        deduped[bucket] = sorted(set(entries))
+    return deduped
+
+
+def chunk_paths(items: Sequence[str], max_size: int) -> list[list[str]]:
+    if max_size <= 0:
+        return [list(items)]
+    return [list(items[idx : idx + max_size]) for idx in range(0, len(items), max_size)]
+
+
+def bucket_description(bucket_name: str) -> str:
+    bucket = BUCKETS_BY_NAME.get(bucket_name)
+    if bucket:
+        return bucket.description
+    return "Paths that did not match predefined review buckets"
+
+
+def bucket_required_checks(bucket_name: str) -> tuple[CheckCommand, ...]:
+    bucket = BUCKETS_BY_NAME.get(bucket_name)
+    if not bucket:
+        return tuple()
+
+    checks: list[CheckCommand] = []
+    for check_id in bucket.required_check_ids:
+        check = CHECKS_BY_ID.get(check_id)
+        if check:
+            checks.append(check)
+    return tuple(checks)
+
+
+def _all_docs(paths: Sequence[str]) -> bool:
+    return bool(paths) and all(path.lower().endswith(".md") for path in paths)
+
+
+def bucket_risk(bucket_name: str, files: Sequence[str]) -> str:
+    if bucket_name == "unassigned":
+        return "P2"
+
+    bucket = BUCKETS_BY_NAME.get(bucket_name)
+    if not bucket:
+        return "P2"
+
+    if _all_docs(files):
+        return "P3"
+
+    return bucket.default_risk
+
+
+def risk_rank(risk: str) -> int:
+    return _RISK_RANK.get(risk, 99)
+
+
+def highest_risk(risks: Iterable[str]) -> str:
+    known = [risk for risk in risks if risk in _RISK_RANK]
+    if not known:
+        return "P3"
+    return min(known, key=risk_rank)
+
+
+def required_checks_for_buckets(bucket_names: Sequence[str]) -> list[CheckCommand]:
+    ordered_checks: list[CheckCommand] = []
+    seen: set[str] = set()
+
+    for bucket_name in bucket_names:
+        for check in bucket_required_checks(bucket_name):
+            if check.id in seen:
+                continue
+            seen.add(check.id)
+            ordered_checks.append(check)
+
+    return ordered_checks
+
+
+def bucket_order(bucket_names: Iterable[str]) -> list[str]:
+    names = set(bucket_names)
+    ordered = [bucket.name for bucket in BUCKETS if bucket.name in names]
+    if "unassigned" in names:
+        ordered.append("unassigned")
+    return ordered

--- a/scripts/review/risk_map.py
+++ b/scripts/review/risk_map.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+if str(THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(THIS_DIR))
+
+from review_buckets import (
+    bucket_description,
+    bucket_order,
+    bucket_paths,
+    bucket_required_checks,
+    bucket_risk,
+    highest_risk,
+    load_changed_paths,
+    normalize_path,
+    required_checks_for_buckets,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate risk map for a PR diff")
+    parser.add_argument("--base", default="main", help="Base revision")
+    parser.add_argument("--head", default="HEAD", help="Head revision")
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[2])
+    parser.add_argument(
+        "--paths",
+        nargs="*",
+        default=None,
+        help="Optional explicit changed paths (bypasses git diff)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON payload (default emits plain text summary)",
+    )
+    return parser.parse_args()
+
+
+def _is_docs_only(paths: list[str]) -> bool:
+    return bool(paths) and all(path.lower().endswith(".md") for path in paths)
+
+
+def build_payload(paths: list[str]) -> dict:
+    grouped = bucket_paths(paths)
+    ordered_buckets = bucket_order(grouped.keys())
+
+    buckets_payload: list[dict] = []
+    for bucket_name in ordered_buckets:
+        files = grouped[bucket_name]
+        checks = list(bucket_required_checks(bucket_name))
+        buckets_payload.append(
+            {
+                "name": bucket_name,
+                "description": bucket_description(bucket_name),
+                "risk": bucket_risk(bucket_name, files),
+                "file_count": len(files),
+                "files": files,
+                "required_checks": [
+                    {
+                        "id": check.id,
+                        "description": check.description,
+                        "command": check.shell_preview,
+                    }
+                    for check in checks
+                ],
+            }
+        )
+
+    overall_risk = highest_risk([entry["risk"] for entry in buckets_payload])
+    required_checks = required_checks_for_buckets(ordered_buckets)
+    has_unassigned = "unassigned" in grouped
+
+    risk_counts: dict[str, int] = {}
+    for entry in buckets_payload:
+        risk = entry["risk"]
+        risk_counts[risk] = risk_counts.get(risk, 0) + 1
+
+    return {
+        "total_files": len(paths),
+        "total_buckets": len(buckets_payload),
+        "docs_only": _is_docs_only(paths),
+        "overall_risk": overall_risk,
+        "manual_review_required": has_unassigned,
+        "risk_bucket_counts": risk_counts,
+        "required_checks": [
+            {
+                "id": check.id,
+                "description": check.description,
+                "command": check.shell_preview,
+            }
+            for check in required_checks
+        ],
+        "buckets": buckets_payload,
+    }
+
+
+def _render_text(payload: dict) -> str:
+    lines: list[str] = []
+    lines.append(f"Overall risk: {payload['overall_risk']}")
+    lines.append(f"Changed files: {payload['total_files']}")
+    lines.append(f"Buckets: {payload['total_buckets']}")
+    lines.append(f"Docs only: {'yes' if payload['docs_only'] else 'no'}")
+    if payload["manual_review_required"]:
+        lines.append("Manual review required: yes (unassigned paths present)")
+    else:
+        lines.append("Manual review required: no")
+
+    lines.append("")
+    lines.append("Buckets:")
+    for bucket in payload["buckets"]:
+        lines.append(f"- [{bucket['risk']}] {bucket['name']} ({bucket['file_count']} files)")
+        lines.append(f"  {bucket['description']}")
+        for file_path in bucket["files"]:
+            lines.append(f"    - {file_path}")
+        if bucket["required_checks"]:
+            lines.append("  Required checks:")
+            for check in bucket["required_checks"]:
+                lines.append(f"    - {check['id']}: {check['command']}")
+
+    lines.append("")
+    lines.append("Aggregate required checks:")
+    if payload["required_checks"]:
+        for check in payload["required_checks"]:
+            lines.append(f"- {check['id']}: {check['command']}")
+    else:
+        lines.append("- none")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    args = _parse_args()
+    repo_root = args.repo_root.resolve()
+
+    if args.paths:
+        changed_paths = [normalize_path(path) for path in args.paths]
+    else:
+        changed_paths = load_changed_paths(repo_root, args.base, args.head)
+
+    payload = build_payload(changed_paths)
+    if args.json:
+        print(json.dumps(payload, indent=2))
+        return
+
+    print(_render_text(payload))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/review/run_review.py
+++ b/scripts/review/run_review.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+THIS_DIR = Path(__file__).resolve().parent
+if str(THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(THIS_DIR))
+
+import format_comment  # noqa: E402
+import invariant_guard  # noqa: E402
+import risk_map  # noqa: E402
+import shard_pr  # noqa: E402
+import verify_plan  # noqa: E402
+from review_buckets import load_changed_paths, normalize_path  # noqa: E402
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run Mergen review automation")
+    parser.add_argument("--base", default="main", help="Base revision")
+    parser.add_argument("--head", default="HEAD", help="Head revision")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[2],
+        help="Repository root",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path(__file__).resolve().parents[2] / "artifacts/review",
+        help="Directory to write review artifacts",
+    )
+    parser.add_argument(
+        "--max-files-per-shard",
+        type=int,
+        default=5,
+        help="Maximum files per review shard",
+    )
+    parser.add_argument(
+        "--run-verification",
+        action="store_true",
+        help="Execute planned verification commands",
+    )
+    parser.add_argument(
+        "--paths",
+        nargs="*",
+        default=None,
+        help="Optional explicit changed paths (bypasses git diff)",
+    )
+    return parser.parse_args()
+
+
+def _invariant_result_to_dict(result: invariant_guard.CheckResult) -> dict[str, Any]:
+    return {
+        "id": result.id,
+        "status": result.status,
+        "files": result.files,
+        "details": result.details,
+    }
+
+
+def _planned_check_to_dict(item: verify_plan.PlannedCheck) -> dict[str, Any]:
+    return {
+        "id": item.command.id,
+        "description": item.command.description,
+        "command": item.command.shell_preview,
+        "buckets": item.buckets,
+    }
+
+
+def main() -> None:
+    args = _parse_args()
+    repo_root = args.repo_root.resolve()
+    output_dir = args.output_dir.resolve()
+
+    # 1. Load changed paths
+    if args.paths:
+        changed_paths = [normalize_path(path) for path in args.paths]
+    else:
+        changed_paths = load_changed_paths(repo_root, args.base, args.head)
+
+    # 2. Risk assessment
+    risk_payload = risk_map.build_payload(changed_paths)
+
+    # 3. PR sharding
+    shard_payload = shard_pr.build_payload(
+        changed_paths, max_files_per_shard=args.max_files_per_shard,
+    )
+
+    # 4. Invariant guard checks
+    invariant_results = invariant_guard.run_invariant_guard(
+        repo_root, changed_paths, run_all=False,
+    )
+    invariant_dicts = [_invariant_result_to_dict(r) for r in invariant_results]
+
+    # 5. Verification plan (invariant guard already ran separately)
+    plan = verify_plan._build_plan(changed_paths, include_invariant_guard=False)
+    plan_dicts = [_planned_check_to_dict(item) for item in plan]
+
+    # 6. Optionally execute verification
+    verification_runs: list[dict[str, Any]] = []
+    if args.run_verification:
+        verification_runs = verify_plan._run_plan(
+            plan, repo_root=repo_root, fail_fast=False,
+        )
+
+    # 7. Assemble review payload
+    review_payload: dict[str, Any] = {
+        "base": args.base,
+        "head": args.head,
+        "changed_files": changed_paths,
+        "risk": risk_payload,
+        "shards": shard_payload,
+        "invariants": invariant_dicts,
+        "verification_plan": plan_dicts,
+        "verification_runs": verification_runs,
+    }
+
+    # 8. Render markdown
+    comment_markdown = format_comment.build_markdown(review_payload)
+
+    # 9. Write artifacts
+    _write_json(output_dir / "risk_map.json", risk_payload)
+    _write_json(output_dir / "shards.json", shard_payload)
+    _write_json(output_dir / "invariants.json", invariant_dicts)
+    _write_json(output_dir / "verification_plan.json", plan_dicts)
+    if verification_runs:
+        _write_json(output_dir / "verification_runs.json", verification_runs)
+    _write_json(output_dir / "review.json", review_payload)
+    comment_path = output_dir / "comment.md"
+    comment_path.parent.mkdir(parents=True, exist_ok=True)
+    comment_path.write_text(comment_markdown, encoding="utf-8")
+
+    print(f"Wrote review artifacts to {output_dir}")
+    print(f"- Changed files: {len(changed_paths)}")
+    print(f"- Overall risk: {risk_payload['overall_risk']}")
+    print(f"- Invariant checks: {len(invariant_results)}")
+    print(f"- Verification checks: {len(plan_dicts)}")
+    print(f"- Comment: {comment_path.as_posix()}")
+
+    # 10. Exit code: 1 if any invariant FAIL or any verification run FAIL
+    has_invariant_failure = any(r.status == "FAIL" for r in invariant_results)
+    has_verification_failure = any(
+        run.get("status") in {"FAIL", "BLOCKED"} for run in verification_runs
+    )
+    raise SystemExit(1 if has_invariant_failure or has_verification_failure else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/review/shard_pr.py
+++ b/scripts/review/shard_pr.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+if str(THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(THIS_DIR))
+
+from review_buckets import (
+    bucket_description,
+    bucket_order,
+    bucket_paths,
+    bucket_required_checks,
+    bucket_risk,
+    chunk_paths,
+    load_changed_paths,
+    normalize_path,
+    required_checks_for_buckets,
+)
+
+
+@dataclass(frozen=True)
+class Shard:
+    name: str
+    files: list[str]
+    description: str
+    source_bucket: str
+    risk: str
+    required_checks: list[str]
+
+
+def shard_paths(paths: list[str], max_files_per_shard: int = 5) -> list[Shard]:
+    grouped = bucket_paths(paths)
+    ordered_buckets = bucket_order(grouped.keys())
+
+    shards: list[Shard] = []
+    for bucket in ordered_buckets:
+        files = grouped[bucket]
+        chunks = chunk_paths(files, max_files_per_shard)
+        checks = [check.id for check in bucket_required_checks(bucket)]
+        risk = bucket_risk(bucket, files)
+
+        for chunk_index, chunk in enumerate(chunks, start=1):
+            suffix = "" if len(chunks) == 1 else f"_{chunk_index}"
+            shards.append(
+                Shard(
+                    name=f"{bucket}{suffix}",
+                    files=chunk,
+                    description=bucket_description(bucket),
+                    source_bucket=bucket,
+                    risk=risk,
+                    required_checks=checks,
+                )
+            )
+
+    return shards
+
+
+def build_payload(paths: list[str], max_files_per_shard: int) -> dict:
+    shards = shard_paths(paths, max_files_per_shard=max_files_per_shard)
+    bucket_names = [shard.source_bucket for shard in shards]
+    required_checks = required_checks_for_buckets(bucket_names)
+
+    return {
+        "total_files": len(paths),
+        "total_shards": len(shards),
+        "max_files_per_shard": max_files_per_shard,
+        "required_checks": [
+            {
+                "id": check.id,
+                "description": check.description,
+                "command": check.shell_preview,
+            }
+            for check in required_checks
+        ],
+        "shards": [asdict(shard) for shard in shards],
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Shard PR changed files into review buckets")
+    parser.add_argument("--base", default="main", help="Base revision")
+    parser.add_argument("--head", default="HEAD", help="Head revision")
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[2])
+    parser.add_argument(
+        "--max-files-per-shard",
+        type=int,
+        default=5,
+        help="Split large buckets into shards of at most this many files",
+    )
+    parser.add_argument(
+        "--paths",
+        nargs="*",
+        default=None,
+        help="Optional explicit changed paths (bypasses git diff)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    repo_root = args.repo_root.resolve()
+    if args.paths:
+        changed_paths = [normalize_path(path) for path in args.paths]
+    else:
+        changed_paths = load_changed_paths(repo_root, args.base, args.head)
+
+    payload = build_payload(changed_paths, max_files_per_shard=args.max_files_per_shard)
+    print(json.dumps(payload, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/review/verify_plan.py
+++ b/scripts/review/verify_plan.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+if str(THIS_DIR) not in sys.path:
+    sys.path.insert(0, str(THIS_DIR))
+
+from review_buckets import (
+    CheckCommand,
+    bucket_order,
+    bucket_paths,
+    bucket_required_checks,
+    load_changed_paths,
+    normalize_path,
+    required_checks_for_buckets,
+)
+
+
+@dataclass(frozen=True)
+class PlannedCheck:
+    command: CheckCommand
+    buckets: list[str]
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create or run targeted verification plan for PR changes")
+    parser.add_argument("--base", default="main", help="Base revision")
+    parser.add_argument("--head", default="HEAD", help="Head revision")
+    parser.add_argument("--repo-root", type=Path, default=Path(__file__).resolve().parents[2])
+    parser.add_argument(
+        "--paths",
+        nargs="*",
+        default=None,
+        help="Optional explicit changed paths (bypasses git diff)",
+    )
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Execute the planned checks in order",
+    )
+    parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Stop immediately when a check fails while running",
+    )
+    parser.add_argument(
+        "--no-invariant-guard",
+        action="store_true",
+        help="Do not prepend scripts/review/invariant_guard.py to the run plan",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON output",
+    )
+    return parser.parse_args()
+
+
+def _docs_only(paths: list[str]) -> bool:
+    return bool(paths) and all(path.lower().endswith(".md") for path in paths)
+
+
+def _build_plan(paths: list[str], include_invariant_guard: bool) -> list[PlannedCheck]:
+    grouped = bucket_paths(paths)
+    ordered_buckets = bucket_order(grouped.keys())
+
+    check_sources: dict[str, list[str]] = {}
+    for bucket in ordered_buckets:
+        for check in bucket_required_checks(bucket):
+            check_sources.setdefault(check.id, []).append(bucket)
+
+    planned = [
+        PlannedCheck(command=check, buckets=check_sources.get(check.id, []))
+        for check in required_checks_for_buckets(ordered_buckets)
+    ]
+
+    if include_invariant_guard and paths and not _docs_only(paths):
+        invariant_cmd = CheckCommand(
+            id="invariant_guard",
+            description="Run review invariant checks",
+            argv=("python", "scripts/review/invariant_guard.py", "--paths", *paths),
+        )
+        planned.insert(0, PlannedCheck(command=invariant_cmd, buckets=ordered_buckets))
+
+    return planned
+
+
+def _run_plan(plan: list[PlannedCheck], repo_root: Path, fail_fast: bool) -> list[dict]:
+    run_results: list[dict] = []
+
+    for item in plan:
+        cmd = list(item.command.argv)
+        try:
+            result = subprocess.run(
+                cmd,
+                cwd=repo_root,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        except OSError as exc:
+            run_results.append(
+                {
+                    "id": item.command.id,
+                    "status": "BLOCKED",
+                    "exit_code": None,
+                    "buckets": item.buckets,
+                    "command": item.command.shell_preview,
+                    "stdout": "",
+                    "stderr": str(exc),
+                }
+            )
+            if fail_fast:
+                break
+            continue
+
+        status = "PASS" if result.returncode == 0 else "FAIL"
+        run_results.append(
+            {
+                "id": item.command.id,
+                "status": status,
+                "exit_code": result.returncode,
+                "buckets": item.buckets,
+                "command": item.command.shell_preview,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+        )
+
+        if status == "FAIL" and fail_fast:
+            break
+
+    return run_results
+
+
+def _plan_payload(paths: list[str], plan: list[PlannedCheck], run_results: list[dict] | None) -> dict:
+    payload = {
+        "total_files": len(paths),
+        "docs_only": _docs_only(paths),
+        "total_checks": len(plan),
+        "checks": [
+            {
+                "id": item.command.id,
+                "description": item.command.description,
+                "command": item.command.shell_preview,
+                "buckets": item.buckets,
+            }
+            for item in plan
+        ],
+    }
+
+    if run_results is not None:
+        payload["run_results"] = run_results
+        payload["failed_checks"] = [entry["id"] for entry in run_results if entry["status"] == "FAIL"]
+        payload["blocked_checks"] = [entry["id"] for entry in run_results if entry["status"] == "BLOCKED"]
+
+    return payload
+
+
+def _render_text(payload: dict) -> str:
+    lines: list[str] = []
+    lines.append(f"Changed files: {payload['total_files']}")
+    lines.append(f"Docs only: {'yes' if payload['docs_only'] else 'no'}")
+    lines.append(f"Planned checks: {payload['total_checks']}")
+    lines.append("")
+
+    if payload["checks"]:
+        lines.append("Plan:")
+        for check in payload["checks"]:
+            bucket_scope = ", ".join(check["buckets"]) if check["buckets"] else "n/a"
+            lines.append(f"- {check['id']}: {check['command']}")
+            lines.append(f"  buckets: {bucket_scope}")
+            lines.append(f"  reason: {check['description']}")
+    else:
+        lines.append("Plan: no checks required for this diff")
+
+    if "run_results" in payload:
+        lines.append("")
+        lines.append("Execution:")
+        for entry in payload["run_results"]:
+            lines.append(f"- [{entry['status']}] {entry['id']} :: {entry['command']}")
+            if entry.get("exit_code") is not None:
+                lines.append(f"  exit_code: {entry['exit_code']}")
+            if entry.get("stderr"):
+                lines.append(f"  stderr: {entry['stderr'].strip()}")
+
+        failed = payload.get("failed_checks", [])
+        blocked = payload.get("blocked_checks", [])
+        if failed or blocked:
+            lines.append("")
+            lines.append(
+                "Verification run incomplete: "
+                + ", ".join(
+                    [
+                        *(f"failed={name}" for name in failed),
+                        *(f"blocked={name}" for name in blocked),
+                    ]
+                )
+            )
+        else:
+            lines.append("")
+            lines.append("Verification run passed")
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    args = _parse_args()
+    repo_root = args.repo_root.resolve()
+
+    if args.paths:
+        changed_paths = [normalize_path(path) for path in args.paths]
+    else:
+        changed_paths = load_changed_paths(repo_root, args.base, args.head)
+
+    plan = _build_plan(changed_paths, include_invariant_guard=not args.no_invariant_guard)
+
+    run_results = None
+    if args.run:
+        run_results = _run_plan(plan, repo_root=repo_root, fail_fast=args.fail_fast)
+
+    payload = _plan_payload(changed_paths, plan, run_results)
+
+    if args.json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(_render_text(payload))
+
+    if run_results is not None:
+        failed_or_blocked = [
+            item for item in run_results if item["status"] in {"FAIL", "BLOCKED"}
+        ]
+        if failed_or_blocked:
+            raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a complete review automation toolkit under `scripts/review/` and performs full cutover from the previous duplicate scripts.

### New modules
- **review_buckets.py** — shared bucket/risk/check taxonomy used by all other scripts
- **risk_map.py** — generates per-bucket risk assessment with required checks from a diff
- **invariant_guard.py** — validates vector schema/shape, XMM register width, manifest safety, backend cache invariants
- **verify_plan.py** — derives minimal verification command plan from changed buckets; supports `--run` for execution
- **shard_pr.py** — refactored to use shared bucket metadata; now emits risk/checks per shard
- **run_review.py** — orchestrator that wires all modules and writes JSON + markdown artifacts
- **format_comment.py** — renders structured review comment from orchestrator payload
- **docs/REVIEWER_RULES.md** — reviewer policy with automation shortcuts

### Cutover
Removed parallel/duplicate scripts that the new modules replace:
- `verification_plan.py` -> `verify_plan.py`
- `invariant_checks.py` -> `invariant_guard.py`
- `lint_vectors.py` -> `invariant_guard.py`
- `build_repro.py` (templates covered by negative tests)
- `__init__.py` (not a package)

### Usage
```bash
# Risk map from diff
python scripts/review/risk_map.py --base main --head HEAD

# Invariant checks
python scripts/review/invariant_guard.py --all

# Verification plan (plan only)
python scripts/review/verify_plan.py --base main --head HEAD

# Verification plan (execute)
python scripts/review/verify_plan.py --base main --head HEAD --run

# Full orchestrated review
python scripts/review/run_review.py --base main --head HEAD --run-verification
```

### Verification
- `python -m compileall scripts/review` (PASS)
- `python scripts/review/invariant_guard.py --all` (PASS)
- `python scripts/review/run_review.py --paths ... --run-verification` (PASS)
- No imports of deleted modules confirmed via AST scan
