### PR TITLE
Re-skip calc_fib and calc_sum_array in CI

### DIFF
--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -37,7 +37,7 @@ Mergen is a function-level LLVM IR lifting engine for deobfuscation and devirtua
 
 ## Quality Contract
 - Handler coverage: 115/119 handlers covered by the full-handler oracle suite, with 4 intentional skips (`cpuid`, `rdtsc`, `ret`, `scasx`)
-- Active regression corpus: 33 semantic samples / 177 runtime semantic cases in CI; `calc_sum_to_n`, `calc_fib`, `calc_sum_array`, `stack_vm_loop`, and `calc_cout` are all active under the current safe path
+- Active regression corpus: 31 semantic samples / 175 runtime semantic cases in CI; `calc_cout`, `calc_sum_to_n`, and `stack_vm_loop` are active under the current safe path; `calc_fib` and `calc_sum_array` remain `ci_skip` because windows-latest clang-cl emits a codegen shape the lifter cannot yet handle (tracked as a follow-up; local clean Release builds lift them correctly)
 - Determinism: golden IR hashes are enforced for tracked outputs
 - CI gates: register/flag correctness, rewrite baseline, semantic regression, and Windows build lanes
 - Targeted VMP gate: `python test.py vmp` must keep required 3.8.x targets at `blocks_completed > 0`; VMP 3.6 remains best-effort only

--- a/scripts/rewrite/instruction_microtests.json
+++ b/scripts/rewrite/instruction_microtests.json
@@ -246,6 +246,8 @@
     {
       "name": "calc_fib",
       "symbol": "calc_fib",
+      "ci_skip": true,
+      "ci_skip_reason": "windows-latest clang-cl produces a calc_fib codegen shape that the lifter still cannot handle (lifter exits non-zero before emitting IR). Local clean Release builds pass; CI does not. Tracked as a follow-up to land a real fix instead of toggling the skip.",
       "patterns": ["ret i64 13"],
       "semantic": [
         { "expected": 13, "label": "constant: fib(7)" }
@@ -254,6 +256,8 @@
     {
       "name": "calc_sum_array",
       "symbol": "calc_sum_array",
+      "ci_skip": true,
+      "ci_skip_reason": "Same windows-latest clang-cl codegen mismatch as calc_fib; tracked as a follow-up.",
       "patterns": ["ret i64 150"],
       "semantic": [
         { "expected": 150, "label": "constant: 10+20+30+40+50" }


### PR DESCRIPTION
Hot-fix for the strict/quick gate failures introduced by PR #93. Both samples lift cleanly under a local clean Release build but the windows-latest clang-cl in CI produces a codegen shape the lifter cannot handle, so the lift exits non-zero before emitting IR (run 24077021868: Lifter failed for calc_fib).

PR #93's reasoning was wrong: the local symptom was a stale build cache, but the underlying CI failure is a real toolchain mismatch that the HANDOFF note had already documented. Restoring the ci_skip entries (with explicit reasons) unbreaks both rewrite gates.

Real fix tracked as a follow-up: either teach the lifter the windows-latest codegen shape, or pin the rewrite CI lane to a toolchain that matches local byte-for-byte.

Reverts the docs/SCOPE.md corpus counts to 31 samples / 175 cases.