### PR TITLE
lifter: relax structured-loop shape check for trampoline-header pattern

### DIFF
--- a/lifter/core/LifterClass.hpp
+++ b/lifter/core/LifterClass.hpp
@@ -521,6 +521,19 @@ public:
     const bool trace = liftProgressDiagEnabled &&
                        (block == addrToBB.lookup(0x1401BAE0FULL) ||
                         block == addrToBB.lookup(0x1401BAE18ULL));
+    // Detect the trampoline pattern at the header: a single unconditional br
+    // (no other instructions). When the header is a trampoline, its successor
+    // is the real per-instruction lift block; if that successor is mid-lift
+    // (no proper terminator yet) we still want to recognise the loop. Without
+    // a trampoline header we keep the original strict shape semantics so
+    // ordinary linear lifts (VMP-style) don't get mis-classified as loops.
+    auto isTrampoline = [](BasicBlock* bb) {
+      if (!bb || bb->size() != 1) return false;
+      auto* term = bb->getTerminator();
+      auto* br = llvm::dyn_cast<llvm::BranchInst>(term);
+      return br && !br->isConditional();
+    };
+    const bool entryIsTrampoline = isTrampoline(block);
     std::set<BasicBlock*> seenBlocks;
     auto* current = block;
     for (unsigned depth = 0; current && depth < 8; ++depth) {
@@ -537,11 +550,28 @@ public:
                              << " max=" << maxPreds << "\n";
         return false;
       }
-      auto* branch = llvm::dyn_cast<llvm::BranchInst>(current->getTerminator());
+      auto* term = current->getTerminator();
+      auto* branch = llvm::dyn_cast<llvm::BranchInst>(term);
       if (!branch) {
+        // Trampoline-header relaxation: when the original header was a single
+        // unconditional-br trampoline and we walked into a successor that is
+        // currently being lifted (no proper terminator yet, but already has
+        // instructions), accept the chain so loop generalization can latch
+        // onto the header. The rest of canGeneralizeStructuredLoopHeader
+        // (backwardVisitedTarget and blockCanReach) still filters out chains
+        // that aren't actually loops.
+        const bool hasProperTerminator = term && term->isTerminator();
+        if (entryIsTrampoline && !hasProperTerminator && depth > 0 &&
+            !current->empty()) {
+          if (trace) std::cout << "[diag] shape depth=" << depth
+                               << " ACCEPT partial-chain-after-trampoline\n";
+          return true;
+        }
         if (trace) std::cout << "[diag] shape depth=" << depth
                              << " reject=not-branch term="
-                             << (current->getTerminator() ? current->getTerminator()->getOpcodeName() : "none")
+                             << (term ? term->getOpcodeName() : "none")
+                             << " isTerm=" << (hasProperTerminator ? 1 : 0)
+                             << " entryTrampoline=" << (entryIsTrampoline ? 1 : 0)
                              << "\n";
         return false;
       }


### PR DESCRIPTION
## Summary

Allows loop generalization to recognize a dispatcher shape that Themida-style obfuscators produce: the loop header candidate is a single-instruction unconditional-br trampoline block, and its successor (the real per-instruction lift block) is still mid-lift when `canGeneralizeStructuredLoopHeader` runs. Previously that rejected with `bad-shape` and the dispatcher spun for 1,142 iterations.

## Why

The #99/#100 diagnostics showed `example2-virt.bin @ 0x140001000` was consuming 86.6% of its 4096-block budget re-lifting a dispatcher loop body that was already semantically a loop. Two observations:

1. `addrToBB[0x1401BAE0F]` points to a `previousjmp_block-...` trampoline (bb-size=1, unconditional `br`).
2. Its successor `bb_solved_const180` has `isTerminator()==false` at the moment `canGeneralizeStructuredLoopHeader` runs (lifter is mid-processing instructions before the conditional branch is emitted).

`isStructuredLoopHeaderShape` then walked the trampoline at depth=0 (passes as unconditional br), walked to depth=1, saw no valid terminator, rejected as `not-branch`. The outer gate returned false and generalization never fired.

## Fix

Detect the trampoline-header shape up front (`bb->size() == 1` with an unconditional BranchInst terminator), cache the flag in `entryIsTrampoline`, and only when it holds allow the depth-1 partial-chain successor to pass. The outer gates in `canGeneralizeStructuredLoopHeader` (`backwardVisitedTarget`, `blockCanReach`) still catch non-loop patterns.

Without the trampoline gate the relaxation is too wide: `simple_vmp381_one_vm` drops from 1629\u21a758 blocks (1\u21a70 completed). With the gate, VMP behavior is preserved.

## Change

One file, `lifter/core/LifterClass.hpp`, +32/-2. All changes are inside `isStructuredLoopHeaderShape`.

## Impact

On `example2-virt.bin @ 0x140001000`:

| metric | before | after |
|---|---|---|
| blocks_attempted | 2639 | 17 |
| dispatcher head re-lifts | 1142 each | 2-3 each |
| unique addresses touched | 139 | 14 |
| max revisits | 1142 | 3 |

## Tests

- `python test.py quick`: all rewrite regressions pass, determinism 42/42, semantic 33/33, all instruction microtests pass
- `python test.py vmp`: `simple_vmp381_one_vm` (1629/1) and `simple_vmp381_full` (1621/1) both still gate-pass. Same counts as main.

## Notes from review

- Review flagged two redundancies (`!current->empty()` is already guaranteed by the top-of-loop guard; `term->isTerminator()` is tautological given `getTerminator()`'s contract in LLVM). Kept both as harmless defensive checks.