### PR TITLE
lifter: add opt-in lift-progress diagnostic for spotting dispatcher spinning

### DIFF
--- a/lifter/core/LiftDriver.hpp
+++ b/lifter/core/LiftDriver.hpp
@@ -85,4 +85,5 @@ inline void runLiftWorklist(lifterConcolic<>* lifter) {
        << lifter->liftStats.instructions_unsupported << " unsupported)";
     lifter->diagnostics.info(DiagCode::LiftComplete, 0, ss.str());
   }
+  lifter->dumpLiftProgressReport(std::cout);
 }

--- a/lifter/core/LifterClass.hpp
+++ b/lifter/core/LifterClass.hpp
@@ -592,6 +592,9 @@ public:
 
   void liftBasicBlockFromAddress(uint64_t addr) {
     ++liftStats.blocks_attempted;
+    if (liftProgressDiagEnabled) {
+      ++liftAttemptCounts[addr];
+    }
     printvalue2(this->finished);
     printvalue2(this->run);
     this->run = 1;
@@ -651,6 +654,54 @@ public:
     }
   }
 
+  // Prints a compact summary of which addresses the lift attempted and how
+  // often. Useful for diagnosing whether progress through a VM's handler graph
+  // is genuine (many distinct addresses, low revisit count) or the dispatcher
+  // is spinning (few distinct addresses, high revisit counts).
+  void dumpLiftProgressReport(std::ostream& os) const {
+    if (!liftProgressDiagEnabled || liftAttemptCounts.empty()) {
+      return;
+    }
+    // Sort addresses by revisit count, descending.
+    std::vector<std::pair<uint64_t, uint32_t>> entries;
+    entries.reserve(liftAttemptCounts.size());
+    for (const auto& kv : liftAttemptCounts) {
+      entries.emplace_back(kv.first, kv.second);
+    }
+    std::sort(entries.begin(), entries.end(),
+              [](const auto& a, const auto& b) { return a.second > b.second; });
+    uint64_t totalAttempts = 0;
+    uint32_t maxCount = 0;
+    // Histogram buckets: 1, 2, 3-4, 5-8, 9-16, 17-32, 33+
+    std::array<uint32_t, 7> histogram{};
+    auto bucket = [](uint32_t count) -> size_t {
+      if (count <= 1) return 0;
+      if (count == 2) return 1;
+      if (count <= 4) return 2;
+      if (count <= 8) return 3;
+      if (count <= 16) return 4;
+      if (count <= 32) return 5;
+      return 6;
+    };
+    for (const auto& [addr, count] : entries) {
+      totalAttempts += count;
+      if (count > maxCount) maxCount = count;
+      ++histogram[bucket(count)];
+    }
+    os << "[diag] lift-progress unique_addresses=" << entries.size()
+       << " total_attempts=" << totalAttempts
+       << " max_revisits=" << maxCount << "\n";
+    os << "[diag] lift-progress histogram 1/2/3-4/5-8/9-16/17-32/33+:";
+    for (uint32_t count : histogram) os << " " << count;
+    os << "\n";
+    const size_t top = std::min<size_t>(entries.size(), 16);
+    os << "[diag] lift-progress top-" << top << " revisited addresses:\n";
+    for (size_t i = 0; i < top; ++i) {
+      os << "  0x" << std::hex << entries[i].first << std::dec
+         << " x" << entries[i].second << "\n";
+    }
+    os << std::flush;
+  }
 
   bool addUnvisitedAddr(BBInfo bb) {
     printvalue2(bb.block_address);
@@ -723,6 +774,13 @@ public:
 
   unsigned int instct = 0;
   LiftStats liftStats;
+  // Per-address lift attempt counts. Only populated when the lift-progress diag
+  // is requested (MERGEN_DIAG_LIFT_PROGRESS=1); otherwise stays empty and the
+  // increment below is a no-op on a DenseMap miss because we gate it behind the
+  // same flag. Used by dumpLiftProgressReport to show whether the dispatcher
+  // is genuinely advancing through distinct VM handlers or churning on a few.
+  llvm::DenseMap<uint64_t, uint32_t> liftAttemptCounts;
+  bool liftProgressDiagEnabled = false;
   LiftDiagnostics diagnostics;
   PipelineProfiler profiler;
   llvm::SimplifyQuery* cachedquery;

--- a/lifter/core/LifterStages.hpp
+++ b/lifter/core/LifterStages.hpp
@@ -21,6 +21,11 @@ createConfiguredLifterForRuntime(uint8_t* fileBase, size_t fileSize,
                                 uint64_t runtimeAddress) {
   auto lifter = std::make_unique<lifterConcolic<>>();
   lifter->loadFile(fileBase);
+  if (const char* env = std::getenv("MERGEN_DIAG_LIFT_PROGRESS")) {
+    const std::string_view value(env);
+    lifter->liftProgressDiagEnabled =
+        value == "1" || value == "true" || value == "TRUE";
+  }
   // Memory policy configured later in prepareLifterStageContext
   // when RuntimeImageContext (with PE stack reserve) is available.
 


### PR DESCRIPTION
## Summary

When `MERGEN_DIAG_LIFT_PROGRESS=1` is set in the environment, the lifter tracks per-address attempt counts and prints a compact summary at the end of the lift. Default behavior (env unset) is completely unchanged.

## What you see with the flag on

On a real Themida-obfuscated sample (`example2-virt.bin` @ `0x140001000`):

```
[diag] lift-progress unique_addresses=139 total_attempts=2639 max_revisits=1142
[diag] lift-progress histogram 1/2/3-4/5-8/9-16/17-32/33+: 122 0 1 0 6 8 2
[diag] lift-progress top-16 revisited addresses:
  0x1401bae0f x1142
  0x1401bae18 x1142
  0x14003e376 x17
  ...
```

139 unique addresses across 2,639 attempts \u2014 two of them (`0x1401BAE0F`, `0x1401BAE18`) account for 2,284 attempts (86.6% of total lift effort). Disassembly confirms `0x1401BAE0F` is a `test rbx,rbx; je` dispatcher loop header whose loop generalization isn't firing. Without this PR, nothing printed.

## Why it's safe

Purely opt-in:
- `MERGEN_DIAG_LIFT_PROGRESS` is read once at lifter construction via the same pattern as `MERGEN_SKIP_OPT` / `MERGEN_WRITE_UNOPT_IR`.
- The per-block increment is guarded by a bool; with the env unset, it's a single branch.
- `dumpLiftProgressReport` early-returns when the flag is off or the map is empty, so there's no stdout output that could interfere with the test harness.

## Tests

`python test.py quick` fully green with the env var unset:
- All rewrite regression checks passed (50+ samples)
- Determinism check: 42/42 golden files match
- Semantic regression: 33/33 passed
- All instruction microtests passed

## Scope

3 files, +64, no deletions, no behavior change.

- `lifter/core/LifterClass.hpp`: new `liftAttemptCounts` DenseMap, `liftProgressDiagEnabled` bool, increment in `liftBasicBlockFromAddress`, new `dumpLiftProgressReport(std::ostream&) const`.
- `lifter/core/LifterStages.hpp`: reads the env var when constructing the lifter.
- `lifter/core/LiftDriver.hpp`: calls the dump method after the lift worklist finishes.