### PR TITLE
Upgrade rewrite gate clang-cl to 21.1.8; re-enable calc_fib and calc_sum_array

### DIFF
--- a/.github/workflows/rewrite-strict-gate.yml
+++ b/.github/workflows/rewrite-strict-gate.yml
@@ -51,9 +51,29 @@ jobs:
           Install-ChocoPkg "ninja"
           Install-ChocoPkg "7zip"
 
+      - name: Upgrade clang-cl to 21.1.8
+        shell: pwsh
+        run: |
+          # The windows-latest preinstalled clang-cl (currently 20.1.8) produces
+          # a lifter binary that segfaults on calc_fib before emitting any IR.
+          # Clang 21.1.8 has been verified locally to compile the lifter into a
+          # binary that lifts both calc_fib and calc_sum_array to their expected
+          # constant returns. Clang 18 cannot be used because the runner image's
+          # MSVC STL (14.44+) hard-requires clang 19.0.0 or newer.
+          choco upgrade llvm --version=21.1.8 --no-progress -y
+          if ($LASTEXITCODE -ne 0) { throw "choco upgrade llvm failed with $LASTEXITCODE" }
+          $clangCl = "C:\Program Files\LLVM\bin\clang-cl.exe"
+          if (!(Test-Path $clangCl)) { throw "clang-cl.exe not found at $clangCl after upgrade" }
+          "CMAKE_C_COMPILER=$clangCl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "CMAKE_CXX_COMPILER=$clangCl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Host "Resolved clang-cl=$clangCl"
+          & $clangCl --version
+
       - name: Resolve LLVM_DIR
         shell: pwsh
         run: |
+          # The LLVM link-time libraries come from the vovkos package because
+          # the Windows LLVM installer does not ship the cmake config files.
           $llvmVersion = "18.1.8"
           $llvmArchiveName = "llvm-$llvmVersion-windows-amd64-msvc17-msvcrt.7z"
           $llvmUrl = "https://github.com/vovkos/llvm-package-windows/releases/download/llvm-$llvmVersion/$llvmArchiveName"
@@ -71,13 +91,10 @@ jobs:
           "LLVM_DIR=$llvmDir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Host "Resolved LLVM_DIR=$llvmDir"
 
-      - name: Resolve clang-cl
+      - name: Print clang-cl version
         shell: pwsh
         run: |
-          $clangCl = (Get-Command clang-cl -ErrorAction Stop).Source
-          "CMAKE_C_COMPILER=$clangCl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          "CMAKE_CXX_COMPILER=$clangCl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          Write-Host "Resolved clang-cl=$clangCl"
+          & "$env:CMAKE_CXX_COMPILER" --version
 
       - name: Configure iced build
         run: cmd /c scripts\dev\configure_iced.cmd

--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -37,7 +37,7 @@ Mergen is a function-level LLVM IR lifting engine for deobfuscation and devirtua
 
 ## Quality Contract
 - Handler coverage: 115/119 handlers covered by the full-handler oracle suite, with 4 intentional skips (`cpuid`, `rdtsc`, `ret`, `scasx`)
-- Active regression corpus: 31 semantic samples / 175 runtime semantic cases in CI; `calc_cout`, `calc_sum_to_n`, and `stack_vm_loop` are active under the current safe path; `calc_fib` and `calc_sum_array` remain `ci_skip` because windows-latest clang-cl emits a codegen shape the lifter cannot yet handle (tracked as a follow-up; local clean Release builds lift them correctly)
+- Active regression corpus: 33 semantic samples / 177 runtime semantic cases in CI; `calc_sum_to_n`, `calc_fib`, `calc_sum_array`, `stack_vm_loop`, and `calc_cout` are all active under the current safe path
 - Determinism: golden IR hashes are enforced for tracked outputs
 - CI gates: register/flag correctness, rewrite baseline, semantic regression, and Windows build lanes
 - Targeted VMP gate: `python test.py vmp` must keep required 3.8.x targets at `blocks_completed > 0`; VMP 3.6 remains best-effort only

--- a/scripts/rewrite/instruction_microtests.json
+++ b/scripts/rewrite/instruction_microtests.json
@@ -246,8 +246,6 @@
     {
       "name": "calc_fib",
       "symbol": "calc_fib",
-      "ci_skip": true,
-      "ci_skip_reason": "windows-latest clang-cl produces a calc_fib codegen shape that the lifter still cannot handle (lifter exits non-zero before emitting IR). Local clean Release builds pass; CI does not. Tracked as a follow-up to land a real fix instead of toggling the skip.",
       "patterns": ["ret i64 13"],
       "semantic": [
         { "expected": 13, "label": "constant: fib(7)" }
@@ -256,8 +254,6 @@
     {
       "name": "calc_sum_array",
       "symbol": "calc_sum_array",
-      "ci_skip": true,
-      "ci_skip_reason": "Same windows-latest clang-cl codegen mismatch as calc_fib; tracked as a follow-up.",
       "patterns": ["ret i64 150"],
       "semantic": [
         { "expected": 150, "label": "constant: 10+20+30+40+50" }


### PR DESCRIPTION
## Summary
The windows-latest preinstalled clang-cl (currently 20.1.8 at `C:\Program Files\LLVM\bin\clang-cl.exe`) produces a lifter binary that segfaults on `calc_fib` before emitting any IR (ACCESS_VIOLATION 0xC0000005), causing the rewrite gates to fail whenever `calc_fib` or `calc_sum_array` is un-skipped. Clang 21.1.8 is verified locally to compile the lifter into a binary that lifts both samples to their expected constant returns.

## Why not downgrade to clang 18?
The runner image's MSVC STL (14.44.35207+) hard-requires clang 19.0.0 or newer via a `static_assert` in `yvals_core.h`:

```
error STL1000: Unexpected compiler version, expected Clang 19.0.0 or newer.
```

Clang 18.1.8 cannot build any C++ TU that includes the STL on the current windows-latest image, so pinning to the same LLVM 18 version the lifter links against is not an option. Clang 21.1.8 is the lowest tested version that both satisfies the STL requirement and avoids the clang-20 miscompile.

## Changes
- `.github/workflows/rewrite-strict-gate.yml`: add an `Upgrade clang-cl to 21.1.8` step before `Resolve LLVM_DIR` that runs `choco upgrade llvm --version=21.1.8` and pins `CMAKE_{C,CXX}_COMPILER` to the upgraded binary.
- `scripts/rewrite/instruction_microtests.json`: drop the `ci_skip` entries on `calc_fib` and `calc_sum_array`.
- `docs/SCOPE.md`: bump the corpus counts to 33 samples / 177 runtime semantic cases.

## Verification
All CI checks pass on this branch (run 24089530699): `rewrite-quick-gate`, `rewrite-strict-gate`, `build (iced)`, `build (zydis)`, `windows-iced`, `windows-zydis`.

## Follow-up
Investigating the underlying clang 20.1.8 miscompile in the lifter is still worth doing \u2014 it is almost certainly UB somewhere in the structured-loop recovery path that clang 21 happens to tolerate. Tracked separately.