### PR TITLE
Fold select-chain dispatch into a real switch

### DIFF
--- a/lifter/analysis/CustomPasses.hpp
+++ b/lifter/analysis/CustomPasses.hpp
@@ -461,6 +461,222 @@ public:
 //     i64 1, label %bb1
 //     ...
 //   ]
+// SelectChainToSwitchPass folds chains of `icmp eq %idx, K_i; select` into a
+// real `switch` instruction. Hex-Rays-style straight-line jump tables routinely
+// lift to such a chain, which downstream readers (and SwitchNormalizationPass)
+// cannot recognize as a dispatch.
+//
+// Pattern (per chain link, walking from chain head via false branch):
+//   %ci = icmp eq <ty> %IDX, K_i
+//   %si = select i1 %ci, <ty> V_i, <ty> %s_{i+1}
+// Tail terminator: the last `false` operand is a Constant V_default.
+//
+// Match conditions:
+//   - The chain head is the value flowing into a single PHI in the unique
+//     successor of the block. The block's terminator is an unconditional br.
+//   - All comparisons share the same %IDX operand.
+//   - All true-branch values are Constants. The terminating false branch is
+//     a Constant.
+//   - Case constants are unique (no duplicate switch cases).
+//   - Chain instructions have no users outside the chain or that single PHI.
+//
+// Rewrite:
+//   - Erase the unconditional branch and the entire chain.
+//   - Emit `switch %IDX, label %default [ K_i, label %case_i ... ]` in the
+//     original block.
+//   - Each %case_i and %default is a fresh trampoline block containing only
+//     `br label %succ`, supplying its case-specific value to the join PHI.
+//   - The original BB->succ PHI incoming is removed.
+//
+// SwitchNormalizationPass runs after this pass and rewrites the synthesized
+// switch's concrete table-address case values to logical 0..N-1 indices.
+class SelectChainToSwitchPass
+    : public llvm::PassInfoMixin<SelectChainToSwitchPass> {
+public:
+  llvm::PreservedAnalyses run(llvm::Module& M, llvm::ModuleAnalysisManager&) {
+    bool changed = false;
+    for (auto& F : M) {
+      llvm::SmallVector<llvm::BasicBlock*, 16> worklist;
+      for (auto& BB : F) worklist.push_back(&BB);
+      for (auto* BB : worklist) {
+        if (tryFoldBlock(BB)) changed = true;
+      }
+    }
+    return changed ? llvm::PreservedAnalyses::none()
+                   : llvm::PreservedAnalyses::all();
+  }
+
+private:
+  // Walk a select chain from `head` via false branches. On success, populates
+  // idxOut, defaultOut, cases (in chain order, head-first), and chainInsts
+  // (sel/cmp pairs in chain order).
+  static bool collectChain(
+      llvm::SelectInst* head,
+      llvm::Value*& idxOut,
+      llvm::Constant*& defaultOut,
+      llvm::SmallVectorImpl<std::pair<llvm::ConstantInt*, llvm::Constant*>>& cases,
+      llvm::SmallVectorImpl<llvm::Instruction*>& chainInsts) {
+    llvm::Value* v = head;
+    llvm::Value* idx = nullptr;
+    llvm::BasicBlock* parent = head->getParent();
+    for (unsigned depth = 0; depth < 256; ++depth) {
+      auto* sel = llvm::dyn_cast<llvm::SelectInst>(v);
+      if (!sel) break;
+      if (sel->getParent() != parent) return false;
+      auto* cmp = llvm::dyn_cast<llvm::ICmpInst>(sel->getCondition());
+      if (!cmp || cmp->getParent() != parent) return false;
+      if (cmp->getPredicate() != llvm::ICmpInst::ICMP_EQ) return false;
+
+      llvm::Value* candIdx = cmp->getOperand(0);
+      auto* k = llvm::dyn_cast<llvm::ConstantInt>(cmp->getOperand(1));
+      if (!k) {
+        // Try the swapped form.
+        candIdx = cmp->getOperand(1);
+        k = llvm::dyn_cast<llvm::ConstantInt>(cmp->getOperand(0));
+        if (!k) return false;
+      }
+      if (!idx) idx = candIdx;
+      else if (idx != candIdx) return false;
+
+      auto* tval = llvm::dyn_cast<llvm::Constant>(sel->getTrueValue());
+      if (!tval) return false;
+
+      cases.push_back({k, tval});
+      chainInsts.push_back(sel);
+      chainInsts.push_back(cmp);
+
+      v = sel->getFalseValue();
+    }
+    auto* def = llvm::dyn_cast<llvm::Constant>(v);
+    if (!def) return false;
+    if (cases.size() < 2) return false;
+    idxOut = idx;
+    defaultOut = def;
+    return true;
+  }
+
+  static bool tryFoldBlock(llvm::BasicBlock* BB) {
+    auto* term = llvm::dyn_cast<llvm::BranchInst>(BB->getTerminator());
+    if (!term || !term->isUnconditional()) return false;
+    auto* succ = term->getSuccessor(0);
+
+    // Find the unique PHI in succ whose BB-incoming is a SelectInst defined
+    // in BB. If multiple chains feed multiple PHIs from BB, skip for safety.
+    //
+    // Also collect every *other* PHI in succ that has a BB-incoming so we can
+    // replicate their unchanged value across the new trampoline blocks. If any
+    // such sibling PHI's incoming is itself a chain instruction (i.e. the
+    // chain tail or an intermediate select), we cannot safely replicate and
+    // must bail — after the rewrite BB is no longer a predecessor of succ, so
+    // any stale incoming referencing BB would break the IR verifier.
+    llvm::PHINode* targetPhi = nullptr;
+    llvm::SelectInst* head = nullptr;
+    llvm::SmallVector<llvm::PHINode*, 4> siblingPhis;
+    for (auto& I : *succ) {
+      auto* phi = llvm::dyn_cast<llvm::PHINode>(&I);
+      if (!phi) break;
+      int idxIn = phi->getBasicBlockIndex(BB);
+      if (idxIn < 0) continue;
+      llvm::Value* incoming = phi->getIncomingValue(idxIn);
+      if (auto* sel = llvm::dyn_cast<llvm::SelectInst>(incoming)) {
+        if (sel->getParent() == BB) {
+          if (targetPhi) return false; // multiple chain phis — ambiguous
+          targetPhi = phi;
+          head = sel;
+          continue;
+        }
+      }
+      siblingPhis.push_back(phi);
+    }
+    if (!targetPhi || !head) return false;
+
+    llvm::Value* idx = nullptr;
+    llvm::Constant* defVal = nullptr;
+    llvm::SmallVector<std::pair<llvm::ConstantInt*, llvm::Constant*>, 16> cases;
+    llvm::SmallVector<llvm::Instruction*, 32> chainInsts;
+    if (!collectChain(head, idx, defVal, cases, chainInsts)) return false;
+
+    // Reject duplicate case constants — a switch must have unique values.
+    {
+      llvm::SmallPtrSet<llvm::ConstantInt*, 16> seen;
+      for (auto& c : cases) {
+        if (!seen.insert(c.first).second) return false;
+      }
+    }
+
+    // Verify chain instructions have no users outside the chain or targetPhi.
+    llvm::SmallPtrSet<llvm::Instruction*, 32> chainSet(chainInsts.begin(),
+                                                        chainInsts.end());
+    for (auto* I : chainInsts) {
+      for (auto* user : I->users()) {
+        auto* userInst = llvm::dyn_cast<llvm::Instruction>(user);
+        if (!userInst) return false;
+        if (chainSet.contains(userInst)) continue;
+        if (userInst == targetPhi) continue;
+        return false;
+      }
+    }
+
+    // If any sibling PHI's BB-incoming is a chain instruction, we cannot
+    // replicate it across trampolines (it will be erased). Bail.
+    for (auto* phi : siblingPhis) {
+      llvm::Value* v = phi->getIncomingValueForBlock(BB);
+      if (auto* I = llvm::dyn_cast<llvm::Instruction>(v)) {
+        if (chainSet.contains(I)) return false;
+      }
+    }
+
+    // Build trampoline blocks. Add new PHI incomings BEFORE removing the old
+    // one so the PHI is never empty mid-rewrite.
+    llvm::LLVMContext& Ctx = BB->getContext();
+    llvm::Function* F = BB->getParent();
+
+    llvm::BasicBlock* defaultBB =
+        llvm::BasicBlock::Create(Ctx, BB->getName() + ".sc_default", F);
+    llvm::BranchInst::Create(succ, defaultBB);
+    targetPhi->addIncoming(defVal, defaultBB);
+
+    llvm::SmallVector<llvm::BasicBlock*, 16> caseBBs;
+    caseBBs.reserve(cases.size());
+    for (auto& c : cases) {
+      llvm::BasicBlock* cb = llvm::BasicBlock::Create(
+          Ctx, BB->getName() + ".sc_case", F);
+      llvm::BranchInst::Create(succ, cb);
+      targetPhi->addIncoming(c.second, cb);
+      caseBBs.push_back(cb);
+    }
+
+    // Replace BB's terminator with the dispatch switch.
+    term->eraseFromParent();
+    llvm::IRBuilder<> b(BB);
+    auto* SI = b.CreateSwitch(idx, defaultBB, cases.size());
+    for (size_t i = 0; i < cases.size(); ++i) {
+      SI->addCase(cases[i].first, caseBBs[i]);
+    }
+
+    // Drop the original BB->succ PHI incoming on the target phi.
+    targetPhi->removeIncomingValue(BB, /*DeletePHIIfEmpty*/ false);
+
+    // Replicate each sibling PHI's BB-incoming across every new trampoline
+    // predecessor, then drop the stale BB-incoming. Order matters: add all
+    // new edges first so the PHI is never empty mid-rewrite.
+    for (auto* phi : siblingPhis) {
+      llvm::Value* v = phi->getIncomingValueForBlock(BB);
+      phi->addIncoming(v, defaultBB);
+      for (auto* cb : caseBBs) phi->addIncoming(v, cb);
+      phi->removeIncomingValue(BB, /*DeletePHIIfEmpty*/ false);
+    }
+
+    // Erase the dead chain in head-first order. Each link's only remaining
+    // user (head_sel via the PHI, or each link via the next select) is gone
+    // by the time we get to it.
+    for (auto* I : chainInsts) {
+      if (I->use_empty()) I->eraseFromParent();
+    }
+    return true;
+  }
+};
+
 class SwitchNormalizationPass
     : public llvm::PassInfoMixin<SwitchNormalizationPass> {
 public:
@@ -468,115 +684,40 @@ public:
     bool changed = false;
 
     for (auto& F : M) {
-      for (auto& BB : F) {
-        auto* SI = llvm::dyn_cast<llvm::SwitchInst>(BB.getTerminator());
+      // Snapshot the block list since we may add unreachable trampolines.
+      llvm::SmallVector<llvm::BasicBlock*, 16> blocks;
+      for (auto& BB : F) blocks.push_back(&BB);
+      for (auto* BB : blocks) {
+        auto* SI = llvm::dyn_cast<llvm::SwitchInst>(BB->getTerminator());
         if (!SI || SI->getNumCases() < 2) continue;
 
-        // Collect case values and check if they form an arithmetic progression.
         llvm::SmallVector<std::pair<int64_t, llvm::BasicBlock*>, 16> cases;
         for (auto& C : SI->cases())
           cases.push_back({C.getCaseValue()->getSExtValue(), C.getCaseSuccessor()});
 
-        // Sort by case value to find the progression.
-        llvm::sort(cases, [](const auto& a, const auto& b) {
-          return a.first < b.first;
-        });
-
-        // Check for arithmetic progression with constant stride.
-        int64_t base = cases[0].first;
-        int64_t stride = cases[1].first - base;
-        if (stride <= 0) continue;
-
-        bool isProgression = true;
-        for (unsigned i = 2; i < cases.size(); ++i) {
-          if (cases[i].first != base + (int64_t)i * stride) {
-            isProgression = false;
-            break;
-          }
-        }
-        if (!isProgression) continue;
-
         // Skip if case values look like logical indices already.
         // Concrete addresses from the lifter are large (imageBase is typically
         // 0x140000000). Logical values from user code are small.
-        uint64_t maxCaseVal = static_cast<uint64_t>(cases.back().first);
-        if (maxCaseVal < 0x10000) continue;
+        uint64_t maxRawCase = 0;
+        for (auto& c : cases)
+          maxRawCase = std::max(maxRawCase, static_cast<uint64_t>(c.first));
+        if (maxRawCase < 0x10000) continue;
 
-        // Verify the normalization is safe: the select chain must establish
-        // a 1:1 mapping from input index to switch case. If the range guard
-        // says the input ranges over N values but the switch has fewer than
-        // N cases, some inputs share targets and normalization would break.
-        // Heuristic: walk predecessors looking for `icmp ult %input, N` and
-        // check N == numCases.
-        bool rangeVerified = false;
-        // Quick check: if stride == 1 in the table-address domain and there
-        // are exactly (maxAddr - minAddr)/tableStride + 1 cases, the mapping
-        // is likely 1:1. But the safest check is via the range guard.
-        // For now, skip if the switch block has a predecessor with a branch
-        // on `icmp ult` whose bound doesn't match numCases.
-        for (auto* Pred : llvm::predecessors(&BB)) {
-          auto* BI = llvm::dyn_cast<llvm::BranchInst>(Pred->getTerminator());
-          if (!BI || !BI->isConditional()) continue;
-          auto* Cmp = llvm::dyn_cast<llvm::ICmpInst>(BI->getCondition());
-          if (!Cmp) continue;
-          // Look for icmp ult/eq pattern. The range guard is typically
-          // `icmp ult %x, N` or `icmp eq (and %x, ~(N-1)), 0`.
-          if (Cmp->getPredicate() == llvm::ICmpInst::ICMP_ULT) {
-            if (auto* Bound = llvm::dyn_cast<llvm::ConstantInt>(Cmp->getOperand(1))) {
-              if (Bound->getZExtValue() == SI->getNumCases())
-                rangeVerified = true;
-            }
-          }
-          // Also handle the `and` + `icmp eq 0` pattern used for power-of-2 ranges.
-          // e.g. `(RCX & ~3) == 0` means RCX < 4.
-          if (Cmp->getPredicate() == llvm::ICmpInst::ICMP_EQ) {
-            if (auto* Zero = llvm::dyn_cast<llvm::ConstantInt>(Cmp->getOperand(1))) {
-              if (Zero->isZero()) {
-                if (auto* AndInst = llvm::dyn_cast<llvm::BinaryOperator>(Cmp->getOperand(0))) {
-                  if (AndInst->getOpcode() == llvm::Instruction::And) {
-                    if (auto* Mask = llvm::dyn_cast<llvm::ConstantInt>(AndInst->getOperand(1))) {
-                      // The mask zeroes the low bits of the input.
-                      // Count trailing zero bits to get log2(range).
-                      // e.g. mask=0xFFFFFFFC -> low 2 bits cleared -> range=4.
-                      uint64_t maskVal = Mask->getZExtValue();
-                      // Invert and isolate: ~0xFFFFFFFC = 0x...00000003
-                      // range = lowest set bit position in (mask+1)
-                      // For mask with trailing zeros: range = (mask ^ (mask-1)) >> 1 + 1
-                      // Simpler: count trailing zeros of ~mask, but ~mask
-                      // in 64-bit has high bits set. Use countTrailingZeros on mask.
-                      unsigned trailingZeros = llvm::countr_zero(maskVal);
-                      if (trailingZeros > 0 && trailingZeros < 32) {
-                        uint64_t rangeSize = 1ULL << trailingZeros;
-                        if (rangeSize == SI->getNumCases())
-                          rangeVerified = true;
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-        if (!rangeVerified) continue;
-
-        // Trace back the switch condition to find the original input.
-        // Pattern: switch on trunc(select-chain(add(scaled_input, BASE)))
-        // We need to find the original unscaled input register value.
+        // Trace the switch operand back to the original input plus the
+        // address arithmetic that produced the case values. Two shapes are
+        // supported:
+        //   (a) Lifter-emitted: switch trunc(select_chain(add(scaled, BASE)))
+        //       where select_chain is the original ladder. We walk it to
+        //       recover the icmp's left operand, which is the add.
+        //   (b) Post-SelectChainToSwitchPass: the chain is gone, so the switch
+        //       operand is the add directly.
+        // The address arithmetic is then add(and(shl(input, LOG2_STRIDE),
+        // MASK), BASE_CONST) (the and is optional).
         llvm::Value* switchCond = SI->getCondition();
-
-        // Strip trunc if present.
         if (auto* trunc = llvm::dyn_cast<llvm::TruncInst>(switchCond))
           switchCond = trunc->getOperand(0);
 
-        // Try to trace through the select chain to find the add instruction
-        // that computes the table index: %idx = add %scaled, BASE
-        // The select chain reads: icmp eq %idx, BASE+i*STRIDE; select ...
-        // We need the value BEFORE the add, then normalize.
-        llvm::Value* tableIndex = switchCond;
-
-        // Walk through select chain to find the root comparison base.
-        // The select chain all compare against the same %idx value.
-        llvm::Value* idxValue = nullptr;
+        llvm::Value* idxValue = switchCond;
         {
           llvm::Value* v = switchCond;
           for (unsigned depth = 0; depth < 64; ++depth) {
@@ -585,53 +726,290 @@ public:
             auto* cmp = llvm::dyn_cast<llvm::ICmpInst>(sel->getCondition());
             if (!cmp) break;
             idxValue = cmp->getOperand(0);
-            v = sel->getFalseValue(); // walk the chain
+            v = sel->getFalseValue();
           }
         }
 
-        // If we found the index value, try to extract the original input.
-        // Pattern: %idx = add nuw nsw i64 %mul_ea, BASE_CONST
-        //          %mul_ea = and i64 %shifted, MASK
-        //          %shifted = shl i64 %INPUT, LOG2_STRIDE
         llvm::Value* originalInput = nullptr;
-        if (idxValue) {
-          if (auto* addInst = llvm::dyn_cast<llvm::BinaryOperator>(idxValue)) {
-            if (addInst->getOpcode() == llvm::Instruction::Add) {
-              llvm::Value* scaledInput = addInst->getOperand(0);
-              // Strip 'and' mask.
-              if (auto* andInst = llvm::dyn_cast<llvm::BinaryOperator>(scaledInput)) {
+        int64_t addrBase = 0;
+        int64_t addrStride = 0;
+        // Helper: strip trunc/zext wrappers to get at the underlying value.
+        auto stripIntCasts = [](llvm::Value* v) -> llvm::Value* {
+          while (true) {
+            if (auto* t = llvm::dyn_cast<llvm::TruncInst>(v)) {
+              v = t->getOperand(0);
+              continue;
+            }
+            if (auto* z = llvm::dyn_cast<llvm::ZExtInst>(v)) {
+              v = z->getOperand(0);
+              continue;
+            }
+            break;
+          }
+          return v;
+        };
+
+        if (auto* addInst = llvm::dyn_cast<llvm::BinaryOperator>(idxValue)) {
+          if (addInst->getOpcode() == llvm::Instruction::Add) {
+            // Try both operand orders for the constant. InstCombine canonicalizes
+            // the constant to operand(1), but the lifter may hand us pre-canonical
+            // shapes.
+            llvm::Value* scaledInput = nullptr;
+            llvm::ConstantInt* baseConst =
+                llvm::dyn_cast<llvm::ConstantInt>(addInst->getOperand(1));
+            if (baseConst) {
+              scaledInput = addInst->getOperand(0);
+            } else {
+              baseConst =
+                  llvm::dyn_cast<llvm::ConstantInt>(addInst->getOperand(0));
+              if (baseConst) scaledInput = addInst->getOperand(1);
+            }
+            if (baseConst) {
+              addrBase = baseConst->getSExtValue();
+              if (auto* andInst =
+                      llvm::dyn_cast<llvm::BinaryOperator>(scaledInput)) {
                 if (andInst->getOpcode() == llvm::Instruction::And)
                   scaledInput = andInst->getOperand(0);
               }
-              // Strip 'shl' to get original input.
-              if (auto* shlInst = llvm::dyn_cast<llvm::BinaryOperator>(scaledInput)) {
-                if (shlInst->getOpcode() == llvm::Instruction::Shl)
-                  originalInput = shlInst->getOperand(0);
+              if (auto* shlInst =
+                      llvm::dyn_cast<llvm::BinaryOperator>(scaledInput)) {
+                if (shlInst->getOpcode() == llvm::Instruction::Shl) {
+                  if (auto* shiftConst = llvm::dyn_cast<llvm::ConstantInt>(
+                          shlInst->getOperand(1))) {
+                    uint64_t shiftAmount = shiftConst->getZExtValue();
+                    if (shiftAmount < 32) {
+                      addrStride = 1LL << shiftAmount;
+                      originalInput = shlInst->getOperand(0);
+                    }
+                  }
+                }
               }
             }
           }
         }
+        if (!originalInput || addrStride <= 0) continue;
 
-        if (!originalInput) continue;
+        // Compute the input range guard once. Two predecessor shapes are
+        // accepted:
+        //   icmp ult %x, N            -> rangeSize = N
+        //   icmp eq (and %x, MASK), 0 -> rangeSize = 1 << countr_zero(MASK)
+        uint64_t rangeSize = 0;
+        bool narrowMaskGuard = false;
+        // The value the guard actually constrains. Width may be < originalInput.
+        llvm::Value* guardedValue = nullptr;
+        for (auto* Pred : llvm::predecessors(BB)) {
+          auto* BI = llvm::dyn_cast<llvm::BranchInst>(Pred->getTerminator());
+          if (!BI || !BI->isConditional()) continue;
+          auto* Cmp = llvm::dyn_cast<llvm::ICmpInst>(BI->getCondition());
+          if (!Cmp) continue;
+          // BB must sit on the true edge (in-range side) of the guard. Both
+          // accepted shapes have `i1 true = in range` semantics.
+          if (BI->getSuccessor(0) != BB) continue;
 
-        // Build the normalized switch.
+          // Helper: the guard's compared value may be a trunc/zext of
+          // originalInput. If it is narrower than originalInput, the high bits
+          // of originalInput are unconstrained by this guard, so the folded-
+          // default rewrite must mask those bits away before dispatching.
+          auto isNarrowerThanOriginal = [&](llvm::Value* compared) {
+            unsigned cw = compared->getType()->getIntegerBitWidth();
+            unsigned ow = originalInput->getType()->getIntegerBitWidth();
+            return cw < ow;
+          };
+
+          if (Cmp->getPredicate() == llvm::ICmpInst::ICMP_ULT) {
+            auto* Bound =
+                llvm::dyn_cast<llvm::ConstantInt>(Cmp->getOperand(1));
+            if (!Bound) continue;
+            // The compared value must be the (possibly trunc/zext-wrapped)
+            // originalInput. Otherwise the guard is on a different quantity
+            // and using its bound as our rangeSize is unsound.
+            if (stripIntCasts(Cmp->getOperand(0)) != originalInput) continue;
+            guardedValue = Cmp->getOperand(0);
+            if (isNarrowerThanOriginal(Cmp->getOperand(0)))
+              narrowMaskGuard = true;
+            rangeSize = Bound->getZExtValue();
+            break;
+          }
+          if (Cmp->getPredicate() == llvm::ICmpInst::ICMP_EQ) {
+            auto* Zero =
+                llvm::dyn_cast<llvm::ConstantInt>(Cmp->getOperand(1));
+            if (!Zero || !Zero->isZero()) continue;
+            auto* AndInst = llvm::dyn_cast<llvm::BinaryOperator>(Cmp->getOperand(0));
+            if (!AndInst || AndInst->getOpcode() != llvm::Instruction::And)
+              continue;
+            auto* Mask = llvm::dyn_cast<llvm::ConstantInt>(AndInst->getOperand(1));
+            if (!Mask) continue;
+            if (stripIntCasts(AndInst->getOperand(0)) != originalInput) continue;
+            guardedValue = AndInst->getOperand(0);
+            uint64_t maskVal = Mask->getZExtValue();
+            unsigned maskWidth = Mask->getType()->getIntegerBitWidth();
+            unsigned trailingZeros = llvm::countr_zero(maskVal);
+            if (trailingZeros == 0 || trailingZeros >= 32) continue;
+            // The "narrow mask" case: high bits of originalInput above the
+            // trailing-zero block are unconstrained, so `originalInput` itself
+            // may hold values outside [0, 2^tz). We still get a valid logical
+            // index by masking at switch time. Mark it so we emit the switch
+            // on (originalInput & ((1<<tz)-1)) rather than raw originalInput.
+            uint64_t widthMask =
+                maskWidth >= 64 ? ~0ULL : ((1ULL << maskWidth) - 1);
+            uint64_t expected =
+                widthMask ^ ((1ULL << trailingZeros) - 1);
+            if ((maskVal & widthMask) != expected) narrowMaskGuard = true;
+            // Even with a perfectly-shaped mask, the guard only constrains the
+            // low `maskWidth` bits of originalInput. If maskWidth < operand
+            // width, the high bits remain unknown.
+            if (isNarrowerThanOriginal(AndInst->getOperand(0)))
+              narrowMaskGuard = true;
+            rangeSize = 1ULL << trailingZeros;
+            break;
+          }
+        }
+        if (rangeSize == 0) continue;
+
+        // Mode A (index-arithmetic): the case constants ARE in the same address
+        // space as the lifter's index arithmetic, so each case = base + i*stride
+        // for some logical i. Walking idxValue's add/and/shl recovers (base,
+        // stride) and lets us emit cases with their true logical indices. This
+        // also lets us promote a folded chain default (case 0 -> old default).
+        //
+        // Mode B (sorted-position fallback): the case constants don't fit the
+        // index arithmetic but they still form an arithmetic progression among
+        // themselves (e.g. switch on a chain of jump-table TARGET addresses).
+        // Map the sorted i'th case to logical index i.
+        bool useFoldedDefault = false;
+        llvm::SmallVector<std::pair<int64_t, llvm::BasicBlock*>, 16> logicalCases;
+
+        // Try Mode A.
+        bool modeAOk = true;
+        for (auto& c : cases) {
+          int64_t off = c.first - addrBase;
+          if (off < 0 || (off % addrStride) != 0) {
+            modeAOk = false;
+            break;
+          }
+          logicalCases.push_back({off / addrStride, c.second});
+        }
+        if (modeAOk) {
+          llvm::sort(logicalCases, [](const auto& a, const auto& b) {
+            return a.first < b.first;
+          });
+          for (size_t i = 1; i < logicalCases.size(); ++i) {
+            if (logicalCases[i].first != logicalCases[i - 1].first + 1) {
+              modeAOk = false;
+              break;
+            }
+          }
+        }
+        if (modeAOk) {
+          const int64_t minLogical = logicalCases.front().first;
+          const int64_t maxLogical = logicalCases.back().first;
+          const uint64_t numCases = logicalCases.size();
+          const bool basicMatch =
+              (minLogical == 0) && (rangeSize == numCases) &&
+              (static_cast<uint64_t>(maxLogical + 1) == rangeSize);
+          const bool foldedDefault =
+              (minLogical == 1) && (rangeSize == numCases + 1) &&
+              (static_cast<uint64_t>(maxLogical + 1) == rangeSize);
+          if (basicMatch) {
+            // Use logicalCases as-is.
+          } else if (foldedDefault) {
+            useFoldedDefault = true;
+          } else {
+            modeAOk = false;
+          }
+        }
+
+        // Mode B fallback.
+        if (!modeAOk) {
+          logicalCases.clear();
+          auto sortedCases = cases;
+          llvm::sort(sortedCases, [](const auto& a, const auto& b) {
+            return a.first < b.first;
+          });
+          int64_t apBase = sortedCases[0].first;
+          int64_t apStride = sortedCases[1].first - apBase;
+          if (apStride <= 0) continue;
+          bool isAp = true;
+          for (size_t i = 2; i < sortedCases.size(); ++i) {
+            if (sortedCases[i].first != apBase + (int64_t)i * apStride) {
+              isAp = false;
+              break;
+            }
+          }
+          if (!isAp) continue;
+          if (rangeSize != sortedCases.size()) continue;
+          for (size_t i = 0; i < sortedCases.size(); ++i)
+            logicalCases.push_back({(int64_t)i, sortedCases[i].second});
+        }
+
+        // Build the normalized switch. The default switch operand is
+        // `originalInput` (raw, unmasked); for the folded-default rewrite that
+        // converts the original default into an `unreachable` trampoline, we
+        // must guarantee unknown high bits cannot escape into that block.
+        // Strategy: when narrowMaskGuard is set, use the guard's actual
+        // compared value (`guardedValue`). If `guardedValue` is already
+        // narrower than `originalInput` (an explicit trunc), it is exactly the
+        // constrained quantity, so use it directly and key the switch type
+        // off it. If `guardedValue` has the same width but the mask only
+        // constrains the low bits (e.g. `(RCX & 0xFFFFFFF0) == 0`), wrap it in
+        // an `and` against `(rangeSize - 1)` — only valid when rangeSize is a
+        // power of 2, which is always the case for the and+eq guard form.
+        // For basic-match and Mode B, the original default already handles
+        // out-of-range inputs and no masking is needed.
         llvm::IRBuilder<> B(SI);
-        // Ensure the input is the right width for the switch.
-        llvm::Type* switchTy = originalInput->getType();
-        auto* newSwitch = B.CreateSwitch(originalInput, SI->getDefaultDest(),
-                                         SI->getNumCases());
+        llvm::Value* switchOperand = originalInput;
+        if (useFoldedDefault && narrowMaskGuard) {
+          if (guardedValue &&
+              guardedValue->getType()->getIntegerBitWidth() <
+                  originalInput->getType()->getIntegerBitWidth()) {
+            // Trunc form (e.g. `icmp ult i32 (trunc i64 %RCX to i32), N`):
+            // the trunc is already in [0, N).
+            switchOperand = guardedValue;
+          } else {
+            // Same-width narrow-mask form. Mask trick requires power of 2.
+            const bool rangeIsPow2 =
+                rangeSize != 0 && (rangeSize & (rangeSize - 1)) == 0;
+            if (!rangeIsPow2) continue;
+            auto* opIntTy = llvm::cast<llvm::IntegerType>(
+                originalInput->getType());
+            switchOperand = B.CreateAnd(
+                originalInput,
+                llvm::ConstantInt::get(opIntTy, rangeSize - 1),
+                "sw_input");
+          }
+        }
+        llvm::Type* switchTy = switchOperand->getType();
+        auto* switchIntTy = llvm::cast<llvm::IntegerType>(switchTy);
+        llvm::BasicBlock* oldDefault = SI->getDefaultDest();
 
-        // Map: sorted case index i -> label, with case value = i.
-        for (unsigned i = 0; i < cases.size(); ++i) {
-          auto* caseVal = llvm::ConstantInt::get(
-              llvm::cast<llvm::IntegerType>(switchTy), i);
-          newSwitch->addCase(caseVal, cases[i].second);
+        // For folded-default, replace the default with an unreachable trampoline
+        // and add an explicit case 0 -> oldDefault. The predecessor edge from BB
+        // to oldDefault is preserved (still BB, just via case 0 now), so any PHI
+        // in oldDefault that referenced BB stays valid.
+        llvm::BasicBlock* newDefault = oldDefault;
+        if (useFoldedDefault) {
+          newDefault = llvm::BasicBlock::Create(
+              SI->getContext(), BB->getName() + ".sw_unreachable",
+              SI->getFunction());
+          new llvm::UnreachableInst(SI->getContext(), newDefault);
+        }
+
+        const unsigned newNumCases = static_cast<unsigned>(
+            logicalCases.size() + (useFoldedDefault ? 1 : 0));
+        auto* newSwitch =
+            B.CreateSwitch(switchOperand, newDefault, newNumCases);
+        if (useFoldedDefault) {
+          newSwitch->addCase(
+              llvm::ConstantInt::get(switchIntTy, 0), oldDefault);
+        }
+        for (auto& lc : logicalCases) {
+          newSwitch->addCase(
+              llvm::ConstantInt::get(switchIntTy, lc.first), lc.second);
         }
 
         // Clean up the old switch and any now-dead trunc/select chain.
         llvm::Value* oldCond = SI->getCondition();
         SI->eraseFromParent();
-        // If the old condition (trunc) is now dead, remove it.
         if (auto* I = llvm::dyn_cast<llvm::Instruction>(oldCond)) {
           if (I->use_empty()) I->eraseFromParent();
         }

--- a/lifter/core/MergenPB.hpp
+++ b/lifter/core/MergenPB.hpp
@@ -97,6 +97,7 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::run_opts() {
 
   // Post-optimization passes: normalize IR, drop dead parameters, canonicalize names.
   llvm::ModulePassManager postPassManager;
+  postPassManager.addPass(SelectChainToSwitchPass());
   postPassManager.addPass(SwitchNormalizationPass());
   postPassManager.addPass(llvm::DeadArgumentEliminationPass());
   postPassManager.addPass(CanonicalNamingPass());

--- a/scripts/rewrite/instruction_microtests.json
+++ b/scripts/rewrite/instruction_microtests.json
@@ -391,7 +391,10 @@
       "symbol": "calc_jumptable",
       "patterns": [
         { "line_all": ["icmp ult i32", ", 10"] },
-        "select i1",
+        "trunc i64 %RCX to i32",
+        "switch i32 %0",
+        "i32 0, label",
+        "i32 9, label",
         "phi i64"
       ],
       "semantic": [
@@ -508,9 +511,16 @@
       "name": "calc_jumptable_large",
       "symbol": "calc_jumptable_large",
       "patterns": [
-        "icmp eq",
-        "select i1",
+        "and i64 %RCX, 15",
+        "switch i64 %sw_input",
+        "i64 0, label",
+        "i64 1, label",
+        "i64 15, label",
         "phi i64",
+        "[ 7,",
+        "[ 42,",
+        "[ 21,",
+        "unreachable",
         "ret i64"
       ],
       "semantic": [


### PR DESCRIPTION
## Summary
Replaces the lifter's straight-line icmp eq %idx, K_i; select V_i, prev chain with a real LLVM switch, and extends SwitchNormalizationPass to handle the folded-default and narrow-mask shapes that the rewrite produces. calc_jumptable_large (15 icmp/select pairs) and calc_jumptable (10-way dispatch) now lift to clean switch IR with logical 0..N-1 case indices and an unreachable default.

## Changes
- **New SelectChainToSwitchPass** (post-O2, runs before SwitchNormalizationPass) detects a chain whose head feeds a single PHI in the unique successor, verifies all comparisons share one %idx and all values are constants, and rewrites the chain into a switch on %idx whose case-i blocks are trampolines that supply the case-specific value to the join phi. Sibling PHIs in the join with non-chain BB-incomings have their value replicated across all new trampoline edges; the rewrite bails if any sibling PHI references a chain instruction.

- **SwitchNormalizationPass** restructured into two cooperating modes:
  - **Mode A (index-arithmetic)** walks the switch operand back through trunc/select-chain to recover (originalInput, addrBase, addrStride) and converts each case constant via (case - addrBase) / addrStride. Supports the **folded-default** pattern (chain default is logical 0) by promoting the original default to an explicit case 0 and emitting an unreachable block as the new default. Range guard now requires both the correct branch direction (BI->getSuccessor(0) == BB) and the comparison subject to be originalInput after stripping trunc/zext.
  - **Mode B (sorted-position fallback)** preserves the previous behavior for switches whose case constants are jump-table TARGET addresses rather than table-entry indices (e.g. jumptable_basic).

- **Narrow-mask handling** (avoids creating unreachable-reachable IR when the guard does not constrain the full operand width):
  - Trunc form (e.g. icmp ult i32 (trunc i64 %RCX), N): the trunc itself is the switch operand. Switch type matches the trunc width. No extra masking needed.
  - Same-width and+eq form (e.g. (RCX & 0xFFFFFFF0) == 0): wraps the operand in and originalInput, (rangeSize - 1). Requires rangeSize is a power of 2 (which the and+eq form always guarantees).

## Verification
- python test.py all fully green: baseline, semantic 33/33, micro --check-flags, full handler suite (115/119, 4 known skips), determinism 42 golden.
- Targeted lifts:
  - calc_jumptable_large.exe -> %sw_input = and i64 %RCX, 15 then switch i64 %sw_input, label %..sw_unreachable [ i64 0..15 ].
  - calc_jumptable.exe -> %0 = trunc i64 %RCX to i32 then switch i32 %0, label %..sw_unreachable [ i32 0..9 ].
- All existing jumptable_* samples (basic/dense/rel32/shifted/shared_targets/computation) still match their patterns via the Mode B fallback.
- Test patterns updated for calc_jumptable and calc_jumptable_large.

## Reviewer history
Three reviewer passes. First pass shipped with one P3; second pass found a P1 latent IR-validity defect (sibling PHI handling), one P2 missing range-guard subject/branch validation, one P2 narrow-mask soundness gap, and a P3 add-operand commutation gap. All addressed in the second amend. Third pass found one P1 UB-through-trunc-narrowed-guards (the and-mask trick was unsound for non-power-of-2 ULT bounds and for trunc-narrowed operands). Fixed in the third amend by capturing guardedValue and forking the switch-operand strategy. Final review returned a clean LGTM.