### PR TITLE
feat: PE export auto-outline + --outline CLI flag

### DIFF
--- a/lifter/core/Lifter.cpp
+++ b/lifter/core/Lifter.cpp
@@ -32,13 +32,18 @@
 
 
 bool InitFunction_and_LiftInstructions(const uint64_t runtime_address,
-                                       std::vector<uint8_t>&& fileData) {
+                                       std::vector<uint8_t>&& fileData,
+                                       const std::vector<uint64_t>& outlineAddresses) {
   std::string stageError;
   auto stageContext =
       prepareLifterStageContext(runtime_address, fileData, stageError);
   if (!stageContext.has_value()) {
     std::cerr << stageError << std::endl;
     return false;
+  }
+
+  for (const auto addr : outlineAddresses) {
+    stageContext->lifter->inlinePolicy.addAddress(addr);
   }
 
   runLifterPipeline(stageContext->lifter.get(), stageContext->runtimeContext,
@@ -110,5 +115,10 @@ int main(int argc, char* argv[]) {
   const std::string suiteFilter = args.size() > 1 ? args[1] : "";
   return testInit(suiteFilter);
 #endif
-  return runLifterApplication(args, InitFunction_and_LiftInstructions);
+  const auto& outlineAddrs = parseResult.outlineAddresses;
+  return runLifterApplication(args,
+      [&outlineAddrs](uint64_t runtime_address, std::vector<uint8_t>&& fileData) {
+        return InitFunction_and_LiftInstructions(runtime_address,
+                                                  std::move(fileData), outlineAddrs);
+      });
 }

--- a/lifter/core/LifterStages.hpp
+++ b/lifter/core/LifterStages.hpp
@@ -3,6 +3,7 @@
 #include "MemoryPolicySetup.hpp"
 #include "RuntimeImageContext.hpp"
 #include "Utils.h"
+#include <nt/directories/dir_export.hpp>
 #include <memory>
 #include <optional>
 #include <sstream>
@@ -20,6 +21,34 @@ createConfiguredLifterForRuntime(uint8_t* fileBase, uint64_t runtimeAddress) {
   lifter->loadFile(fileBase);
   // Memory policy configured later in prepareLifterStageContext
   // when RuntimeImageContext (with PE stack reserve) is available.
+
+  // Auto-outline PE exports: exported functions are separate entry points
+  // that should not be inlined when called from the lifted function.
+  {
+    auto* dosHdr = reinterpret_cast<win::dos_header_t*>(fileBase);
+    auto* ntHdr  = reinterpret_cast<win::nt_headers_t<true>*>(
+        fileBase + dosHdr->e_lfanew);
+    auto& expDir = ntHdr->optional_header.data_directories.export_directory;
+    if (expDir.size >= sizeof(win::export_directory_t)) {
+      uint64_t imageBase = ntHdr->optional_header.image_base;
+      auto fileOff = lifter->file.RvaToFileOffset(expDir.rva);
+      if (fileOff != 0) {
+        auto* exp = reinterpret_cast<const win::export_directory_t*>(
+            fileBase + fileOff);
+        auto funcTableOff = lifter->file.RvaToFileOffset(exp->rva_functions);
+        if (funcTableOff != 0 && exp->num_functions > 0) {
+          auto* funcRVAs = reinterpret_cast<const uint32_t*>(
+              fileBase + funcTableOff);
+          for (uint32_t i = 0; i < exp->num_functions; ++i) {
+            if (funcRVAs[i] != 0) {
+              uint64_t va = imageBase + funcRVAs[i];
+              lifter->inlinePolicy.addAddress(va);
+            }
+          }
+        }
+      }
+    }
+  }
 
   lifter->blockInfo = BBInfo(runtimeAddress, lifter->bb);
   lifter->unvisitedBlocks.push_back(lifter->blockInfo);

--- a/lifter/core/LifterStages.hpp
+++ b/lifter/core/LifterStages.hpp
@@ -40,10 +40,12 @@ createConfiguredLifterForRuntime(uint8_t* fileBase, uint64_t runtimeAddress) {
           auto* funcRVAs = reinterpret_cast<const uint32_t*>(
               fileBase + funcTableOff);
           for (uint32_t i = 0; i < exp->num_functions; ++i) {
-            if (funcRVAs[i] != 0) {
-              uint64_t va = imageBase + funcRVAs[i];
-              lifter->inlinePolicy.addAddress(va);
-            }
+            uint32_t rva = funcRVAs[i];
+            if (rva == 0) continue;
+            // Skip forwarded exports: RVA points within the export directory
+            // itself (to an ASCII forwarder string, not code).
+            if (rva >= expDir.rva && rva < expDir.rva + expDir.size) continue;
+            lifter->inlinePolicy.addAddress(imageBase + rva);
           }
         }
       }

--- a/lifter/core/Utils.cpp
+++ b/lifter/core/Utils.cpp
@@ -2,6 +2,7 @@
 #include "llvm/IR/Value.h"
 #include <chrono>
 #include <iostream>
+#include <sstream>
 #include <llvm/Analysis/ValueLattice.h>
 #include <llvm/Support/KnownBits.h>
 #include <map>
@@ -125,6 +126,7 @@ void printHelp() {
             << "  -h, --help                Display this help message\n"
             << "  --concretize-unsafe-reads Concretizes potentially unsafe "
                "reads to writable sections\n"
+            << "  --outline <addrs>         Comma-separated addresses to outline (not inline)\n"
             << "  --                        Stop option parsing\n";
 }
 
@@ -158,6 +160,28 @@ ParseResult parseArguments(const std::vector<std::string>& args,
       }
       if (arg == "--concretize-unsafe-reads") {
         result.concretizeUnsafeReads = true;
+        continue;
+      }
+      if (arg == "--outline" || arg.rfind("--outline=", 0) == 0) {
+        std::string value;
+        if (arg.size() > 10 && arg[9] == '=') {
+          value = arg.substr(10);
+        } else if (index + 1 < args.size()) {
+          value = args[++index];
+        } else {
+          result.errors.push_back("--outline requires an argument");
+          continue;
+        }
+        std::istringstream stream(value);
+        std::string token;
+        while (std::getline(stream, token, ',')) {
+          if (token.empty()) continue;
+          try {
+            result.outlineAddresses.push_back(std::stoull(token, nullptr, 0));
+          } catch (const std::exception&) {
+            result.errors.push_back("Invalid outline address: " + token);
+          }
+        }
         continue;
       }
 

--- a/lifter/core/Utils.cpp
+++ b/lifter/core/Utils.cpp
@@ -164,8 +164,12 @@ ParseResult parseArguments(const std::vector<std::string>& args,
       }
       if (arg == "--outline" || arg.rfind("--outline=", 0) == 0) {
         std::string value;
-        if (arg.size() > 10 && arg[9] == '=') {
+        if (arg.rfind("--outline=", 0) == 0) {
           value = arg.substr(10);
+          if (value.empty()) {
+            result.errors.push_back("--outline= requires a value after '='");
+            continue;
+          }
         } else if (index + 1 < args.size()) {
           value = args[++index];
         } else {

--- a/lifter/core/Utils.h
+++ b/lifter/core/Utils.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "llvm/IR/Value.h"
 #include <functional>
+#include <cstdint>
 #include <linuxpe>
 #include <llvm/Support/raw_ostream.h>
 #include <string>
@@ -92,6 +93,7 @@ namespace argparser {
     bool showHelp = false;
     bool enableDebug = false;
     bool concretizeUnsafeReads = false;
+    std::vector<uint64_t> outlineAddresses;
     std::vector<std::string> errors;
 
     [[nodiscard]] bool ok() const { return errors.empty(); }


### PR DESCRIPTION
## Summary

Adds two outline policy layers on top of the ABI call-boundary framework (#76):

### Layer 2: PE export auto-outline
Parses the PE export directory at lifter setup. Every exported function RVA is added to `inlinePolicy`'s outline set. Calls to exported functions are automatically outlined with `CreateCall` + ABI effects.

### Layer 6: `--outline` CLI flag
```
--outline <addrs>    Comma-separated hex addresses to outline (not inline)
```

Supports `--outline 0x140004100,0x140005000` and `--outline=0x140004100`. Multiple `--outline` flags accumulate.

## Verified

- `calc_cout` with `--outline 0x140004100`: lifts `x*3+7` with outlined `operator<<` call
- VMP 3.8.1: identical `a+b+c` deobfuscation
- All baseline, semantic (23/23), micro (15/15) tests pass
- Determinism: 34 golden files match

## Related
- Closes the Layer 2 and Layer 6 items from #75