### PR TITLE
chore: gitignore session scratch + note cross-branch build cache hazard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,15 @@ check_*.py
 =*
 scriptsdev/
 
+# session-scratch from frontier research / ad-hoc lifter runs at specific
+# addresses.  These get produced when a session dumps per-function IR, saves
+# a handoff note, or records a binary-probe target; they should never land.
+internal_0x*.ll
+internal_0x*_diag.json
+*handoff.md
+linked_target.txt
+vlizer_stub.txt
+
 # review automation
 /artifacts/
 scripts/rewrite/tmp_*.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,7 @@ scripts\rewrite\run_microtests.cmd --check-flags xor
 - If you edit the same file twice, re-read it first.
 - Default to one main line of work; split into subtasks only when file boundaries are real and outputs are independent.
 - Do not finish non-trivial work without focused verification that matches the changed subsystem.
+- Before comparing two branches with `python test.py baseline`/`quick`, wipe `build_iced/` (`rm -rf build_iced && cmd /c scripts\dev\configure_iced.cmd && cmd /c scripts\dev\build_iced.cmd`).  Incremental builds reuse object files across branches and will happily link a stale mix of old and new code, producing a lifter binary whose failure set reflects neither branch.  This has caused at least one false "branch matches main" claim.
 
 ## What not to do
 - Do not start with repo-root scans when a narrower directory or entry document can answer the question.


### PR DESCRIPTION
Two small hardenings based on failure modes observed during the Themida frontier work (PRs #110-#112).

## `.gitignore` additions

The research session produced several classes of scratch files that ended up tracked on a working branch and had to be scrubbed before merge:

- `internal_0x*.ll` / `internal_0x*_diag.json` — per-function IR/diagnostic dumps produced by ad-hoc lifter runs at specific addresses
- `*handoff.md` — session handoff notes (`autoresearch_handoff.md`, `themidahandoff.md`)
- `linked_target.txt`, `vlizer_stub.txt` — session-specific scratch

None of these are currently tracked on `main`; the patterns just keep them from leaking in on future branches.

## `AGENTS.md` operator default

Added a bullet to the operator workflow defaults about wiping `build_iced/` before cross-branch comparison:

> Before comparing two branches with `python test.py baseline`/`quick`, wipe `build_iced/` … Incremental builds reuse object files across branches and will happily link a stale mix of old and new code, producing a lifter binary whose failure set reflects neither branch.

This is exactly the failure mode that produced the false "branch matches main" claim in the closed PR #109 — documenting it in the operator defaults so the next session doesn't repeat it.

No code changes.
