### PR TITLE
lifter: remove resolveTargetedThemidaR9 - obsoleted by generalized-loop phi infrastructure

### DIFF
--- a/docs/LOOP_HANDLING.md
+++ b/docs/LOOP_HANDLING.md
@@ -133,7 +133,6 @@ When the lifter is in loop mode (`currentBlockUsesGeneralizedLoopState() == true
 | `retrieve_generalized_loop_target_slot_value(addr, bytes)` | Phi of canonical/backedge values for a recognized target slot. |
 | `retrieve_generalized_loop_phi_address_value(load, bytes, orgLoad)` | Phi of loaded values when the load's address is a phi of two concrete addresses derived from canonical/backedge. |
 | `retrieve_generalized_loop_local_phi_address_value(load, bytes, orgLoad)` | Same as above for loop-local stack-buffer addresses. |
-| `resolveTargetedThemidaR9(value)` | At three hardcoded Themida instruction addresses, replaces R9 with `(canonicalControl + offset, backedgeControl + offset)` phi. See [Hardcoded reference-sample addresses](#hardcoded-reference-sample-addresses). |
 
 `computePossibleValues` (in `lifter/memory/GEPTracker.ipp`) also has a `PHINode` case that unions every incoming's value set, so callers downstream of these phis get the full possible-value enumeration instead of an empty fallback.
 
@@ -148,18 +147,6 @@ static constexpr std::array<uint64_t, 3> kSupportedGeneralizedControlFieldOffset
     0x6ULL, 0xAULL, 0xCULL};
 ```
 
-`resolveTargetedThemidaR9` adds three hardcoded `(instruction-address, control-offset)` pairs:
-
-| Instruction address | Control offset | Verified hit count on reference sample |
-|---|---|---|
-| `0x140023671` | `0x0` | 3 |
-| `0x14002368D` | `0xA` | 6 |
-| `0x140023741` | `0xC` | 12 |
-
-These pairs are load-bearing for the 2544-instruction Themida benchmark — removing them regresses the lifted output. They exist because the lifter's symbolic R9 value at those points has lost the controlCursor identity; the override re-injects the canonical/backedge phi directly.
-
-Generalizing this away requires either (a) preserving the controlCursor identity through the upstream symbolic computation, (b) adding a tagging layer that marks values as "derived from controlCursor + const," or (c) a static-analysis pass that scans the function once and auto-derives the `(address, offset)` pairs. This is documented as known follow-up work, not a quick refactor.
-
 The diagnostic prints scattered across `PathSolver.ipp`, `LifterClass.hpp`, `LifterClass_Concolic.hpp`, and `GEPTracker.ipp` that gate on specific Themida addresses (`0x1400237F9ULL`, `0x140023582-0x1400237FFULL`, etc.) only fire under `MERGEN_DIAG_LIFT_PROGRESS=1` and are session scaffolding for that sample. They produce no output for any other binary.
 
 ## Tests
@@ -173,7 +160,6 @@ Loop handling has roughly thirty microtests in `lifter/test/Tester.hpp`. The mos
 | `pending_generalized_loop_*` | Same guards in the `pendingLoopGeneralizationAddresses` lifecycle. |
 | `generalized_loop_restore_*` | Backedge flag-state and register-state merging across `load_generalized_backup`. |
 | `generalized_loop_*_creates_phi` | Each `retrieve_generalized_loop_*` helper produces the expected phi shape (control slot, control slot displacement, target slot, control field load, local phi address). |
-| `targeted_themida_r9_override_produces_phi` | All three hardcoded `(address, offset)` pairs in `resolveTargetedThemidaR9`. |
 | `compute_possible_values_*` | The PHI handler unions incomings (also covers cast-width preservation and rolled-arithmetic-chain enumeration). |
 
 When changing loop handling, run at minimum:
@@ -197,6 +183,5 @@ and inspect `output_diagnostics.json` for `lift_stats.instructions_lifted == 254
 |---|---|
 | `REP`/`REPE`/`REPNE`-prefixed `SCAS` | Rejected as `not_implemented`; needs a model for repeated-scan termination. |
 | `INT 2` continuation under VMP 3.6 | Naive architectural fallthrough is wrong; recovery requires modeling the dispatcher / exception-mediated control flow. See `VMP_TESTING_NOTES.md`. |
-| Hardcoded `(address, offset)` pairs in `resolveTargetedThemidaR9` | Only fire on the reference Themida sample. See [Hardcoded reference-sample addresses](#hardcoded-reference-sample-addresses). |
 | Loop unrolling / loop-invariant code motion | Not implemented. The lifter relies on LLVM's downstream optimization passes for this once the IR is in shape. |
 | Multi-way backedges (≥3 paths to the same header) | Not exercised by the current generalized-loop machinery; the canonical/backedge model assumes exactly two incoming paths. |

--- a/lifter/core/LifterClass_Concolic.hpp
+++ b/lifter/core/LifterClass_Concolic.hpp
@@ -139,72 +139,7 @@ public:
     }
   }
 
-  llvm::Value* resolveTargetedThemidaR9(llvm::Value* value) {
-    auto* state = getMostRecentGeneralizedLoopState();
-    if (this->liftProgressDiagEnabled && this->current_address >= 0x140023500ULL &&
-        this->current_address <= 0x140023800ULL) {
-      std::cout << "[diag] targeted_r9_state current=0x" << std::hex
-                << this->current_address << std::dec
-                << " hasState=" << (state ? 1 : 0) << "\n";
-    }
-    if (!value || !state || !this->builder) {
-      return value;
-    }
-    uint64_t offset = 0;
-    switch (this->current_address) {
-    case 0x140023671ULL:
-      offset = 0;
-      break;
-    case 0x14002368DULL:
-      offset = 0xA;
-      break;
-    case 0x140023741ULL:
-      offset = 0xC;
-      break;
-    default:
-      return value;
-    }
-    auto* canonicalValue = this->builder->getInt64(state->canonicalControl + offset);
-    auto* backedgeValue = this->builder->getInt64(state->backedgeControl + offset);
-    if (this->liftProgressDiagEnabled) {
-      std::cout << "[diag] targeted_r9 current=0x" << std::hex
-                << this->current_address << " canonical=0x"
-                << state->canonicalControl + offset << " backedge=0x"
-                << state->backedgeControl + offset << std::dec << "\n";
-    }
-    if (canonicalValue == backedgeValue) {
-      return canonicalValue;
-    }
-    llvm::IRBuilder<> phiBuilder(state->headerBlock, state->headerBlock->begin());
-    auto* phi =
-        phiBuilder.CreatePHI(canonicalValue->getType(), 2, "targeted_r9_phi");
-    phi->addIncoming(canonicalValue, state->canonicalSource);
-    phi->addIncoming(backedgeValue, state->backedgeSource);
-    return phi;
-  }
-
-  llvm::Value* GetRegisterValue_impl(Register key) {
-    auto* value = get_impl(key);
-    if (key == Register::R9 && this->liftProgressDiagEnabled &&
-        this->current_address >= 0x140023500ULL &&
-        this->current_address <= 0x140023800ULL) {
-      std::cout << "[diag] r9_read current=0x" << std::hex << this->current_address
-                << std::dec << " value=";
-      if (value) {
-        std::string text;
-        llvm::raw_string_ostream os(text);
-        value->print(os);
-        std::cout << os.str();
-      } else {
-        std::cout << "<null>";
-      }
-      std::cout << "\n";
-    }
-    if (key == Register::R9) {
-      return resolveTargetedThemidaR9(value);
-    }
-    return value;
-  }
+  llvm::Value* GetRegisterValue_impl(Register key) { return get_impl(key); }
   void SetRegisterValue_impl(Register key, llvm::Value* val) {
 
     set_impl(key, val);

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -2040,156 +2040,6 @@ bool runSolvePathResolvesGeneralizedPhiLoadTarget(std::string& details) {
   }
 
 
-  bool runTargetedThemidaR9OverrideProducesPhi(std::string& details) {
-    // resolveTargetedThemidaR9 hardcodes three instruction addresses where a
-    // Themida cursor-derived R9 value must be rematerialized as a phi over
-    // canonical/backedge control bases with a per-address offset.  Verify
-    // all three cases, not just one, so a regression that silently drops or
-    // re-offsets a single entry is caught.
-    constexpr uint64_t controlSlot = 0x14004DD19ULL;
-    constexpr uint64_t canonicalControl = 0x1401AF740ULL;
-    constexpr uint64_t backedgeControl = 0x1401AF0F6ULL;
-    struct Case {
-      uint64_t address;
-      uint64_t offset;
-    };
-    constexpr std::array<Case, 3> cases = {
-        {{0x140023671ULL, 0x0},
-         {0x14002368DULL, 0xA},
-         {0x140023741ULL, 0xC}}};
-
-    for (const auto& c : cases) {
-      LifterUnderTest lifter;
-      auto& context = lifter.context;
-      auto* preheader =
-          llvm::BasicBlock::Create(context, "preheader", lifter.fnc);
-      auto* firstBackedge =
-          llvm::BasicBlock::Create(context, "first_backedge", lifter.fnc);
-      auto* loopHeader =
-          llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
-
-      lifter.builder->SetInsertPoint(preheader);
-      lifter.SetMemoryValue(makeI64(context, controlSlot),
-                            makeI64(context, canonicalControl));
-      lifter.branch_backup(loopHeader);
-
-      lifter.builder->SetInsertPoint(firstBackedge);
-      lifter.SetMemoryValue(makeI64(context, controlSlot),
-                            makeI64(context, backedgeControl));
-      lifter.branch_backup(loopHeader, /*generalized=*/true);
-
-      lifter.load_generalized_backup(loopHeader);
-      lifter.builder->SetInsertPoint(loopHeader);
-      lifter.current_address = c.address;
-      auto* value = lifter.GetRegisterValue(RegisterUnderTest::R9);
-      auto* phi = llvm::dyn_cast<llvm::PHINode>(value);
-      if (!phi) {
-        std::ostringstream os;
-        os << "  targeted Themida R9 override should return a phi at 0x"
-           << std::hex << c.address << "\n";
-        details = os.str();
-        return false;
-      }
-      bool sawCanonical = false;
-      bool sawBackedge = false;
-      for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
-        auto* incomingBlock = phi->getIncomingBlock(i);
-        auto actual = readConstantAPInt(phi->getIncomingValue(i));
-        if (!actual.has_value()) {
-          std::ostringstream os;
-          os << "  targeted R9 phi incoming values should be concrete at 0x"
-             << std::hex << c.address << "\n";
-          details = os.str();
-          return false;
-        }
-        if (incomingBlock == preheader &&
-            actual->getZExtValue() == canonicalControl + c.offset) {
-          sawCanonical = true;
-        }
-        if (incomingBlock == firstBackedge &&
-            actual->getZExtValue() == backedgeControl + c.offset) {
-          sawBackedge = true;
-        }
-      }
-      if (!sawCanonical || !sawBackedge) {
-        std::ostringstream os;
-        os << "  targeted R9 phi at 0x" << std::hex << c.address
-           << " should carry control+0x" << c.offset
-           << " on both preheader and backedge incomings\n";
-        details = os.str();
-        return false;
-      }
-    }
-    return true;
-  }
-
-
-  bool runTargetedThemidaR9OverrideDoesNotFireAtAdjacentAddress(std::string& details) {
-    // The switch in resolveTargetedThemidaR9 is exact-address.  A regression
-    // that accidentally broadened it to a range (e.g. `addr >= 0x140023500 &&
-    // addr <= 0x140023800`) would silently produce a phi at every R9 read in
-    // that window, corrupting samples that rely on exact-match behavior.
-    // Pick an address one byte off every known hot address; the override must
-    // return the original value unchanged.
-    LifterUnderTest lifter;
-    auto& context = lifter.context;
-    constexpr uint64_t controlSlot = 0x14004DD19ULL;
-    constexpr uint64_t canonicalControl = 0x1401AF740ULL;
-    constexpr uint64_t backedgeControl = 0x1401AF0F6ULL;
-    auto* preheader =
-        llvm::BasicBlock::Create(context, "preheader", lifter.fnc);
-    auto* firstBackedge =
-        llvm::BasicBlock::Create(context, "first_backedge", lifter.fnc);
-    auto* loopHeader =
-        llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
-
-    lifter.builder->SetInsertPoint(preheader);
-    lifter.SetMemoryValue(makeI64(context, controlSlot),
-                          makeI64(context, canonicalControl));
-    lifter.branch_backup(loopHeader);
-
-    lifter.builder->SetInsertPoint(firstBackedge);
-    lifter.SetMemoryValue(makeI64(context, controlSlot),
-                          makeI64(context, backedgeControl));
-    lifter.branch_backup(loopHeader, /*generalized=*/true);
-
-    lifter.load_generalized_backup(loopHeader);
-    lifter.builder->SetInsertPoint(loopHeader);
-    constexpr std::array<uint64_t, 3> adjacent = {
-        0x140023672ULL, 0x14002368EULL, 0x140023742ULL};
-    for (uint64_t addr : adjacent) {
-      lifter.current_address = addr;
-      auto* r9 = lifter.GetRegisterValue(RegisterUnderTest::R9);
-      if (llvm::isa<llvm::PHINode>(r9)) {
-        std::ostringstream os;
-        os << "  targeted R9 override fired at non-hot address 0x"
-           << std::hex << addr << " (exact-match contract broken)\n";
-        details = os.str();
-        return false;
-      }
-    }
-    return true;
-  }
-
-  bool runTargetedThemidaR9OverrideFallsThroughWithoutLoopState(std::string& details) {
-    // Before any generalized-loop backup has been created,
-    // getMostRecentGeneralizedLoopState() returns null and the override must
-    // fall through to the ordinary R9 value instead of attempting to build a
-    // phi from uninitialized state.
-    LifterUnderTest lifter;
-    auto& context = lifter.context;
-    auto* entry = llvm::BasicBlock::Create(context, "entry", lifter.fnc);
-    lifter.builder->SetInsertPoint(entry);
-    lifter.current_address = 0x140023741ULL;   // a hot address, on purpose
-    auto* r9 = lifter.GetRegisterValue(RegisterUnderTest::R9);
-    if (llvm::isa<llvm::PHINode>(r9)) {
-      details =
-          "  targeted R9 override should not fire without an active generalized loop state\n";
-      return false;
-    }
-    return true;
-  }
-
   bool runGeneralizedLoopControlSlotCreatesPhi(std::string& details) {
     LifterUnderTest lifter;
     auto& context = lifter.context;
@@ -2457,7 +2307,6 @@ bool runRolledGeneralizedPhiAddressUsesAdvancedPair(std::string& details) {
 
   lifter.load_generalized_backup(loopHeader);
   lifter.builder->SetInsertPoint(loopHeader);
-  lifter.current_address = 0x140023741ULL;
   llvm::IRBuilder<> phiBuilder(loopHeader, loopHeader->begin());
   auto* controlPhi = phiBuilder.CreatePHI(llvm::Type::getInt64Ty(context), 2,
                                           "rolled_control_phi");
@@ -2613,9 +2462,11 @@ bool runComputePossibleValuesOnGeneralizedPhiLoad(std::string& details) {
 
   lifter.load_generalized_backup(loopHeader);
   lifter.builder->SetInsertPoint(loopHeader);
-  lifter.current_address = 0x140023671ULL;
-  auto* r9Phi = lifter.GetRegisterValue(RegisterUnderTest::R9);
-  auto* pointer = lifter.getPointer(r9Phi);
+  // Obtain a phi-of-concrete-addresses by loading the control slot in
+  // generalized loop mode; retrieve_generalized_loop_control_slot_value
+  // synthesizes a phi(canonicalControl, backedgeControl) for this load.
+  auto* phiAddress = lifter.GetMemoryValue(makeI64(context, controlSlot), 64);
+  auto* pointer = lifter.getPointer(phiAddress);
   auto* load = lifter.builder->CreateLoad(llvm::Type::getInt64Ty(context), pointer,
                                           "generalized_phi_load_probe");
   auto values = lifter.computePossibleValues(load, 0);
@@ -2705,7 +2556,6 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
 
   lifter.load_generalized_backup(loopHeader);
   lifter.builder->SetInsertPoint(loopHeader);
-  lifter.current_address = 0x140023741ULL;
   llvm::IRBuilder<> phiBuilder(loopHeader, loopHeader->begin());
   auto* controlPhi = phiBuilder.CreatePHI(llvm::Type::getInt64Ty(context), 2,
                                           "rolled_control_phi_for_arith");
@@ -3076,8 +2926,6 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runPromotedGeneralizedLoopRestoresCanonicalBackup);
     runCustom("generalized_loop_restore_merges_backedge_flag_state",
              &InstructionTester::runGeneralizedLoopRestoreMergesBackedgeFlagState);
-    runCustom("targeted_themida_r9_override_produces_phi",
-             &InstructionTester::runTargetedThemidaR9OverrideProducesPhi);
     runCustom("generalized_loop_restore_merges_backedge_register_state",
              &InstructionTester::runGeneralizedLoopRestoreMergesBackedgeRegisterState);
     runCustom("set_register_value_zero_extends_32bit_writes",
@@ -3104,10 +2952,6 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runComputePossibleValuesCircularPhiBailsViaDepthGuard);
     runCustom("compute_possible_values_trunc_to_i1_preserves_width",
              &InstructionTester::runComputePossibleValuesTruncToI1PreservesWidth);
-    runCustom("targeted_themida_r9_override_does_not_fire_at_adjacent_address",
-             &InstructionTester::runTargetedThemidaR9OverrideDoesNotFireAtAdjacentAddress);
-    runCustom("targeted_themida_r9_override_falls_through_without_loop_state",
-             &InstructionTester::runTargetedThemidaR9OverrideFallsThroughWithoutLoopState);
     runCustom("generalized_loop_control_field_load_creates_phi",
              &InstructionTester::runGeneralizedLoopControlFieldLoadCreatesPhi);
     runCustom("solve_path_prefers_mapped_target_over_null_for_indirect_jump",


### PR DESCRIPTION
## Summary

`resolveTargetedThemidaR9` was added to recover the controlCursor identity of R9 at three hardcoded Themida instruction addresses where the symbolic pipeline had lost provenance. **PR #112** since landed `retrieve_generalized_loop_control_*` helpers that produce the correct phi shape through the normal `GetMemoryValue` path. The R9 override is now dead code: it overwrites a correct value with another correct value at three sites the upstream pipeline already handles.

## Empirical evidence

Bisect on the reference Themida sample (`../testthemida/example2-virt.bin @ 0x140001000`):

| Configuration | Lifted | Warn | Err |
|---|---|---|---|
| baseline (override active) | 2544 | 0 | 0 |
| site 0x140023671 disabled alone | 2544 | 0 | 0 |
| site 0x14002368D disabled alone | 2544 | 0 | 0 |
| site 0x140023741 disabled alone | 2544 | 0 | 0 |
| **all three disabled simultaneously** | **2544** | **0** | **0** |

`MERGEN_DIAG_LIFT_PROGRESS=1` trace at site `0x14002368D` shows R9 already arrives as `add i64 %generalized_phi_load, 10` before the override fires - the generalized-loop machinery produced the correct phi independently.

## Removed

- `resolveTargetedThemidaR9()` in `lifter/core/LifterClass_Concolic.hpp`
- R9 special-case branch + session-scaffolding diag block in `GetRegisterValue_impl` (now just `return get_impl(key)`)
- Three microtests in `lifter/test/Tester.hpp`:
  - `runTargetedThemidaR9OverrideProducesPhi`
  - `runTargetedThemidaR9OverrideDoesNotFireAtAdjacentAddress`
  - `runTargetedThemidaR9OverrideFallsThroughWithoutLoopState`
- Their three `runCustom()` registrations
- Override row in helper table, "Hardcoded reference-sample addresses" subsection content, and limitations table row in `docs/LOOP_HANDLING.md`

## Retained

`kThemidaControlCursorSlot`, `kThemidaLoopCarriedSlot`, and `kSupportedGeneralizedControlFieldOffsets` - still consumed by the generalized-loop control-field/slot `retrieve_*` helpers.

## Verification

- `python test.py micro`: all instruction microtests passed
- `python test.py baseline`: all rewrite regression checks passed, determinism check passed (42 golden files match)
- Themida reference sample: 2544 instructions lifted, 0 warnings, 0 errors

## Diff

3 files changed, 1 insertion(+), 237 deletions(-)