### PR TITLE
Re-enable calc_fib and calc_sum_array in rewrite gate

### DIFF
--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -37,7 +37,7 @@ Mergen is a function-level LLVM IR lifting engine for deobfuscation and devirtua
 
 ## Quality Contract
 - Handler coverage: 115/119 handlers covered by the full-handler oracle suite, with 4 intentional skips (`cpuid`, `rdtsc`, `ret`, `scasx`)
-- Active regression corpus: 31 semantic samples / 175 runtime semantic cases in CI; `calc_cout` is active again now that `PUNPCKLQDQ` is implemented; `calc_fib` and `calc_sum_array` remain `ci_skip` because they currently trip a separate lifter assertion (tracked as a follow-up)
+- Active regression corpus: 33 semantic samples / 177 runtime semantic cases in CI; `calc_sum_to_n`, `calc_fib`, `calc_sum_array`, `stack_vm_loop`, and `calc_cout` are all active under the current safe path
 - Determinism: golden IR hashes are enforced for tracked outputs
 - CI gates: register/flag correctness, rewrite baseline, semantic regression, and Windows build lanes
 - Targeted VMP gate: `python test.py vmp` must keep required 3.8.x targets at `blocks_completed > 0`; VMP 3.6 remains best-effort only

--- a/scripts/rewrite/instruction_microtests.json
+++ b/scripts/rewrite/instruction_microtests.json
@@ -246,8 +246,6 @@
     {
       "name": "calc_fib",
       "symbol": "calc_fib",
-      "ci_skip": true,
-      "ci_skip_reason": "Lifter dyn_cast assertion on calc_fib codegen — separate from PUNPCKLQDQ work; tracked for follow-up.",
       "patterns": ["ret i64 13"],
       "semantic": [
         { "expected": 13, "label": "constant: fib(7)" }
@@ -256,8 +254,6 @@
     {
       "name": "calc_sum_array",
       "symbol": "calc_sum_array",
-      "ci_skip": true,
-      "ci_skip_reason": "Lifter dyn_cast assertion on calc_sum_array codegen — separate from PUNPCKLQDQ work; tracked for follow-up.",
       "patterns": ["ret i64 150"],
       "semantic": [
         { "expected": 150, "label": "constant: 10+20+30+40+50" }


### PR DESCRIPTION
## Summary
Both samples were originally CI-skipped (commits 81bc3a8 and fa95a27) because windows-latest clang-cl produced loop/array codegen shapes that tripped the lifter on CI even though local runs passed. Since then the rewrite CI lane has been pinned to the same LLVM 18.1.8 clang-cl used locally (eb49a35, 949acaa, a28a368) and several structured loop recovery fixes have landed (2989e5a, 2eaa22e), so the codegen mismatch that motivated the skips no longer exists.

## Investigation note
The local working tree had a stale, mis-configured build_iced/ cache (no /O2, no /DNDEBUG) which made an old LLVM dyn_cast assertion fire on calc_fib/calc_sum_array. After rmdir build_iced && scripts\dev\configure_iced.cmd && build_iced.cmd the proper Release flags (/O2 /Ob2 /DNDEBUG) are restored and both samples lift cleanly. The repo CI lane already uses a clean configure, so this was never a CI failure mode \u2014 just a stale local cache.

## Verification
Clean Release build, python test.py all fully green:
- calc_fib lifts to ret i64 13; semantic case passes
- calc_sum_array lifts to ret i64 150; semantic case passes
- Semantic regression: **33/33** (was 31/31)
- Baseline, micro --check-flags, full handler suite (115/119, 4 known skips), determinism (42 golden) all pass
- Targeted: build_iced/lifter.exe ..\rewrite-regression-work\calc_fib.exe 0x140001000 and ...calc_sum_array.exe 0x140001000 both produce the expected constant-folded IR

## Changes
- Drop ci_skip + ci_skip_reason for calc_fib and calc_sum_array in scripts/rewrite/instruction_microtests.json
- Update docs/SCOPE.md corpus counts: 33 samples / 177 cases