### PR TITLE
lifter: preserve integer cast widths in computePossibleValues

### DIFF
--- a/lifter/memory/GEPTracker.ipp
+++ b/lifter/memory/GEPTracker.ipp
@@ -718,6 +718,37 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(pvalueset)::computePossibleValues(
 
     if (v_inst->getNumOperands() == 1) {
       auto result = computePossibleValues(v_inst->getOperand(0), Depth + 1);
+      // Integer casts change the bit-width of every value in the set.  Without
+      // this step the set returned for a trunc/zext/sext instruction carries
+      // the *operand* width, which then mismatches callers that compare or
+      // index by the instruction's declared type (e.g. switch dispatch on an
+      // i32 after a trunc from i64).
+      if (auto* castInst = dyn_cast<CastInst>(v_inst)) {
+        auto* srcTy = castInst->getOperand(0)->getType();
+        auto* dstTy = castInst->getType();
+        if (srcTy->isIntegerTy() && dstTy->isIntegerTy()) {
+          std::set<APInt, APIntComparator> castResult;
+          const unsigned width = dstTy->getIntegerBitWidth();
+          for (const auto& value : result) {
+            switch (castInst->getOpcode()) {
+            case Instruction::Trunc:
+              castResult.insert(value.trunc(width));
+              break;
+            case Instruction::ZExt:
+              castResult.insert(value.zext(width));
+              break;
+            case Instruction::SExt:
+              castResult.insert(value.sext(width));
+              break;
+            default:
+              castResult.insert(value);
+              break;
+            }
+          }
+          pv_cache[V] = castResult;
+          return castResult;
+        }
+      }
       pv_cache[V] = result;
       return result;
     }

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -1083,6 +1083,101 @@ private:
   }
 
 
+  bool runComputePossibleValuesPreservesCastWidths(std::string& details) {
+    LifterUnderTest lifter;
+    auto& context = lifter.context;
+    auto* entry = llvm::BasicBlock::Create(context, "entry", lifter.fnc);
+    lifter.builder->SetInsertPoint(entry);
+
+    // Two i64 constants that differ in both halves, so a trunc to i32 yields
+    // two distinct i32 values and a zext back to i64 would not recover the
+    // high half.
+    const uint64_t lhsValue = 0x00000001'DEADBEEFULL;
+    const uint64_t rhsValue = 0x00000002'CAFEBABEULL;
+
+    // A select over an unresolved condition gives computePossibleValues a
+    // concrete two-element set to feed into the cast.
+    auto* cond = lifter.builder->CreateICmpEQ(
+        lifter.GetRegisterValue(RegisterUnderTest::RAX),
+        makeI64(context, 1), "cast_width_cond");
+    auto* selected = lifter.builder->CreateSelect(
+        cond, makeI64(context, lhsValue), makeI64(context, rhsValue),
+        "cast_width_select");
+
+    auto* truncI32 = lifter.builder->CreateTrunc(
+        selected, llvm::Type::getInt32Ty(context), "cast_width_trunc");
+    auto truncValues = lifter.computePossibleValues(truncI32, 0);
+    if (truncValues.size() != 2) {
+      std::ostringstream os;
+      os << "  trunc result should enumerate both low halves, got size "
+         << truncValues.size() << "\n";
+      details = os.str();
+      return false;
+    }
+    for (const auto& value : truncValues) {
+      if (value.getBitWidth() != 32) {
+        std::ostringstream os;
+        os << "  trunc result width should be 32, got " << value.getBitWidth()
+           << "\n";
+        details = os.str();
+        return false;
+      }
+    }
+    if (!truncValues.contains(llvm::APInt(32, static_cast<uint32_t>(lhsValue))) ||
+        !truncValues.contains(llvm::APInt(32, static_cast<uint32_t>(rhsValue)))) {
+      details =
+          "  trunc result should contain both 32-bit low halves\n";
+      return false;
+    }
+
+    auto* zextI64 = lifter.builder->CreateZExt(
+        truncI32, llvm::Type::getInt64Ty(context), "cast_width_zext");
+    auto zextValues = lifter.computePossibleValues(zextI64, 0);
+    if (zextValues.size() != 2) {
+      std::ostringstream os;
+      os << "  zext result should enumerate both widened values, got size "
+         << zextValues.size() << "\n";
+      details = os.str();
+      return false;
+    }
+    for (const auto& value : zextValues) {
+      if (value.getBitWidth() != 64) {
+        std::ostringstream os;
+        os << "  zext result width should be 64, got " << value.getBitWidth()
+           << "\n";
+        details = os.str();
+        return false;
+      }
+    }
+    if (!zextValues.contains(llvm::APInt(64, static_cast<uint32_t>(lhsValue))) ||
+        !zextValues.contains(llvm::APInt(64, static_cast<uint32_t>(rhsValue)))) {
+      details =
+          "  zext result should zero-extend both trunc halves back to 64 bits\n";
+      return false;
+    }
+
+    auto* sextI64 = lifter.builder->CreateSExt(
+        truncI32, llvm::Type::getInt64Ty(context), "cast_width_sext");
+    auto sextValues = lifter.computePossibleValues(sextI64, 0);
+    for (const auto& value : sextValues) {
+      if (value.getBitWidth() != 64) {
+        std::ostringstream os;
+        os << "  sext result width should be 64, got " << value.getBitWidth()
+           << "\n";
+        details = os.str();
+        return false;
+      }
+    }
+    // 0xDEADBEEF has its high bit set, so SExt must produce 0xFFFFFFFF'DEADBEEF.
+    if (!sextValues.contains(llvm::APInt(64, 0xFFFFFFFF'DEADBEEFULL))) {
+      details =
+          "  sext result should sign-extend the negative low half\n";
+      return false;
+    }
+    return true;
+  }
+
+
   bool runSolvePathSkipsRawZeroInMultiTargetSwitch(std::string& details) {
     LifterUnderTest lifter;
     auto* current = llvm::BasicBlock::Create(lifter.context, "current", lifter.fnc);
@@ -1375,6 +1470,8 @@ private:
              &InstructionTester::runGeneralizedLoopRestoreMergesBackedgeRegisterState);
     runCustom("solve_load_infers_concrete_base_from_tracked_load",
              &InstructionTester::runSolveLoadInfersConcreteBaseFromTrackedLoad);
+    runCustom("compute_possible_values_preserves_cast_widths",
+             &InstructionTester::runComputePossibleValuesPreservesCastWidths);
     runCustom("solve_path_skips_raw_zero_in_multi_target_switch",
              &InstructionTester::runSolvePathSkipsRawZeroInMultiTargetSwitch);
     runCustom("solve_path_widens_mapped_rva_target",


### PR DESCRIPTION
## Problem

`computePossibleValues` recurses through single-operand instructions by passing the operand's value set through unchanged. For integer casts that silently widens the bit-width contract:

- A `trunc i64 %x to i32` returns i64-wide `APInt`s.
- A `zext i32 %x to i64` returns i32-wide `APInt`s.
- Same story for `sext`.

Callers that compare or index the set by the instruction's declared type — e.g. switch dispatch on a freshly-truncated `i32` — then silently mismatch.

## Fix

In the `getNumOperands() == 1` branch of `computePossibleValues`, detect `trunc` / `zext` / `sext` between integer types and rewrite each `APInt` to the destination type's bit width. Default through for other single-operand opcodes, so non-cast unary instructions stay on the existing pass-through path.

```cpp
if (auto* castInst = dyn_cast<CastInst>(v_inst)) {
  auto* srcTy = castInst->getOperand(0)->getType();
  auto* dstTy = castInst->getType();
  if (srcTy->isIntegerTy() && dstTy->isIntegerTy()) {
    const unsigned width = dstTy->getIntegerBitWidth();
    for (const auto& value : result) {
      switch (castInst->getOpcode()) {
      case Instruction::Trunc: castResult.insert(value.trunc(width)); break;
      case Instruction::ZExt:  castResult.insert(value.zext(width));  break;
      case Instruction::SExt:  castResult.insert(value.sext(width));  break;
      default:                 castResult.insert(value);              break;
      }
    }
    ...
  }
}
```

## Test

`compute_possible_values_preserves_cast_widths` feeds a `select i1 %cond, i64 0x1DEADBEEF, i64 0x2CAFEBABE` through `trunc -> i32`, `zext -> i64`, and `sext -> i64`, pinning the post-cast width explicitly and checking a sign-extended negative round-trip. A regression in any of the three branches surfaces as a width mismatch or a missing sign-extended value.

The `select` feed intentionally avoids the generalized-loop / phi-in-BB machinery so the test exercises only `computePossibleValues` cast handling.

## Verification

Fresh `build_iced/`:

- `python test.py baseline` — 0 failures
- `python test.py micro` — 0 failures (new test included)

## Scope

PR 2 of a planned sequence. PR 1 (#110, raw-zero switch filter) merged already. Follow-up (control-slot canonical phi generalization) is a larger semantics change and will be its own PR with deliberate vm_loop verification.