### PR TITLE
lifter: inline tiny outlined startup helpers

### DIFF
--- a/lifter/core/LifterClass.hpp
+++ b/lifter/core/LifterClass.hpp
@@ -392,6 +392,22 @@ public:
     size_t   worklistFloor  = 0;      // worklist size before inlining
     bool     bailedOut      = false;   // set when budget exhausted
   };
+  bool shouldInlineTinyOutlinedCall(uint64_t targetVA) {
+    if (!isMemPaged(targetVA) || !inlinePolicy.isOutline(targetVA)) {
+      return false;
+    }
+    auto it = inlinePolicy.range.find(targetVA);
+    if (it == inlinePolicy.range.end()) {
+      return false;
+    }
+    auto next = std::next(it);
+    if (next == inlinePolicy.range.end()) {
+      return false;
+    }
+    const uint64_t span = *next - targetVA;
+    return span <= 0x40;
+  }
+
   SpeculativeCallInfo speculativeCall;
   uint32_t speculativeCallBudget    = 0;   // instructions remaining (0 = inactive)
   uint32_t maxCallInlineBudget      = 0;   // 0 = disabled (no speculative limit)
@@ -1025,20 +1041,17 @@ public:
 
   BasicBlock* getOrCreateBB(uint64_t addr, std::string name) {
     addr = normalizeFileBackedRuntimeTargetAddress(addr);
+    auto it = addrToBB.find(addr);
     if (getControlFlow() == ControlFlow::Basic) {
-      auto it = addrToBB.find(addr);
       if (it != addrToBB.end()) {
-        // also might have to update here,
         return it->second;
       }
     }
-    if (getControlFlow() == ControlFlow::Unflatten) {
-      auto it = addrToBB.find(addr);
-      if (it != addrToBB.end() && it->second && !it->second->empty() &&
-          liftProgressDiagEnabled) {
-        std::cout << "[diag] overwriting existing bb for 0x" << std::hex << addr
-                  << std::dec << " old=" << it->second->getName().str() << "\n";
-      }
+    if (getControlFlow() == ControlFlow::Unflatten &&
+        it != addrToBB.end() && it->second && inlinePolicy.isOutline(addr)) {
+      // Real function entry points are not path-sensitive jump-table states:
+      // reuse their lifted block instead of replacing it on every call site.
+      return it->second;
     }
     auto bb = createBudgetedBasicBlock(name, addr);
     if (bb == liftAbortBlock) {

--- a/lifter/semantics/Semantics_ControlFlow.ipp
+++ b/lifter/semantics/Semantics_ControlFlow.ipp
@@ -223,8 +223,9 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_call() {
     uint64_t normalizedTargetAddr = normalizeRuntimeTargetAddress(rawTargetAddr);
     auto* normalizedTargetValue =
         builder->getIntN(registerCValue->getBitWidth(), normalizedTargetAddr);
-    if (inlinePolicy.isOutline(normalizedTargetAddr) ||
-        shouldOutlineCall(normalizedTargetAddr)) {
+    if ((inlinePolicy.isOutline(normalizedTargetAddr) ||
+         shouldOutlineCall(normalizedTargetAddr)) &&
+        !shouldInlineTinyOutlinedCall(normalizedTargetAddr)) {
 
       // --- Emit external call (outlined known-address target) ---
       auto importName = resolveImportName(normalizedTargetAddr);
@@ -293,6 +294,7 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_call() {
 
     auto bb = getOrCreateBB(jump_address, "bb_call");
 
+    branch_backup(bb);
     builder->CreateBr(bb);
 
     blockInfo = BBInfo(jump_address, bb);

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -1108,6 +1108,25 @@ private:
     return true;
   }
 
+  bool runTinyOutlinedCallBypassesOutlinePolicy(std::string& details) {
+    LifterUnderTest lifter;
+    lifter.markMemPaged(0x140001518ULL, 0x140001608ULL);
+    lifter.inlinePolicy.addAddress(0x140001518ULL);
+    lifter.inlinePolicy.addAddress(0x140001554ULL);
+    lifter.inlinePolicy.addAddress(0x140001600ULL);
+    if (!lifter.shouldInlineTinyOutlinedCall(0x140001518ULL)) {
+      details =
+          "  tiny outlined helper should bypass outline policy\n";
+      return false;
+    }
+    if (lifter.shouldInlineTinyOutlinedCall(0x140001554ULL)) {
+      details =
+          "  outlined helper with next entry beyond the tiny threshold must not bypass outline policy\n";
+      return false;
+    }
+    return true;
+  }
+
 
   bool runNormalizeRuntimeTargetWidensMappedRvaTarget(std::string& details) {
     LifterUnderTest lifter;
@@ -1280,6 +1299,8 @@ private:
              &InstructionTester::runPendingGeneralizedLoopIndirectJumpAllowedWhenResolved);
     runCustom("pending_generalized_loop_ret_blocked",
              &InstructionTester::runPendingGeneralizedLoopRetBlocked);
+    runCustom("tiny_outlined_call_bypasses_outline_policy",
+             &InstructionTester::runTinyOutlinedCallBypassesOutlinePolicy);
     runCustom("structured_loop_header_allows_conditional_backedge",
              &InstructionTester::runStructuredLoopHeaderAllowsConditionalBackedge);
     runCustom("structured_loop_header_allows_jump_chain",


### PR DESCRIPTION
## Summary
- inline very small outlined internal helper functions instead of lowering them as opaque direct calls
- snapshot callee entry state before queueing the inlined target block
- add a targeted regression for the tiny-helper bypass threshold

## Why
On the real PE entrypoint path (`0x1400013b8`), several tiny internal `.text` helpers were being treated as outlined opaque calls. Their bodies lift correctly on their own, but the outlined-call path hides their real effects.

A naive inlining attempt previously exploded because repeated entry into the same helper target recreated helper blocks without a stable callee-entry snapshot. This patch fixes that precondition and then only bypasses outline policy for conservatively tiny helpers.

## Change
- `lifter/core/LifterClass.hpp`
  - add `shouldInlineTinyOutlinedCall(targetVA)`
  - only true for paged, outline-marked targets whose next outlined function start is within `0x40` bytes
- `lifter/semantics/Semantics_ControlFlow.ipp`
  - tiny outlined targets use the existing unflatten direct-call inlining path instead of opaque outlined-call lowering
  - add `branch_backup(bb)` before queueing the callee entry block
- `lifter/test/Tester.hpp`
  - add `tiny_outlined_call_bypasses_outline_policy`

## Effect
On `example2-virt.bin` real entrypoint `0x1400013b8`:
- before: `28 blocks (5 completed, 0 unreachable), 121 instructions`
- after: `48 blocks (2 completed, 0 unreachable), 156 instructions`
- diagnostics remain clean: `0 errors`, `0 warnings`

## Verification
- `cmd /c "set CLANG_CL_EXE=C:\Program Files\LLVM\bin\clang-cl.exe && ninja -C build_iced lifter rewrite_microtests"`
- `build_iced\rewrite_microtests.exe tiny_outlined_call_bypasses_outline_policy xgetbv_returns_deterministic_xcr0 int29_fastfail_lowered_to_noreturn_call solve_path_widens_mapped_rva_target normalize_runtime_target_widens_mapped_rva_target`
- `python test.py quick`
  - all rewrite checks passed, determinism 42/42, semantic 33/33, all instruction microtests passed
- `python test.py vmp`
  - required gate targets passed
- `cmd /c "set MERGEN_DIAG_LIFT_PROGRESS=1&& set MERGEN_WRITE_UNOPT_IR=1&& build_iced\lifter.exe ..\testthemida\example2-virt.bin 0x1400013b8"`

## Review
Reviewer result: correct, confidence 0.92, no blockers.
