### PR TITLE
lifter: lower INT29 to fastfail

### DIFF
--- a/lifter/semantics/Semantics.ipp
+++ b/lifter/semantics/Semantics.ipp
@@ -66,6 +66,38 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::liftInstructionSemantics() {
     finished = 1;
     return;
   }
+  case Mnemonic::INT: {
+    if (instruction.immediate == 0x29) {
+      auto* fastFailType = llvm::FunctionType::get(
+          llvm::Type::getVoidTy(context),
+          {llvm::Type::getInt64Ty(context)}, false);
+      auto* fastFail = llvm::cast<llvm::Function>(
+          fnc->getParent()
+              ->getOrInsertFunction("fastfail", fastFailType)
+              .getCallee());
+      auto* code = createZExtOrTruncFolder(
+          GetRegisterValue(Register::RCX), llvm::Type::getInt64Ty(context));
+      builder->CreateCall(fastFail, {code});
+      builder->CreateUnreachable();
+      run = 0;
+      finished = 1;
+      return;
+    }
+    {
+      std::string mnem(magic_enum::enum_name(instruction.mnemonic));
+      uint64_t instrAddr = current_address - instruction.length;
+      diagnostics.error(DiagCode::InstructionNotImplemented, instrAddr,
+                        "Instruction not implemented: " + mnem, mnem);
+    }
+    Function* externFunc = cast<Function>(
+        fnc->getParent()
+            ->getOrInsertFunction("not_implemented", fnc->getReturnType())
+            .getCallee());
+    builder->CreateRet(builder->CreateCall(externFunc));
+    run = 0;
+    finished = 1;
+    break;
+  }
   case Mnemonic::FXRSTOR:
   case Mnemonic::FXSAVE:
   case Mnemonic::PAUSE:

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -412,6 +412,23 @@ private:
   }
 
 
+  bool runInt29FastfailLoweredToNoReturnCall(std::string& details) {
+    LifterUnderTest lifter;
+    lifter.SetRegisterValue(RegisterUnderTest::RCX,
+                            makeI64(lifter.builder->getContext(), 0x42));
+    static constexpr uint8_t kInt29[] = {0xCD, 0x29};
+    lifter.liftBytes(kInt29, sizeof(kInt29));
+    if (!functionHasDirectCallTo(lifter.fnc, "fastfail")) {
+      details = "  int 29h should lower to a direct fastfail call\n";
+      return false;
+    }
+    if (!llvm::isa<llvm::UnreachableInst>(lifter.bb->getTerminator())) {
+      details = "  int 29h should terminate the block with unreachable\n";
+      return false;
+    }
+    return true;
+  }
+
   bool runLoopGeneralizationConditionalBranchAllowed(std::string& details) {
     LifterUnderTest lifter;
     lifter.currentPathSolveContext =
@@ -1229,6 +1246,8 @@ private:
              &InstructionTester::runLoopGeneralizationDirectJumpAllowed);
     runCustom("loop_generalization_indirect_jump_blocked_when_unresolved",
              &InstructionTester::runLoopGeneralizationIndirectJumpBlockedWhenUnresolved);
+    runCustom("int29_fastfail_lowered_to_noreturn_call",
+             &InstructionTester::runInt29FastfailLoweredToNoReturnCall);
     runCustom("loop_generalization_indirect_jump_allowed_when_resolved",
              &InstructionTester::runLoopGeneralizationIndirectJumpAllowedWhenResolved);
     runCustom("loop_generalization_ret_blocked",


### PR DESCRIPTION
## Summary
- add explicit INT 29h lowering to a non-returning `fastfail(i64)` call
- preserve the existing unsupported-instruction behavior for all other INT immediates
- add a targeted regression covering the fast-fail lowering shape

## Why
The real PE entrypoint for `example2-virt.bin` is `0x1400013b8`, not `0x140001000`. Lifting that entrypoint failed on `int 0x29` at `0x14000179e`.

On x64 Windows, `INT 29h` is the fast-fail mechanism (`__fastfail`) and does not return. Modeling it as an unsupported instruction was stopping entrypoint lifting at the first concrete runtime guard path.

## Change
- `lifter/semantics/Semantics.ipp`
  - `INT 29h` now lowers to a direct call to `fastfail(i64)` using RCX as the fail code
  - the block terminates with `unreachable`
  - non-`0x29` INT immediates explicitly route to the existing `not_implemented` path
- `lifter/test/Tester.hpp`
  - add `int29_fastfail_lowered_to_noreturn_call`

## Effect
On the real entrypoint `0x1400013b8`:
- before: two `Instruction not implemented: INT` errors at `0x14000179e`
- after: no errors, no warnings
- current lift stats: `28 blocks (5 completed, 0 unreachable), 121 instructions`

## Verification
- `cmd /c "set CLANG_CL_EXE=C:\Program Files\LLVM\bin\clang-cl.exe && ninja -C build_iced lifter rewrite_microtests"`
- `build_iced\rewrite_microtests.exe int29_fastfail_lowered_to_noreturn_call solve_path_widens_mapped_rva_target normalize_runtime_target_widens_mapped_rva_target solve_load_infers_concrete_base_from_tracked_load generalized_loop_restore_merges_backedge_register_state`
- `python test.py quick`
  - all rewrite checks passed, determinism 42/42, semantic 33/33, all instruction microtests passed
- `python test.py vmp`
  - required gate targets passed
- `cmd /c "set MERGEN_DIAG_LIFT_PROGRESS=1&& set MERGEN_WRITE_UNOPT_IR=1&& build_iced\lifter.exe ..\testthemida\example2-virt.bin 0x1400013b8"`

## Review
Reviewer result: correct, confidence 0.93, no blockers.
