### PR TITLE
lifter: preserve deep invariant loop spill state

### DIFF
--- a/lifter/core/LifterClass.hpp
+++ b/lifter/core/LifterClass.hpp
@@ -508,6 +508,11 @@ public:
   void load_generalized_backup(BasicBlock* bb) {
     static_cast<Derived*>(this)->load_generalized_backup_impl(bb);
   }
+  llvm::Value* retrieve_generalized_loop_local_value(uint64_t startAddress,
+                                                     uint8_t byteCount) {
+    return static_cast<Derived*>(this)->retrieve_generalized_loop_local_value_impl(
+        startAddress, byteCount);
+  }
   bool currentBlockUsesGeneralizedLoopState() const {
     return currentBlockRestoreMode == BlockRestoreMode::GeneralizedLoop;
   }

--- a/lifter/core/LifterClass_Concolic.hpp
+++ b/lifter/core/LifterClass_Concolic.hpp
@@ -201,6 +201,18 @@ public:
       generalizedLoopRegisterPhis;
   llvm::DenseMap<BasicBlock*, std::array<llvm::PHINode*, FLAGS_END>>
       generalizedLoopFlagPhis;
+  llvm::DenseMap<uint64_t, ValueByteReference> activeGeneralizedLoopLocalBuffer;
+
+  llvm::DenseMap<uint64_t, ValueByteReference> extractLocalStackBuffer(
+      const llvm::DenseMap<uint64_t, ValueByteReference>& sourceBuffer) {
+    llvm::DenseMap<uint64_t, ValueByteReference> localBuffer;
+    for (const auto& entry : sourceBuffer) {
+      if (this->isTrackedLocalStackAddress(entry.first)) {
+        localBuffer[entry.first] = entry.second;
+      }
+    }
+    return localBuffer;
+  }
 
   backup_point make_generalized_loop_backup(BasicBlock* bb,
                                             const backup_point& canonical,
@@ -223,10 +235,9 @@ public:
         canonicalSource == backedgeSource) {
       return generalized;
     }
+
     std::array<llvm::PHINode*, REGISTER_COUNT> registerPhis{};
     std::array<llvm::PHINode*, FLAGS_END> flagPhis{};
-
-
     llvm::IRBuilder<> phiBuilder(bb, bb->begin());
     auto mergeValue = [&](llvm::Value* canonicalValue, llvm::Value* backedgeValue,
                           const char* name, llvm::PHINode*& phiOut)
@@ -238,9 +249,6 @@ public:
       }
       auto* phi = phiBuilder.CreatePHI(canonicalValue->getType(), 2, name);
       phi->addIncoming(canonicalValue, canonicalSource);
-      // Seed the backedge with undef until the real generalized self-edge is
-      // recorded. Using the concrete first-iteration value here over-constrains
-      // the loop header and folds exits like `test reg, reg; je exit` away.
       phi->addIncoming(llvm::UndefValue::get(backedgeValue->getType()),
                        backedgeSource);
       phiOut = phi;
@@ -289,6 +297,7 @@ public:
   }
 
   void load_backup_impl(BasicBlock* bb) {
+    activeGeneralizedLoopLocalBuffer.clear();
     if (BBbackup.contains(bb)) {
       printvalue2("loading backup");
       restore_backup_point(BBbackup[bb]);
@@ -296,12 +305,60 @@ public:
   }
 
   void load_generalized_backup_impl(BasicBlock* bb) {
+    activeGeneralizedLoopLocalBuffer.clear();
     if (generalizedLoopBackedgeBackup.contains(bb) && BBbackup.contains(bb)) {
       printvalue2("loading generalized backup");
       auto snapshot =
           make_generalized_loop_backup(bb, BBbackup[bb],
                                        generalizedLoopBackedgeBackup[bb]);
       restore_backup_point(snapshot);
+      activeGeneralizedLoopLocalBuffer =
+          extractLocalStackBuffer(generalizedLoopBackedgeBackup[bb].buffer);
+      auto seedInvariantLocalQwords = [&](const backup_point& canonicalSnapshot,
+                                          const backup_point& backedgeSnapshot) {
+        std::set<uint64_t> seededQwordStarts;
+        auto readConstantQword = [&](const llvm::DenseMap<uint64_t, ValueByteReference>& src,
+                                     uint64_t qwordStart, uint64_t& out) {
+          llvm::APInt combined(64, 0);
+          for (uint8_t i = 0; i < 8; ++i) {
+            auto it = src.find(qwordStart + i);
+            if (it == src.end() || !it->second.value) {
+              return false;
+            }
+            auto* ci = llvm::dyn_cast<llvm::ConstantInt>(it->second.value);
+            if (!ci) {
+              return false;
+            }
+            auto byteValue =
+                ci->getValue().lshr(it->second.byteOffset * 8).trunc(8);
+            combined |= byteValue.zext(64).shl(i * 8);
+          }
+          out = combined.getZExtValue();
+          return true;
+        };
+
+        for (const auto& entry : activeGeneralizedLoopLocalBuffer) {
+          uint64_t qwordStart = entry.first & ~0x7ULL;
+          if (qwordStart > STACKP_VALUE - 0x100) {
+            continue;
+          }
+          if (!seededQwordStarts.insert(qwordStart).second) {
+            continue;
+          }
+          uint64_t canonicalValue = 0;
+          uint64_t backedgeValue = 0;
+          if (!readConstantQword(canonicalSnapshot.buffer, qwordStart, canonicalValue) ||
+              !readConstantQword(backedgeSnapshot.buffer, qwordStart, backedgeValue) ||
+              canonicalValue != backedgeValue) {
+            continue;
+          }
+          for (uint8_t i = 0; i < 8; ++i) {
+            this->buffer[qwordStart + i] =
+                activeGeneralizedLoopLocalBuffer[qwordStart + i];
+          }
+        }
+      };
+      seedInvariantLocalQwords(BBbackup[bb], generalizedLoopBackedgeBackup[bb]);
       return;
     }
     if (BBbackup.contains(bb)) {
@@ -309,6 +366,53 @@ public:
       auto snapshot = make_generalized_loop_backup(bb, BBbackup[bb], BBbackup[bb]);
       restore_backup_point(snapshot);
     }
+  }
+
+  llvm::Value* retrieve_generalized_loop_local_value_impl(uint64_t startAddress,
+                                                          uint8_t byteCount) {
+    if (activeGeneralizedLoopLocalBuffer.empty()) {
+      return nullptr;
+    }
+    auto firstIt = activeGeneralizedLoopLocalBuffer.find(startAddress);
+    if (firstIt == activeGeneralizedLoopLocalBuffer.end() || !firstIt->second.value) {
+      return nullptr;
+    }
+
+    bool contiguousSingleValue = true;
+    auto* sharedValue = firstIt->second.value;
+    uint8_t firstByteOffset = firstIt->second.byteOffset;
+    for (uint8_t i = 0; i < byteCount; ++i) {
+      auto it = activeGeneralizedLoopLocalBuffer.find(startAddress + i);
+      if (it == activeGeneralizedLoopLocalBuffer.end() || !it->second.value) {
+        return nullptr;
+      }
+      if (it->second.value != sharedValue ||
+          it->second.byteOffset != firstByteOffset + i) {
+        contiguousSingleValue = false;
+      }
+    }
+    if (contiguousSingleValue) {
+      return this->extractBytes(sharedValue, firstByteOffset,
+                                firstByteOffset + byteCount);
+    }
+
+    llvm::Value* result = llvm::ConstantInt::get(
+        llvm::Type::getIntNTy(this->context, byteCount * 8), 0);
+    for (uint8_t i = 0; i < byteCount; ++i) {
+      auto it = activeGeneralizedLoopLocalBuffer.find(startAddress + i);
+      auto* byteValue = this->extractBytes(it->second.value, it->second.byteOffset,
+                                           it->second.byteOffset + 1);
+      if (!byteValue) {
+        return nullptr;
+      }
+      auto* shiftedByteValue = this->createShlFolder(
+          this->createZExtOrTruncFolder(
+              byteValue, llvm::Type::getIntNTy(this->context, byteCount * 8)),
+          llvm::APInt(byteCount * 8, i * 8));
+      result = this->createOrFolder(result, shiftedByteValue,
+                                    "generalized-local-byte");
+    }
+    return result;
   }
   void migrate_generalized_loop_block_impl(BasicBlock* oldBlock,
                                            BasicBlock* newBlock) {
@@ -351,6 +455,7 @@ public:
         phi->addIncoming(vec[i], sourceBlock);
       }
     }
+
 
     auto flagIt = generalizedLoopFlagPhis.find(bb);
     if (flagIt != generalizedLoopFlagPhis.end()) {

--- a/lifter/core/LifterClass_Symbolic.hpp
+++ b/lifter/core/LifterClass_Symbolic.hpp
@@ -154,6 +154,13 @@ public:
   void record_generalized_loop_backedge_impl(BasicBlock* bb) {
     (void)bb;
   }
+  llvm::Value* retrieve_generalized_loop_local_value_impl(uint64_t startAddress,
+                                                          uint8_t byteCount) {
+    (void)startAddress;
+    (void)byteCount;
+    return nullptr;
+  }
+
 
   void createFunction_impl() {
     std::vector<llvm::Type*> argTypes;

--- a/lifter/memory/GEPTracker.ipp
+++ b/lifter/memory/GEPTracker.ipp
@@ -79,10 +79,48 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(Value*)::retrieveCombinedValue(
     uint64_t startAddress, uint8_t byteCount, LazyValue orgLoad) {
   printvalue2(startAddress);
 
+  auto bufferFullyCoversRange = [&](uint64_t rangeStart, uint8_t rangeSize) {
+    for (uint8_t i = 0; i < rangeSize; ++i) {
+      if (!buffer.contains(rangeStart + i)) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  auto trackedBufferConstant = [&](uint64_t rangeStart, uint8_t rangeSize)
+      -> Value* {
+    if (!bufferFullyCoversRange(rangeStart, rangeSize)) {
+      return nullptr;
+    }
+
+    llvm::APInt combined(rangeSize * 8, 0);
+    for (uint8_t i = 0; i < rangeSize; ++i) {
+      auto it = buffer.find(rangeStart + i);
+      if (it == buffer.end()) {
+        return nullptr;
+      }
+      auto* ci = dyn_cast<ConstantInt>(it->second.value);
+      if (!ci) {
+        return nullptr;
+      }
+      auto byteValue = ci->getValue().lshr(it->second.byteOffset * 8).trunc(8);
+      combined |= byteValue.zext(combined.getBitWidth()).shl(i * 8);
+    }
+    return ConstantInt::get(builder->getContext(), combined);
+  };
+
+  if (auto* tracked = trackedBufferConstant(startAddress, byteCount)) {
+    return tracked;
+  }
+
   if (memoryPolicy.isRangeFullyCovered(startAddress, startAddress + byteCount,
-                                       MemoryAccessMode::SYMBOLIC)) {
-    // Fully symbolic range: use concrete bytes only when mapping is proven;
-    // otherwise preserve symbolic fallback from the original load.
+                                       MemoryAccessMode::SYMBOLIC) &&
+      !bufferFullyCoversRange(startAddress, byteCount)) {
+    // Fully symbolic range with no tracked-byte coverage: use concrete bytes
+    // only when mapping is proven; otherwise preserve the symbolic fallback.
+    // When the concolic buffer covers the whole range, rebuild from tracked
+    // bytes below even though the address is symbolic.
     uint64_t sym_value;
     if (file.readMemory(startAddress, byteCount, sym_value)) {
       return builder->getIntN(byteCount * 8, sym_value);
@@ -126,10 +164,9 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(Value*)::retrieveCombinedValue(
         (isLastReference && isDifferentReferenceOrDiscontinuousOffset(
                                 values.back(), currentAddress)) ||
         currentAccessMode != lastAccessMode) {
-      if (buffer.contains(currentAddress) &&
-          currentAccessMode != MemoryAccessMode::SYMBOLIC) {
+      if (buffer.contains(currentAddress)) {
         values.push_back(
-            ValueByteReferenceRange(buffer[currentAddress], i, i + 1));
+          ValueByteReferenceRange(buffer[currentAddress], i, i + 1));
       } else {
         printvalue2(currentAddress);
         values.push_back(ValueByteReferenceRange(currentAddress, i, i + 1));
@@ -655,6 +692,30 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(pvalueset)::computePossibleValues(
     if (v_inst->getOpcode() == Instruction::Alloca) {
       return {};
     }
+    if (auto* loadInst = dyn_cast<LoadInst>(v_inst)) {
+      if (loadInst->getType()->isIntegerTy()) {
+        auto* gep = dyn_cast<GetElementPtrInst>(loadInst->getPointerOperand());
+        if (gep && gep->getPointerOperand() == memoryAlloc) {
+          if (auto* offsetCI = dyn_cast<ConstantInt>(gep->getOperand(1))) {
+            unsigned loadBits = loadInst->getType()->getIntegerBitWidth();
+            if (loadBits % 8 == 0) {
+              LazyValue nestedLoad(
+                  [loadInst]() -> Value* { return loadInst; });
+              if (auto* resolved = retrieveCombinedValue(
+                      offsetCI->getZExtValue(),
+                      static_cast<uint8_t>(loadBits / 8), nestedLoad)) {
+                if (auto* resolvedCI = dyn_cast<ConstantInt>(resolved)) {
+                  res.insert(resolvedCI->getValue());
+                  pv_cache[V] = res;
+                  return res;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
     if (v_inst->getNumOperands() == 1) {
       auto result = computePossibleValues(v_inst->getOperand(0), Depth + 1);
       pv_cache[V] = result;
@@ -782,11 +843,30 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(Value*)::solveLoad(LazyValue load,
       return load.get();
     }
 
+    if (isTrackedLocalStackAddress(loadOffsetCIval)) {
+      bool currentBufferCoversRange = true;
+      for (uint8_t i = 0; i < cloadsize; ++i) {
+        auto currentIt = buffer.find(loadOffsetCIval + i);
+        if (currentIt == buffer.end() || !currentIt->second.value) {
+          currentBufferCoversRange = false;
+          break;
+        }
+      }
+      if (!currentBufferCoversRange) {
+        if (auto* generalizedLocalValue =
+                retrieve_generalized_loop_local_value(loadOffsetCIval, cloadsize)) {
+          addValueReference(generalizedLocalValue, loadOffsetCIval);
+          return generalizedLocalValue;
+        }
+      }
+    }
+
     auto valueExtractedFromVirtualStack =
         retrieveCombinedValue(loadOffsetCIval, cloadsize, load);
     if (valueExtractedFromVirtualStack) {
       return valueExtractedFromVirtualStack;
     }
+
   } else {
     auto stripIntegerCasts = [](Value* candidate) -> Value* {
       while (auto* castInst = dyn_cast<CastInst>(candidate)) {
@@ -942,6 +1022,55 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(Value*)::solveLoad(LazyValue load,
       return false;
     };
 
+    auto resolveSingleConcreteTerm = [&](Value* term)
+        -> std::optional<APInt> {
+      auto* stripped = stripIntegerCasts(term);
+      if (auto* ci = dyn_cast<ConstantInt>(stripped)) {
+        return ci->getValue();
+      }
+
+      if (auto* loadInst = dyn_cast<LoadInst>(stripped)) {
+        if (loadInst->getType()->isIntegerTy()) {
+          auto* gep = dyn_cast<GetElementPtrInst>(loadInst->getPointerOperand());
+          if (gep && gep->getPointerOperand() == memoryAlloc) {
+            if (auto* offsetCI = dyn_cast<ConstantInt>(gep->getOperand(1))) {
+              unsigned loadBits = loadInst->getType()->getIntegerBitWidth();
+              if (loadBits % 8 == 0) {
+                LazyValue nestedLoad(
+                    [loadInst]() -> Value* { return loadInst; });
+                if (auto* resolved = retrieveCombinedValue(
+                        offsetCI->getZExtValue(),
+                        static_cast<uint8_t>(loadBits / 8), nestedLoad)) {
+                  if (auto* resolvedCI = dyn_cast<ConstantInt>(resolved)) {
+                    return resolvedCI->getValue();
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      auto values = computePossibleValues(stripped, 0);
+      if (values.size() == 1) {
+        return *values.begin();
+      }
+      return std::nullopt;
+    };
+
+    auto canUseConcreteLoadAddress = [&](uint64_t address) {
+      if (isMemPaged(address)) {
+        return true;
+      }
+      for (uint8_t i = 0; i < cloadsize; ++i) {
+        if (!buffer.contains(address + i)) {
+          uint64_t ignored = 0;
+          return file.readMemory(address, cloadsize, ignored);
+        }
+      }
+      return true;
+    };
+
     auto inferIndexedOffsetsFromAssumptions =
         [&](Value* offsetExpr) -> std::set<APInt, APIntComparator> {
       std::set<APInt, APIntComparator> inferredOffsets;
@@ -953,6 +1082,20 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(Value*)::solveLoad(LazyValue load,
             addInst && addInst->getOpcode() == Instruction::Add) {
           return self(self, addInst->getOperand(0), terms) &&
                  self(self, addInst->getOperand(1), terms);
+        }
+        if (auto* subInst = dyn_cast<BinaryOperator>(expr);
+            subInst && subInst->getOpcode() == Instruction::Sub) {
+          if (!self(self, subInst->getOperand(0), terms)) {
+            return false;
+          }
+          auto* rhs = stripIntegerCasts(subInst->getOperand(1));
+          if (auto* rhsCI = dyn_cast<ConstantInt>(rhs)) {
+            auto negated = rhsCI->getValue().zextOrTrunc(
+                subInst->getType()->getIntegerBitWidth());
+            negated = -negated;
+            terms.push_back(ConstantInt::get(subInst->getType(), negated));
+            return true;
+          }
         }
         terms.push_back(expr);
         return true;
@@ -1005,11 +1148,10 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(Value*)::solveLoad(LazyValue load,
       };
 
       for (Value* term : addTerms) {
-        if (auto* ci = dyn_cast<ConstantInt>(term)) {
-          baseOffset += ci->getZExtValue();
+        if (auto resolved = resolveSingleConcreteTerm(term)) {
+          baseOffset += resolved->getZExtValue();
           continue;
         }
-
         Value* candidateIndex = nullptr;
         uint64_t candidateScale = 0;
         if (!matchScaledIndexTerm(term, candidateIndex, candidateScale)) {
@@ -1029,6 +1171,9 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(Value*)::solveLoad(LazyValue load,
       }
 
       if (!indexValue || indexScale == 0) {
+        if (canUseConcreteLoadAddress(baseOffset)) {
+          inferredOffsets.insert(APInt(64, baseOffset));
+        }
         return inferredOffsets;
       }
 
@@ -1062,7 +1207,7 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(Value*)::solveLoad(LazyValue load,
 
       for (uint64_t idx = 0; idx <= upperInclusive; ++idx) {
         uint64_t possibleOffset = baseOffset + idx * indexScale;
-        if (!isMemPaged(possibleOffset)) {
+        if (!canUseConcreteLoadAddress(possibleOffset)) {
           continue;
         }
         inferredOffsets.insert(APInt(64, possibleOffset));
@@ -1079,16 +1224,17 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(Value*)::solveLoad(LazyValue load,
       }
 
       Value* selectedValue = nullptr;
-
       for (auto possibleValue : possibleValues) {
-        auto isPaged = isMemPaged(possibleValue.getZExtValue());
-        if (!isPaged)
+        if (!canUseConcreteLoadAddress(possibleValue.getZExtValue()))
           continue;
         printvalue2(possibleValue);
         auto possible_values_from_mem = retrieveCombinedValue(
             possibleValue.getZExtValue(), cloadsize, load);
         printvalue2((uint64_t)cloadsize);
         printvalue(possible_values_from_mem);
+        if (!possible_values_from_mem) {
+          continue;
+        }
         if (!possible_values_from_mem) {
           continue;
         }

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -916,6 +916,134 @@ private:
 
 
 
+  bool runSolveLoadInfersConcreteBaseFromTrackedLoad(std::string& details) {
+    LifterUnderTest lifter;
+    auto& context = lifter.context;
+    auto* i8Ty = llvm::Type::getInt8Ty(context);
+    auto* i64Ty = llvm::Type::getInt64Ty(context);
+
+    constexpr uint64_t baseSlot = STACKP_VALUE - 0x20;
+    constexpr uint64_t indexSlot = STACKP_VALUE - 0x28;
+    constexpr uint64_t tableBase = 0x14004DBECULL;
+    constexpr uint64_t tableIndex = 4;
+    constexpr uint64_t tableEntry = tableBase + tableIndex * 8;
+    constexpr uint64_t tableTarget = 0x1401BAF04ULL;
+
+    lifter.SetMemoryValue(makeI64(context, baseSlot), makeI64(context, tableBase));
+    lifter.SetMemoryValue(makeI64(context, indexSlot), makeI64(context, tableIndex));
+    lifter.SetMemoryValue(makeI64(context, tableEntry), makeI64(context, tableTarget));
+
+    auto directBase =
+        readConstantAPInt(lifter.GetMemoryValue(makeI64(context, baseSlot), 64));
+    auto directIndex =
+        readConstantAPInt(lifter.GetMemoryValue(makeI64(context, indexSlot), 64));
+    if (!directBase.has_value() || !directIndex.has_value()) {
+      std::ostringstream os;
+      os << "  direct tracked loads did not resolve: base="
+         << (directBase.has_value() ? std::to_string(directBase->getZExtValue())
+                                    : std::string("<non-const>"))
+         << " index="
+         << (directIndex.has_value() ? std::to_string(directIndex->getZExtValue())
+                                     : std::string("<non-const>")) << "\n";
+      details = os.str();
+      return false;
+    }
+
+
+
+    auto directTarget =
+        readConstantAPInt(lifter.GetMemoryValue(makeI64(context, tableEntry), 64));
+    if (!directTarget.has_value() || directTarget->getZExtValue() != tableTarget) {
+      std::ostringstream os;
+      os << "  direct table-entry load resolved to ";
+      if (directTarget.has_value()) {
+        os << "0x" << std::hex << directTarget->getZExtValue();
+      } else {
+        os << "<non-const>";
+      }
+      os << " instead of 0x" << std::hex << tableTarget << "\n";
+      details = os.str();
+      return false;
+    }
+
+    auto* basePtr = lifter.builder->CreateGEP(
+        i8Ty, lifter.memoryAlloc, makeI64(context, baseSlot), "base_slot_ptr");
+    auto* indexPtr = lifter.builder->CreateGEP(
+        i8Ty, lifter.memoryAlloc, makeI64(context, indexSlot), "index_slot_ptr");
+
+    auto* baseLoad = lifter.builder->CreateLoad(i64Ty, basePtr, "base_term");
+    auto* indexLoad = lifter.builder->CreateLoad(i64Ty, indexPtr, "index_term");
+    auto rawBaseValues = lifter.computePossibleValues(baseLoad, 0);
+    auto rawIndexValues = lifter.computePossibleValues(indexLoad, 0);
+    if (rawBaseValues.size() != 1 || rawIndexValues.size() != 1) {
+      std::ostringstream os;
+      os << "  computePossibleValues raw base/index sizes: "
+         << rawBaseValues.size() << "/" << rawIndexValues.size() << "\n";
+      details = os.str();
+      return false;
+    }
+
+    auto* indexScaled =
+        lifter.builder->CreateShl(indexLoad, makeI64(context, 3), "index_scaled");
+    auto* tableAddr = lifter.builder->CreateAdd(baseLoad, indexScaled, "table_addr");
+    auto tableAddrValues = lifter.computePossibleValues(tableAddr, 0);
+    if (tableAddrValues.size() != 1 ||
+        tableAddrValues.begin()->getZExtValue() != tableEntry) {
+      std::ostringstream os;
+      os << "  computePossibleValues tableAddr size/value: "
+         << tableAddrValues.size();
+      if (!tableAddrValues.empty()) {
+        os << " / 0x" << std::hex << tableAddrValues.begin()->getZExtValue();
+      }
+      os << "\n";
+      details = os.str();
+      return false;
+    }
+
+    auto* probePtr = lifter.getPointer(tableAddr);
+    LazyValue probeLoad([&]() -> llvm::Value* {
+      return lifter.builder->CreateLoad(i64Ty, probePtr, "probe_load");
+    });
+    auto* directProbe = lifter.retrieveCombinedValue(tableEntry, 8, probeLoad);
+    auto probeActual = readConstantAPInt(directProbe);
+    if (!probeActual.has_value() || probeActual->getZExtValue() != tableTarget) {
+      std::ostringstream os;
+      os << "  direct retrieveCombinedValue probe resolved to ";
+      if (probeActual.has_value()) {
+        os << "0x" << std::hex << probeActual->getZExtValue();
+      } else {
+        std::string valueText;
+        llvm::raw_string_ostream valueOs(valueText);
+        directProbe->print(valueOs);
+        os << valueOs.str();
+      }
+      os << " instead of 0x" << std::hex << tableTarget << "\n";
+      details = os.str();
+      return false;
+    }
+
+    auto* resolved = lifter.GetMemoryValue(tableAddr, 64);
+    auto actual = readConstantAPInt(resolved);
+    if (!actual.has_value()) {
+      std::string valueText;
+      llvm::raw_string_ostream os(valueText);
+      resolved->print(os);
+      details =
+          "  solveLoad should resolve a jump-table address built from tracked base/index loads; got `" +
+          os.str() + "`\n";
+      return false;
+    }
+    if (actual->getZExtValue() != tableTarget) {
+      std::ostringstream os;
+      os << "  solveLoad resolved 0x" << std::hex << actual->getZExtValue()
+         << " instead of expected jump-table target 0x" << tableTarget << "\n";
+      details = os.str();
+      return false;
+    }
+    return true;
+  }
+
+
   bool runGeneralizedLoopRestoreMergesBackedgeRegisterState(
       std::string& details) {
     LifterUnderTest lifter;
@@ -1086,6 +1214,8 @@ private:
              &InstructionTester::runPromotedGeneralizedLoopRestoresCanonicalBackup);
     runCustom("generalized_loop_restore_merges_backedge_register_state",
              &InstructionTester::runGeneralizedLoopRestoreMergesBackedgeRegisterState);
+    runCustom("solve_load_infers_concrete_base_from_tracked_load",
+             &InstructionTester::runSolveLoadInfersConcreteBaseFromTrackedLoad);
 
     return failures;
   }


### PR DESCRIPTION
## Summary
- keep generalized-loop local stack bytes in a side map instead of restoring the whole local stack into normal generalized-loop state
- reseed only deep local qwords whose canonical and backedge snapshots agree on the same concrete 8-byte value
- let `solveLoad` materialize missing local constant loads from that carried state when the current buffer lacks real byte coverage

## Why
After the loop-header/generalized-backedge work, the remaining Themida blocker was the indirect jump at `0x1401BAF5D`. Broadly restoring local stack state fixed it, but regressed rewrite VM-loop samples by over-constraining loop-carried locals.

The missing data turned out to be loop-invariant deep spill slots that survive the generalized loop and feed the post-loop indirect dispatch. This change preserves just that stable spill subset instead of reintroducing the full local-stack carry.

## Effect
On `example2-virt.bin @ 0x140001000`:
- before: `20 blocks (0 completed, 2 unreachable), 963 instructions`, two unresolved-jump warnings at `0x1401BAF5D`
- after: `20 blocks (1 completed, 0 unreachable), 933 instructions`, no unresolved-jump warnings

## Verification
- `cmd /c "set CLANG_CL_EXE=C:\Program Files\LLVM\bin\clang-cl.exe && ninja -C build_iced lifter rewrite_microtests"`
- `build_iced\rewrite_microtests.exe solve_load_infers_concrete_base_from_tracked_load generalized_loop_restore_merges_backedge_register_state generalized_loop_with_bypass_tag_uses_generalized_restore generalized_loop_bypass_tag_clears_after_promotion promoted_generalized_loop_restores_canonical_backup`
- `python test.py quick`
  - log result: all rewrite regression checks passed, determinism 42/42, semantic 33/33, all instruction microtests passed
- `python test.py vmp`
  - required targets still pass: `simple_vmp381_one_vm`, `simple_vmp381_full`
- `cmd /c "set MERGEN_DIAG_LIFT_PROGRESS=1&& build_iced\lifter.exe ..\testthemida\example2-virt.bin 0x140001000"`

## Review
Attempted reviewer subagent run, but the environment is missing the Anthropic API key required for subagent execution. Proceeding with the grounded verification above and noting the tool failure explicitly.
