### PR TITLE
docs: correct SCOPE loop-header generalization status

### DIFF
--- a/docs/SCOPE.md
+++ b/docs/SCOPE.md
@@ -25,7 +25,7 @@ Mergen is a function-level LLVM IR lifting engine for deobfuscation and devirtua
 | 32-bit x86 lifting | Not supported |
 | ARM / RISC-V / other architectures | Not supported |
 | Jump-table IR quality | Supported shapes still dispatch on concrete target addresses, not logical case indices |
-| Loop-header generalization | Temporarily disabled while the team keeps required VMP 3.8.x targets on the safe high-budget path |
+| Loop-header generalization | Gated by path-solve context: allowed for `ConditionalBranch` and `DirectJump`, and for `IndirectJump` only when the target is already resolved concretely; `Ret` never generalizes. See `docs/LOOP_HANDLING.md`. |
 
 ## Current Development Focus
 - Near term: broaden control-flow recovery and IR quality for loops, jump tables, indirect branches, and VM-style dispatcher shapes.


### PR DESCRIPTION
`docs/SCOPE.md` line 28 read:

> Loop-header generalization — Temporarily disabled while the team keeps required VMP 3.8.x targets on the safe high-budget path

That is stale relative to current code:

- `canGeneralizeStructuredLoopHeader` in `lifter/core/LifterClass.hpp` runs a nine-step guard sequence and accepts when they pass; it is not wholesale disabled.
- `currentPathSolveAllowsStructuredLoopGeneralization()` returns `true` for `ConditionalBranch` and `DirectJump`, and the resolved-target widening adds `IndirectJump` when the target is pinned. `Ret` is never accepted.
- The `loop_generalization_*` and `pending_generalized_loop_*` microtest groups cover the allowed/blocked matrix and all pass on main.

Update the line to describe the actual gating and point readers at `docs/LOOP_HANDLING.md` (added in #116).

Docs-only.
