### PR TITLE
lifter: widen generalized loop backedges

### DIFF
--- a/lifter/analysis/PathSolver.ipp
+++ b/lifter/analysis/PathSolver.ipp
@@ -52,6 +52,7 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(PATH_info)::solvePath(
   auto resolveTargetBlock = [&](uint64_t target, const std::string& name)
       -> ResolvedTargetBlock {
     if (auto* reused = getLiftedBackedgeBB(target)) {
+      record_generalized_loop_backedge(reused);
       return {reused, true, false};
     }
 

--- a/lifter/core/LifterClass.hpp
+++ b/lifter/core/LifterClass.hpp
@@ -493,6 +493,14 @@ public:
   void branch_backup(BasicBlock* bb, bool generalized = false) {
     static_cast<Derived*>(this)->branch_backup_impl(bb, generalized);
   }
+  void migrate_generalized_loop_block(BasicBlock* oldBlock, BasicBlock* newBlock) {
+    static_cast<Derived*>(this)->migrate_generalized_loop_block_impl(oldBlock, newBlock);
+  }
+
+  void record_generalized_loop_backedge(BasicBlock* bb) {
+    static_cast<Derived*>(this)->record_generalized_loop_backedge_impl(bb);
+  }
+
   // useless in symbolic?
   void load_backup(BasicBlock* bb) {
     static_cast<Derived*>(this)->load_backup_impl(bb);
@@ -971,6 +979,8 @@ public:
 
     auto it = addrToBB.find(addr);
     if (it != addrToBB.end() && it->second && it->second != newBlock) {
+      static_cast<Derived*>(this)->migrate_generalized_loop_block_impl(it->second,
+                                                                      newBlock);
       it->second->replaceAllUsesWith(newBlock);
     }
 

--- a/lifter/core/LifterClass_Concolic.hpp
+++ b/lifter/core/LifterClass_Concolic.hpp
@@ -160,40 +160,51 @@ public:
     InstructionCache cache;
     llvm::DenseMap<llvm::Instruction*, llvm::APInt> assumptions;
     uint64_t ct;
+    llvm::BasicBlock* sourceBlock;
 
     bool operator==(const backup_point& other) const {
       if (buffer != other.buffer)
         return false;
-      return vec == other.vec && vecflag == other.vecflag;
+      return vec == other.vec && vecflag == other.vecflag &&
+             sourceBlock == other.sourceBlock;
     }
 
     backup_point(backup_point& other)
         : vec(other.vec), vecflag(other.vecflag), buffer(other.buffer),
-          cache(other.cache), assumptions(other.assumptions), ct(other.ct){};
+          cache(other.cache), assumptions(other.assumptions), ct(other.ct),
+          sourceBlock(other.sourceBlock){};
 
     backup_point(backup_point&& other) noexcept
         : vec(std::move(other.vec)), vecflag(std::move(other.vecflag)),
           buffer(std::move(other.buffer)), cache(std::move(other.cache)),
-          assumptions(other.assumptions), ct(other.ct) {}
+          assumptions(other.assumptions), ct(other.ct),
+          sourceBlock(other.sourceBlock) {}
 
     backup_point(std::array<llvm::Value*, REGISTER_COUNT> vec,
                  std::array<llvm::Value*, FLAGS_END> vecflag,
                  llvm::DenseMap<uint64_t, ValueByteReference> buffer,
                  InstructionCache cc,
                  llvm::DenseMap<llvm::Instruction*, llvm::APInt> assumptions,
-                 uint64_t ct)
+                 uint64_t ct, llvm::BasicBlock* sourceBlock)
         : vec(vec), vecflag(vecflag), buffer(buffer), cache(cc),
-          assumptions(assumptions), ct(ct){};
+          assumptions(assumptions), ct(ct), sourceBlock(sourceBlock){};
     backup_point() = default;
     backup_point(const backup_point&) = default;
-    // backup_point(const backup_point&&) = default;
     backup_point& operator=(const backup_point&) = default;
     backup_point& operator=(backup_point&&) noexcept = default;
   };
 
   llvm::DenseMap<BasicBlock*, backup_point> BBbackup;
+  llvm::DenseMap<BasicBlock*, backup_point> generalizedLoopBackedgeBackup;
 
-  backup_point make_generalized_loop_backup(const backup_point& source) {
+  llvm::DenseMap<BasicBlock*, std::array<llvm::PHINode*, REGISTER_COUNT>>
+      generalizedLoopRegisterPhis;
+  llvm::DenseMap<BasicBlock*, std::array<llvm::PHINode*, FLAGS_END>>
+      generalizedLoopFlagPhis;
+
+  backup_point make_generalized_loop_backup(BasicBlock* bb,
+                                            const backup_point& canonical,
+                                            const backup_point& source) {
     backup_point generalized = source;
     llvm::DenseMap<uint64_t, ValueByteReference> filteredBuffer;
     filteredBuffer.reserve(source.buffer.size());
@@ -205,6 +216,48 @@ public:
     generalized.buffer = std::move(filteredBuffer);
     generalized.cache = InstructionCache();
     generalized.assumptions.clear();
+
+    auto* canonicalSource = canonical.sourceBlock;
+    auto* backedgeSource = source.sourceBlock;
+    if (!bb || !canonicalSource || !backedgeSource ||
+        canonicalSource == backedgeSource) {
+      return generalized;
+    }
+    std::array<llvm::PHINode*, REGISTER_COUNT> registerPhis{};
+    std::array<llvm::PHINode*, FLAGS_END> flagPhis{};
+
+
+    llvm::IRBuilder<> phiBuilder(bb, bb->begin());
+    auto mergeValue = [&](llvm::Value* canonicalValue, llvm::Value* backedgeValue,
+                          const char* name, llvm::PHINode*& phiOut)
+        -> llvm::Value* {
+      if (!canonicalValue || !backedgeValue ||
+          canonicalValue->getType() != backedgeValue->getType() ||
+          canonicalValue == backedgeValue) {
+        return backedgeValue;
+      }
+      auto* phi = phiBuilder.CreatePHI(canonicalValue->getType(), 2, name);
+      phi->addIncoming(canonicalValue, canonicalSource);
+      // Seed the backedge with undef until the real generalized self-edge is
+      // recorded. Using the concrete first-iteration value here over-constrains
+      // the loop header and folds exits like `test reg, reg; je exit` away.
+      phi->addIncoming(llvm::UndefValue::get(backedgeValue->getType()),
+                       backedgeSource);
+      phiOut = phi;
+      return phi;
+    };
+
+    for (size_t i = 0; i < REGISTER_COUNT; ++i) {
+      generalized.vec[i] = mergeValue(canonical.vec[i], source.vec[i],
+                                      "loop_reg_phi", registerPhis[i]);
+    }
+    for (size_t i = 0; i < FLAGS_END; ++i) {
+      generalized.vecflag[i] =
+          mergeValue(canonical.vecflag[i], source.vecflag[i], "loop_flag_phi",
+                     flagPhis[i]);
+    }
+    generalizedLoopRegisterPhis[bb] = registerPhis;
+    generalizedLoopFlagPhis[bb] = flagPhis;
     return generalized;
   }
 
@@ -217,14 +270,21 @@ public:
     this->counter = snapshot.ct;
   }
 
-  void branch_backup_impl(BasicBlock* bb, bool /*generalized*/) {
+  void branch_backup_impl(BasicBlock* bb, bool generalized) {
     printvalue2("backing up");
     printvalue2(this->counter);
 
     auto snapshot = backup_point(vec, vecflag, this->buffer, this->cache,
-                                 this->assumptions, this->counter);
-    // Persist the canonical state. Generalized loop restore filters stack-local
-    // state only at load time while the temporary bypass mode is active.
+                                 this->assumptions, this->counter,
+                                 this->builder->GetInsertBlock());
+    if (generalized) {
+      if (!BBbackup.contains(bb)) {
+        BBbackup[bb] = snapshot;
+      }
+      generalizedLoopBackedgeBackup[bb] = std::move(snapshot);
+      return;
+    }
+
     BBbackup[bb] = std::move(snapshot);
   }
 
@@ -236,10 +296,73 @@ public:
   }
 
   void load_generalized_backup_impl(BasicBlock* bb) {
+    if (generalizedLoopBackedgeBackup.contains(bb) && BBbackup.contains(bb)) {
+      printvalue2("loading generalized backup");
+      auto snapshot =
+          make_generalized_loop_backup(bb, BBbackup[bb],
+                                       generalizedLoopBackedgeBackup[bb]);
+      restore_backup_point(snapshot);
+      return;
+    }
     if (BBbackup.contains(bb)) {
       printvalue2("loading generalized backup");
-      auto snapshot = make_generalized_loop_backup(BBbackup[bb]);
+      auto snapshot = make_generalized_loop_backup(bb, BBbackup[bb], BBbackup[bb]);
       restore_backup_point(snapshot);
+    }
+  }
+  void migrate_generalized_loop_block_impl(BasicBlock* oldBlock,
+                                           BasicBlock* newBlock) {
+    if (oldBlock == newBlock) {
+      return;
+    }
+    if (generalizedLoopRegisterPhis.contains(oldBlock) &&
+        !generalizedLoopRegisterPhis.contains(newBlock)) {
+      generalizedLoopRegisterPhis[newBlock] = generalizedLoopRegisterPhis[oldBlock];
+    }
+    if (generalizedLoopFlagPhis.contains(oldBlock) &&
+        !generalizedLoopFlagPhis.contains(newBlock)) {
+      generalizedLoopFlagPhis[newBlock] = generalizedLoopFlagPhis[oldBlock];
+    }
+    if (BBbackup.contains(oldBlock) && !BBbackup.contains(newBlock)) {
+      BBbackup[newBlock] = BBbackup[oldBlock];
+    }
+    if (generalizedLoopBackedgeBackup.contains(oldBlock) &&
+        !generalizedLoopBackedgeBackup.contains(newBlock)) {
+      generalizedLoopBackedgeBackup[newBlock] =
+          generalizedLoopBackedgeBackup[oldBlock];
+    }
+  }
+
+  void record_generalized_loop_backedge_impl(BasicBlock* bb) {
+    auto* sourceBlock = this->builder->GetInsertBlock();
+    if (!bb || !sourceBlock) {
+      return;
+    }
+
+    auto regIt = generalizedLoopRegisterPhis.find(bb);
+    if (regIt != generalizedLoopRegisterPhis.end()) {
+      for (size_t i = 0; i < REGISTER_COUNT; ++i) {
+        auto* phi = regIt->second[i];
+        if (!phi || !vec[i] || phi->getType() != vec[i]->getType() ||
+            phi->getParent() != bb ||
+            phi->getBasicBlockIndex(sourceBlock) >= 0) {
+          continue;
+        }
+        phi->addIncoming(vec[i], sourceBlock);
+      }
+    }
+
+    auto flagIt = generalizedLoopFlagPhis.find(bb);
+    if (flagIt != generalizedLoopFlagPhis.end()) {
+      for (size_t i = 0; i < FLAGS_END; ++i) {
+        auto* phi = flagIt->second[i];
+        if (!phi || !vecflag[i] || phi->getType() != vecflag[i]->getType() ||
+            phi->getParent() != bb ||
+            phi->getBasicBlockIndex(sourceBlock) >= 0) {
+          continue;
+        }
+        phi->addIncoming(vecflag[i], sourceBlock);
+      }
     }
   }
 

--- a/lifter/core/LifterClass_Symbolic.hpp
+++ b/lifter/core/LifterClass_Symbolic.hpp
@@ -145,6 +145,16 @@ public:
     //
     return;
   }
+  void migrate_generalized_loop_block_impl(BasicBlock* oldBlock,
+                                           BasicBlock* newBlock) {
+    (void)oldBlock;
+    (void)newBlock;
+  }
+
+  void record_generalized_loop_backedge_impl(BasicBlock* bb) {
+    (void)bb;
+  }
+
   void createFunction_impl() {
     std::vector<llvm::Type*> argTypes;
 

--- a/lifter/memory/GEPTracker.ipp
+++ b/lifter/memory/GEPTracker.ipp
@@ -958,6 +958,7 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(Value*)::solveLoad(LazyValue load,
         return true;
       };
 
+
       if (!collectAddTerms(collectAddTerms, offsetExpr, addTerms)) {
         return inferredOffsets;
       }
@@ -1031,6 +1032,7 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(Value*)::solveLoad(LazyValue load,
         return inferredOffsets;
       }
 
+
       uint64_t upperInclusive = 0;
       bool foundUpper = false;
       for (const auto& assumption : assumptions) {
@@ -1038,17 +1040,20 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(Value*)::solveLoad(LazyValue load,
           continue;
         }
 
+
         uint64_t candidateUpper = 0;
         if (!matchIndexUpperBound(matchIndexUpperBound, assumption.first,
                                   indexValue, candidateUpper)) {
           continue;
         }
 
+
         if (!foundUpper || candidateUpper < upperInclusive) {
           upperInclusive = candidateUpper;
           foundUpper = true;
         }
       }
+
 
       constexpr uint64_t kMaxJumpTableTargets = 64;
       if (!foundUpper || upperInclusive >= kMaxJumpTableTargets) {
@@ -1065,6 +1070,7 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(Value*)::solveLoad(LazyValue load,
 
       return inferredOffsets;
     };
+
 
     if (getControlFlow() == ControlFlow::Unflatten) {
       auto possibleValues = computePossibleValues(loadOffset, 0);

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -916,6 +916,87 @@ private:
 
 
 
+  bool runGeneralizedLoopRestoreMergesBackedgeRegisterState(
+      std::string& details) {
+    LifterUnderTest lifter;
+    auto* preheader =
+        llvm::BasicBlock::Create(lifter.context, "preheader", lifter.fnc);
+    auto* firstBackedge =
+        llvm::BasicBlock::Create(lifter.context, "first_backedge", lifter.fnc);
+    auto* loopBody =
+        llvm::BasicBlock::Create(lifter.context, "loop_body", lifter.fnc);
+    auto* loopHeader =
+        llvm::BasicBlock::Create(lifter.context, "loop_header", lifter.fnc);
+
+    lifter.builder->SetInsertPoint(preheader);
+    auto* canonicalRbx = makeI64(lifter.context, 37);
+    lifter.SetRegisterValue(RegisterUnderTest::RBX, canonicalRbx);
+    lifter.branch_backup(loopHeader);
+
+    lifter.builder->SetInsertPoint(firstBackedge);
+    auto* firstBackedgeRbx = lifter.builder->CreateSub(
+        makeI64(lifter.context, 37), makeI64(lifter.context, 1), "rbx_dec_init");
+    lifter.SetRegisterValue(RegisterUnderTest::RBX, firstBackedgeRbx);
+    lifter.branch_backup(loopHeader, /*generalized=*/true);
+
+    lifter.load_generalized_backup(loopHeader);
+    auto* mergedRbx = lifter.GetRegisterValue(RegisterUnderTest::RBX);
+    auto* phi = llvm::dyn_cast<llvm::PHINode>(mergedRbx);
+    if (!phi) {
+      details =
+          "  generalized loop restore should merge canonical and widened backedge RBX through a phi\n";
+      return false;
+    }
+
+    bool sawCanonical = false;
+    bool sawWidenedBackedge = false;
+    for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
+      auto* incomingBlock = phi->getIncomingBlock(i);
+      auto* incomingValue = phi->getIncomingValue(i);
+      if (incomingBlock == preheader && incomingValue == canonicalRbx) {
+        sawCanonical = true;
+      }
+      if (incomingBlock == firstBackedge &&
+          llvm::isa<llvm::UndefValue>(incomingValue)) {
+        sawWidenedBackedge = true;
+      }
+    }
+
+    if (!sawCanonical || !sawWidenedBackedge) {
+      details =
+          "  generalized loop RBX phi should keep the canonical incoming value and widen the first concrete backedge\n";
+      return false;
+    }
+
+    lifter.builder->SetInsertPoint(loopBody);
+    auto* recurrentRbx = lifter.builder->CreateSub(
+        phi, llvm::ConstantInt::get(phi->getType(), 1), "rbx_dec_loop");
+    lifter.SetRegisterValue(RegisterUnderTest::RBX, recurrentRbx);
+    lifter.record_generalized_loop_backedge(loopHeader);
+
+    bool sawRecurrentIncoming = false;
+    for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
+      if (phi->getIncomingBlock(i) == loopBody &&
+          phi->getIncomingValue(i) == recurrentRbx) {
+        sawRecurrentIncoming = true;
+      }
+    }
+    if (!sawRecurrentIncoming) {
+      details =
+          "  generalized loop backedge should add the live recurrent RBX value to the header phi\n";
+      return false;
+    }
+
+    lifter.load_backup(loopHeader);
+    if (lifter.GetRegisterValue(RegisterUnderTest::RBX) != canonicalRbx) {
+      details =
+          "  canonical loop-header backup should remain available after generalized restore\n";
+      return false;
+    }
+    return true;
+  }
+
+
   int runCustomKnownBitsTests(const std::string& suiteFilter) {
     int failures = 0;
 
@@ -1003,6 +1084,8 @@ private:
              &InstructionTester::runGeneralizedLoopBypassTagClearsAfterPromotion);
     runCustom("promoted_generalized_loop_restores_canonical_backup",
              &InstructionTester::runPromotedGeneralizedLoopRestoresCanonicalBackup);
+    runCustom("generalized_loop_restore_merges_backedge_register_state",
+             &InstructionTester::runGeneralizedLoopRestoreMergesBackedgeRegisterState);
 
     return failures;
   }


### PR DESCRIPTION
## Summary
- keep canonical and generalized-loop backedge snapshots separate for promoted loop headers
- widen the first generalized backedge with PHIs at restore time, then record live recurrent self-edge values on later re-entry
- carry generalized-loop bookkeeping across loop-header block replacement so reused backedges keep their merge state

## Why
Themida dispatcher lifting was still over-constraining the promoted loop header with the first concrete backedge state. That let the generalized header fold exits like `test reg, reg; je exit` away before the real self-edge was recorded, so lifting stayed inside the loop body and never reached the downstream indirect jump escape.

This change keeps the canonical pre-loop snapshot intact, widens the first generalized backedge with `undef` on the provisional incoming edge, and then adds the live recurrent values once the generalized loop is actually re-entered.

## Effect
On `example2-virt.bin @ 0x140001000`:
- before: `blocks_attempted=17`, `blocks_unreachable=0`, `instructions_lifted=884`
- after: `blocks_attempted=20`, `blocks_unreachable=2`, `instructions_lifted=963`
- newly reaches `0x1401BAE69`, `0x1401BAEDA`, `0x1401BAF04`
- next blocker is now the unresolved indirect jump at `0x1401BAF5D`

## Verification
- `cmd /c "set CLANG_CL_EXE=C:\Program Files\LLVM\bin\clang-cl.exe && ninja -C build_iced lifter rewrite_microtests"`
- `build_iced\rewrite_microtests.exe generalized_loop_restore_merges_backedge_register_state`
- `cmd /c "set CLANG_CL_EXE=C:\Program Files\LLVM\bin\clang-cl.exe&& python test.py quick"`
- `python test.py vmp`
- `cmd /c "set MERGEN_DIAG_LIFT_PROGRESS=1&& set MERGEN_WRITE_UNOPT_IR=1&& build_iced\lifter.exe ..\testthemida\example2-virt.bin 0x140001000"`

## Review
Reviewer result: correct, confidence 0.92; no blockers found.
