### PR TITLE
lifter: prefer file-backed queued targets

### DIFF
--- a/lifter/analysis/PathSolver.ipp
+++ b/lifter/analysis/PathSolver.ipp
@@ -27,25 +27,7 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(PATH_info)::solvePath(
   // (from different branch paths), so cached results don't carry over.
   pv_cache.clear();
   auto normalizeTargetAddress = [&](uint64_t target) -> uint64_t {
-    if (isMemPaged(target)) {
-      return target;
-    }
-
-    if (target <= std::numeric_limits<uint32_t>::max() &&
-        file.imageBase > std::numeric_limits<uint32_t>::max()) {
-      const uint64_t highBits = file.imageBase & 0xFFFFFFFF00000000ULL;
-      const uint64_t widenedLow32 = highBits | target;
-      if (isMemPaged(widenedLow32)) {
-        return widenedLow32;
-      }
-
-      const uint64_t widenedRva = file.imageBase + target;
-      if (isMemPaged(widenedRva)) {
-        return widenedRva;
-      }
-    }
-
-    return target;
+    return normalizeRuntimeTargetAddress(target);
   };
 
   struct ResolvedTargetBlock {

--- a/lifter/core/LifterClass.hpp
+++ b/lifter/core/LifterClass.hpp
@@ -823,6 +823,13 @@ public:
       out = std::move(unvisitedBlocks.back());
       unvisitedBlocks.pop_back();
 
+      const uint64_t normalizedAddr =
+          normalizeFileBackedRuntimeTargetAddress(out.block_address);
+      if (normalizedAddr != out.block_address) {
+        addrToBB[normalizedAddr] = out.block;
+        out.block_address = normalizedAddr;
+      }
+
       // In Basic mode, skip blocks that already have instructions
       // (they were processed in a previous iteration).
       if (getControlFlow() == ControlFlow::Basic && !out.block->empty() &&
@@ -1017,11 +1024,20 @@ public:
 
 
   BasicBlock* getOrCreateBB(uint64_t addr, std::string name) {
+    addr = normalizeFileBackedRuntimeTargetAddress(addr);
     if (getControlFlow() == ControlFlow::Basic) {
       auto it = addrToBB.find(addr);
       if (it != addrToBB.end()) {
         // also might have to update here,
         return it->second;
+      }
+    }
+    if (getControlFlow() == ControlFlow::Unflatten) {
+      auto it = addrToBB.find(addr);
+      if (it != addrToBB.end() && it->second && !it->second->empty() &&
+          liftProgressDiagEnabled) {
+        std::cout << "[diag] overwriting existing bb for 0x" << std::hex << addr
+                  << std::dec << " old=" << it->second->getName().str() << "\n";
       }
     }
     auto bb = createBudgetedBasicBlock(name, addr);
@@ -1333,6 +1349,54 @@ public:
 
     --it;
     return address >= it->first && address < it->second;
+
+  }
+
+  bool isFileBackedRuntimeAddress(uint64_t address) {
+    uint64_t ignored = 0;
+    return file.readMemory(address, 1, ignored);
+  }
+
+  uint64_t normalizeRuntimeTargetAddress(uint64_t target) {
+    if (isMemPaged(target)) {
+      return target;
+    }
+
+    if (target <= std::numeric_limits<uint32_t>::max() &&
+        file.imageBase > std::numeric_limits<uint32_t>::max()) {
+      const uint64_t highBits = file.imageBase & 0xFFFFFFFF00000000ULL;
+      const uint64_t widenedLow32 = highBits | target;
+      const uint64_t widenedRva = file.imageBase + target;
+      if (isMemPaged(widenedLow32)) {
+        return widenedLow32;
+      }
+      if (isMemPaged(widenedRva)) {
+        return widenedRva;
+      }
+    }
+
+    return target;
+  }
+
+  uint64_t normalizeFileBackedRuntimeTargetAddress(uint64_t target) {
+    if (isFileBackedRuntimeAddress(target)) {
+      return target;
+    }
+
+    if (target <= std::numeric_limits<uint32_t>::max() &&
+        file.imageBase > std::numeric_limits<uint32_t>::max()) {
+      const uint64_t highBits = file.imageBase & 0xFFFFFFFF00000000ULL;
+      const uint64_t widenedLow32 = highBits | target;
+      const uint64_t widenedRva = file.imageBase + target;
+      if (isFileBackedRuntimeAddress(widenedLow32)) {
+        return widenedLow32;
+      }
+      if (isFileBackedRuntimeAddress(widenedRva)) {
+        return widenedRva;
+      }
+    }
+
+    return target;
   }
 
   std::set<llvm::APInt, APIntComparator>

--- a/lifter/semantics/Semantics.ipp
+++ b/lifter/semantics/Semantics.ipp
@@ -156,12 +156,14 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::liftInstruction() {
         return;
       }
       auto RIP_value = cast<ConstantInt>(next_jump);
-      auto jump_address = RIP_value->getZExtValue();
+      auto jump_address =
+          normalizeRuntimeTargetAddress(RIP_value->getZExtValue());
 
       auto bb = getOrCreateBB(jump_address, "bb_call");
       builder->CreateBr(bb);
 
       blockInfo = BBInfo(jump_address, bb);
+      addUnvisitedAddr(blockInfo);
       run = 0;
       return;
     }
@@ -181,10 +183,7 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::liftInstruction() {
             STACKP_VALUE) {
       printvalueforce2(jump_address);
 
-      // TODO: ideally remove this part
-      auto bb = getOrCreateBB(jump_address, "bb_indirectly_called");
       // actually call the function first
-
       auto functionName = file.getName(jump_address);
       debugging::doIfDebug([&]() {
         outs() << "calling : " << functionName
@@ -198,11 +197,13 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::liftInstruction() {
 
       // get [rsp], jump there
       auto RIP_value = cast<ConstantInt>(next_jump);
-      jump_address = RIP_value->getZExtValue();
+      jump_address = normalizeRuntimeTargetAddress(RIP_value->getZExtValue());
+      auto bb = getOrCreateBB(jump_address, "bb_indirectly_called");
 
       builder->CreateBr(bb);
 
       blockInfo = BBInfo(jump_address, bb);
+      addUnvisitedAddr(blockInfo);
       run = 0;
       return;
     }

--- a/lifter/semantics/Semantics_ControlFlow.ipp
+++ b/lifter/semantics/Semantics_ControlFlow.ipp
@@ -219,12 +219,15 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_call() {
       break;
     }
     auto registerCValue = cast<ConstantInt>(registerValue);
-    if (inlinePolicy.isOutline(registerCValue->getZExtValue()) ||
-        shouldOutlineCall(registerCValue->getZExtValue())) {
+    uint64_t rawTargetAddr = registerCValue->getZExtValue();
+    uint64_t normalizedTargetAddr = normalizeRuntimeTargetAddress(rawTargetAddr);
+    auto* normalizedTargetValue =
+        builder->getIntN(registerCValue->getBitWidth(), normalizedTargetAddr);
+    if (inlinePolicy.isOutline(normalizedTargetAddr) ||
+        shouldOutlineCall(normalizedTargetAddr)) {
 
       // --- Emit external call (outlined known-address target) ---
-      uint64_t targetAddr = registerCValue->getZExtValue();
-      auto importName = resolveImportName(targetAddr);
+      auto importName = resolveImportName(normalizedTargetAddr);
 
       if (!importName.empty()) {
         // Named import: emit a proper LLVM function declaration.
@@ -242,7 +245,7 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_call() {
         fx.target = CallTargetClass::UnknownDirect;
 
         auto idltvm = builder->CreateIntToPtr(
-            registerValue, PointerType::get(context, 0));
+            normalizedTargetValue, PointerType::get(context, 0));
         auto callResult = builder->CreateCall(
             parseArgsType(nullptr, context), idltvm, parseArgs(nullptr));
 
@@ -255,7 +258,7 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_call() {
       emittedExternalCall = true;
       break;
     }
-    jump_address = registerCValue->getZExtValue();
+    jump_address = normalizedTargetAddr;
     break;
   }
   default:

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -1070,6 +1070,24 @@ private:
   }
 
 
+  bool runNormalizeRuntimeTargetWidensMappedRvaTarget(std::string& details) {
+    LifterUnderTest lifter;
+    lifter.file.imageBase = 0x140000000ULL;
+    lifter.markMemPaged(0x140052532ULL, 0x140052540ULL);
+    const uint64_t normalized = lifter.normalizeRuntimeTargetAddress(0x52532ULL);
+    if (normalized != 0x140052532ULL) {
+      std::ostringstream os;
+      os << "  normalizeRuntimeTargetAddress widened to 0x" << std::hex
+         << normalized << " instead of mapped RVA target 0x140052532\n";
+      details = os.str();
+      return false;
+    }
+    return true;
+  }
+
+
+
+
   bool runGeneralizedLoopRestoreMergesBackedgeRegisterState(
       std::string& details) {
     LifterUnderTest lifter;
@@ -1244,6 +1262,8 @@ private:
              &InstructionTester::runSolveLoadInfersConcreteBaseFromTrackedLoad);
     runCustom("solve_path_widens_mapped_rva_target",
              &InstructionTester::runSolvePathWidensMappedRvaTarget);
+    runCustom("normalize_runtime_target_widens_mapped_rva_target",
+             &InstructionTester::runNormalizeRuntimeTargetWidensMappedRvaTarget);
 
     return failures;
   }


### PR DESCRIPTION
## Summary
- split target normalization into paged vs file-backed variants
- keep PathSolver on the broader paged normalization it already relies on
- use stricter file-backed normalization when dequeuing/creating queued runtime targets so low stack aliases like `0x52532` prefer their image-backed RVA forms
- queue the fake indirect-call return targets in `Semantics.ipp`

## Why
After PR #104, Themida still reached a raw low target (`0x52532`) that should be interpreted as an image-backed RVA form rather than as a low address that only happens to be paged because the synthetic stack range covers it. Using the broad `isMemPaged` predicate for queued targets was too permissive for this case.

## Change
- Added `isFileBackedRuntimeAddress()` and `normalizeFileBackedRuntimeTargetAddress()` in `LifterClass.hpp`
- Switched `getUnvisitedAddr()` and `getOrCreateBB()` to the file-backed variant
- Left `PathSolver` on the original broad normalization behavior
- Ensured the fake indirect-call path queues the normalized return destination so it actually gets lifted
- Added normalization regression coverage in `Tester.hpp`

## Effect
On `example2-virt.bin @ 0x140001000`:
- before: `24 blocks (1 completed, 0 unreachable), 1086 instructions`
- after: `35 blocks (0 completed, 0 unreachable), 1565 instructions`
- newly reaches addresses including:
  - `0x14001d463`
  - `0x14001d62f`
  - `0x140020ead`
  - `0x1400234a0`
  - `0x140023582`
  - `0x140023699`

## Verification
- `cmd /c "set CLANG_CL_EXE=C:\Program Files\LLVM\bin\clang-cl.exe && ninja -C build_iced lifter rewrite_microtests"`
- `build_iced\rewrite_microtests.exe solve_path_widens_mapped_rva_target normalize_runtime_target_widens_mapped_rva_target solve_load_infers_concrete_base_from_tracked_load generalized_loop_restore_merges_backedge_register_state`
- `python test.py quick`
  - all rewrite checks passed, determinism 42/42, semantic 33/33, all instruction microtests passed
- `python test.py vmp`
  - required gate targets passed
- `cmd /c "set MERGEN_DIAG_LIFT_PROGRESS=1&& build_iced\lifter.exe ..\testthemida\example2-virt.bin 0x140001000"`

## Review
Reviewer result: correct, confidence 0.92, no blockers.
