### PR TITLE
lifter: expand lift-progress diag with per-reason canGeneralize/shape tracing

### DIFF
--- a/lifter/core/LifterClass.hpp
+++ b/lifter/core/LifterClass.hpp
@@ -518,28 +518,46 @@ public:
            currentPathSolveContext == PathSolveContext::IndirectJump;
   }
   bool isStructuredLoopHeaderShape(BasicBlock* block) const {
+    const bool trace = liftProgressDiagEnabled &&
+                       (block == addrToBB.lookup(0x1401BAE0FULL) ||
+                        block == addrToBB.lookup(0x1401BAE18ULL));
     std::set<BasicBlock*> seenBlocks;
     auto* current = block;
     for (unsigned depth = 0; current && depth < 8; ++depth) {
       if (!seenBlocks.insert(current).second || current->empty()) {
+        if (trace) std::cout << "[diag] shape depth=" << depth << " reject="
+                             << (current->empty() ? "empty" : "cycle") << "\n";
         return false;
       }
       const size_t maxPreds = depth == 0 ? 2 : 1;
-      if (llvm::pred_size(current) > maxPreds) {
+      const size_t preds = llvm::pred_size(current);
+      if (preds > maxPreds) {
+        if (trace) std::cout << "[diag] shape depth=" << depth
+                             << " reject=pred-count preds=" << preds
+                             << " max=" << maxPreds << "\n";
         return false;
       }
       auto* branch = llvm::dyn_cast<llvm::BranchInst>(current->getTerminator());
       if (!branch) {
+        if (trace) std::cout << "[diag] shape depth=" << depth
+                             << " reject=not-branch term="
+                             << (current->getTerminator() ? current->getTerminator()->getOpcodeName() : "none")
+                             << "\n";
         return false;
       }
       if (branch->isConditional()) {
+        if (trace) std::cout << "[diag] shape depth=" << depth << " ACCEPT cond-br\n";
         return true;
       }
       if (branch->getNumSuccessors() != 1) {
+        if (trace) std::cout << "[diag] shape depth=" << depth
+                             << " reject=multi-succ count="
+                             << branch->getNumSuccessors() << "\n";
         return false;
       }
       current = branch->getSuccessor(0);
     }
+    if (trace) std::cout << "[diag] shape reject=depth-exceeded\n";
     return false;
   }
   bool blockCanReach(BasicBlock* source, BasicBlock* target) const {
@@ -574,20 +592,59 @@ public:
         targetResolvedConcretely
             ? currentPathSolveAllowsStructuredLoopGeneralizationForResolvedTarget()
             : currentPathSolveAllowsStructuredLoopGeneralization();
-    if (getControlFlow() != ControlFlow::Unflatten || !contextAllows ||
-        addr > blockInfo.block_address || !visitedAddresses.contains(addr) ||
-        pendingLoopGeneralizationAddresses.contains(addr) ||
-        generalizedLoopAddresses.contains(addr)) {
+    const bool traceHere = liftProgressDiagEnabled &&
+                           (addr == 0x1401BAE0FULL || addr == 0x1401BAE18ULL);
+    auto reject = [&](const char* reason) {
+      if (traceHere) {
+        std::cout << "[diag] canGeneralize addr=0x" << std::hex << addr
+                  << " current=0x" << blockInfo.block_address << std::dec
+                  << " ctx=" << static_cast<int>(currentPathSolveContext)
+                  << " resolved=" << (targetResolvedConcretely ? 1 : 0)
+                  << " reject=" << reason << "\n";
+      }
       return false;
-    }
+    };
+    if (getControlFlow() != ControlFlow::Unflatten) return reject("not-unflatten");
+    if (!contextAllows) return reject("context-not-allowed");
+    if (addr > blockInfo.block_address) return reject("forward-target");
+    if (!visitedAddresses.contains(addr)) return reject("not-visited");
+    if (pendingLoopGeneralizationAddresses.contains(addr)) return reject("already-pending");
+    if (generalizedLoopAddresses.contains(addr)) return reject("already-generalized");
     auto it = addrToBB.find(addr);
-    if (it == addrToBB.end() || !it->second || it->second->empty()) {
-      return false;
-    }
+    if (it == addrToBB.end() || !it->second || it->second->empty())
+      return reject("empty-or-missing-bb");
     // Only treat a visited header as reusable when it already reaches the
     // current block; acyclic backward jumps into earlier diamonds are not loops.
-    return isStructuredLoopHeaderShape(it->second) &&
-           blockInfo.block && blockCanReach(it->second, blockInfo.block);
+    if (traceHere) {
+      auto* bb = it->second;
+      std::string termName = bb->getTerminator()
+                                 ? bb->getTerminator()->getOpcodeName()
+                                 : std::string("NO-TERM");
+      std::cout << "[diag] canGeneralize addr=0x" << std::hex << addr << std::dec
+                << " bb-size=" << bb->size()
+                << " term=" << termName
+                << " succs=" << (bb->getTerminator() ? bb->getTerminator()->getNumSuccessors() : 0)
+                << " preds=" << llvm::pred_size(bb)
+                << "\n" << std::flush;
+    }
+    if (traceHere) {
+      auto* bb = it->second;
+      std::string bbText;
+      llvm::raw_string_ostream os(bbText);
+      bb->print(os);
+      if (bbText.size() > 500) bbText = bbText.substr(0, 500) + " ...";
+      std::cout << "[diag] canGeneralize addr=0x" << std::hex << addr << std::dec
+                << " bb-ir: " << bbText << "\n" << std::flush;
+    }
+    if (!isStructuredLoopHeaderShape(it->second)) return reject("bad-shape");
+    if (!blockInfo.block) return reject("no-current-block");
+    if (!blockCanReach(it->second, blockInfo.block)) return reject("no-reach");
+    if (traceHere) {
+      std::cout << "[diag] canGeneralize addr=0x" << std::hex << addr
+                << " current=0x" << blockInfo.block_address << std::dec
+                << " ACCEPT\n";
+    }
+    return true;
   }
 
   void liftBasicBlockFromAddress(uint64_t addr) {


### PR DESCRIPTION
## Summary

Extends the opt-in `MERGEN_DIAG_LIFT_PROGRESS` diagnostic from #99 with per-invocation trace output for `canGeneralizeStructuredLoopHeader` and `isStructuredLoopHeaderShape`. Used to pin down why loop generalization fails for specific addresses without needing to rebuild with ad-hoc prints.

## Motivation

Using #99's diagnostic we observed that `0x1401BAE0F` and `0x1401BAE18` dominate the Themida sample's lift effort (1,142 attempts each, 86.6% of all work). This PR adds enough extra trace to see *why*.

Sample output with the env flag on, running `example2-virt.bin @ 0x140001000`:

```
[diag] canGeneralize addr=0x1401bae0f current=0x1401bae18 ctx=2 resolved=1 reject=bad-shape  (\u00d71141)
[diag] canGeneralize addr=0x1401bae0f bb-size=1 term=br succs=1 preds=1                        (\u00d71141)
[diag] canGeneralize addr=0x1401bae0f bb-ir: previousjmp_block-5370523160-181:
                                              ; preds = %bb_solved_const178
                                              br label %bb_solved_const180                     (\u00d71141)
[diag] shape depth=1 reject=not-branch term=none                                               (\u00d71141)
```

This reveals the actual rejection: `addrToBB[0x1401BAE0F]` points to a 1-instruction `previousjmp_block` trampoline. The shape check walks it at depth=0, reaches the successor at depth=1, and finds the successor has no terminator (it's a partially-lifted block). So `isStructuredLoopHeaderShape` rejects.

## Change

Single file, `lifter/core/LifterClass.hpp`, +68 / -11:

1. `canGeneralizeStructuredLoopHeader`: refactors the sequential `if (...) return false;` rejection chain into a named `reject(reason)` lambda so each gate tags itself. Every rejection path prints one line with the reason when tracing is enabled. Also prints block size/term/successors/predecessors and a truncated IR dump of the block.

2. `isStructuredLoopHeaderShape`: prints per-depth `reject=<reason>` lines (`empty`, `cycle`, `pred-count`, `not-branch`, `multi-succ`, `depth-exceeded`) or `ACCEPT cond-br`, same gate.

3. Both gated behind `liftProgressDiagEnabled && (addr \u2208 {0x1401BAE0F, 0x1401BAE18})`. The hot-address filter keeps output focused; update the filter to investigate other samples.

No new fields or includes. All original rejection logic is preserved in identical order \u2014 the `reject` lambda just wraps the trace + `return false`.

## Tests

`python test.py quick` fully green with the env flag unset:
- All rewrite regression checks passed
- Determinism check: 42/42
- Semantic regression: 33/33
- All instruction microtests passed