### PR TITLE
lifter: widen mapped RVA-style jump targets

### DIFF
--- a/lifter/analysis/PathSolver.ipp
+++ b/lifter/analysis/PathSolver.ipp
@@ -34,9 +34,14 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(PATH_info)::solvePath(
     if (target <= std::numeric_limits<uint32_t>::max() &&
         file.imageBase > std::numeric_limits<uint32_t>::max()) {
       const uint64_t highBits = file.imageBase & 0xFFFFFFFF00000000ULL;
-      const uint64_t widened = highBits | target;
-      if (isMemPaged(widened)) {
-        return widened;
+      const uint64_t widenedLow32 = highBits | target;
+      if (isMemPaged(widenedLow32)) {
+        return widenedLow32;
+      }
+
+      const uint64_t widenedRva = file.imageBase + target;
+      if (isMemPaged(widenedRva)) {
+        return widenedRva;
       }
     }
 

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -1044,6 +1044,32 @@ private:
   }
 
 
+  bool runSolvePathWidensMappedRvaTarget(std::string& details) {
+    LifterUnderTest lifter;
+    auto* current = llvm::BasicBlock::Create(lifter.context, "current", lifter.fnc);
+    lifter.builder->SetInsertPoint(current);
+    lifter.blockInfo = BBInfo(0x1401BAF5DULL, current);
+    lifter.file.imageBase = 0x140000000ULL;
+    lifter.markMemPaged(0x1400118C8ULL, 0x1400118D0ULL);
+
+    uint64_t destination = 0;
+    auto pathResult =
+        lifter.solvePath(lifter.fnc, destination, makeI64(lifter.context, 0x118C8));
+    if (pathResult != PATH_solved) {
+      details = "  solvePath did not resolve the mapped RVA-style target\n";
+      return false;
+    }
+    if (destination != 0x1400118C8ULL) {
+      std::ostringstream os;
+      os << "  solvePath widened to 0x" << std::hex << destination
+         << " instead of mapped RVA target 0x1400118c8\n";
+      details = os.str();
+      return false;
+    }
+    return true;
+  }
+
+
   bool runGeneralizedLoopRestoreMergesBackedgeRegisterState(
       std::string& details) {
     LifterUnderTest lifter;
@@ -1216,6 +1242,8 @@ private:
              &InstructionTester::runGeneralizedLoopRestoreMergesBackedgeRegisterState);
     runCustom("solve_load_infers_concrete_base_from_tracked_load",
              &InstructionTester::runSolveLoadInfersConcreteBaseFromTrackedLoad);
+    runCustom("solve_path_widens_mapped_rva_target",
+             &InstructionTester::runSolvePathWidensMappedRvaTarget);
 
     return failures;
   }


### PR DESCRIPTION
## Summary
- extend low-target normalization to recognize mapped RVA-style jump targets on 64-bit images
- keep the existing low-32-VA widening first, then fall back to `imageBase + target` when that mapped RVA exists
- add a targeted regression covering the mapped-RVA case

## Why
After fixing the generalized-loop spill-state issue, the next Themida bottleneck was an indirect jump whose table entries contained low RVAs like `0x118c8` instead of full runtime VAs. The previous normalization logic only tried `highBits | target`, which is insufficient for image bases like `0x140000000` and left those targets as unmapped low addresses.

## Effect
On `example2-virt.bin @ 0x140001000`:
- before: `20 blocks (1 completed, 0 unreachable), 933 instructions`
- after: `24 blocks (1 completed, 0 unreachable), 1086 instructions`
- newly reaches mapped low-RVA targets such as:
  - `0x1400118c8`
  - `0x14000cde2`
  - `0x1400a185c`
  - `0x1400b91b6`

## Verification
- `cmd /c "set CLANG_CL_EXE=C:\Program Files\LLVM\bin\clang-cl.exe && ninja -C build_iced lifter rewrite_microtests"`
- `build_iced\rewrite_microtests.exe solve_path_widens_mapped_rva_target solve_load_infers_concrete_base_from_tracked_load`
- `python test.py quick`
- `python test.py vmp`
- `cmd /c "set MERGEN_DIAG_LIFT_PROGRESS=1&& build_iced\lifter.exe ..\testthemida\example2-virt.bin 0x140001000"`

## Review
Reviewer result: correct, confidence 0.93, no blockers.
