### PR TITLE
lifter: support multi-way backedges with N-way generalized-loop phi construction

### DIFF
--- a/docs/LOOP_HANDLING.md
+++ b/docs/LOOP_HANDLING.md
@@ -63,11 +63,13 @@ struct GeneralizedLoopControlFieldState {
   bool valid = false;
   llvm::BasicBlock* headerBlock = nullptr;
   llvm::BasicBlock* canonicalSource = nullptr;
-  llvm::BasicBlock* backedgeSource = nullptr;
+  // Backedge side is variable-width: a loop header may be reached from
+  // multiple backedges (N>=1). Size 1 is the common 2-way loop case.
+  llvm::SmallVector<llvm::BasicBlock*, 2> backedgeSources;
   uint64_t canonicalControl = 0;
-  uint64_t backedgeControl = 0;
+  llvm::SmallVector<uint64_t, 2> backedgeControls;
   llvm::DenseMap<uint64_t, ValueByteReference> canonicalBuffer;
-  llvm::DenseMap<uint64_t, ValueByteReference> backedgeBuffer;
+  llvm::SmallVector<llvm::DenseMap<uint64_t, ValueByteReference>, 2> backedgeBuffers;
 } activeGeneralizedLoopControlFieldState;
 
 llvm::DenseMap<llvm::BasicBlock*, GeneralizedLoopControlFieldState>
@@ -86,29 +88,32 @@ State transitions:
 | Event | What changes |
 |---|---|
 | `branch_backup(bb, generalized=false)` | Snapshots current registers/flags/buffer/cache/assumptions/counter into `BBbackup[bb]`. |
-| `branch_backup(bb, generalized=true)` | Same snapshot stored into `generalizedLoopBackedgeBackup[bb]`; `BBbackup[bb]` only set if absent. |
+| `branch_backup(bb, generalized=true)` | Appends the snapshot to `generalizedLoopBackedgeBackup[bb]` (a `SmallVector<backup_point, 2>`), deduplicated by `sourceBlock` so a repeat call from the same source replaces its entry in place. `BBbackup[bb]` only set if absent. |
 | `load_backup(bb)` | Restores `BBbackup[bb]`, clears `activeGeneralizedLoopLocalBuffer`. |
 | `load_generalized_backup(bb)` | Builds `make_generalized_loop_backup(bb)` and restores it; populates `activeGeneralizedLoopControlFieldState` from the canonical/backedge snapshots. |
 | `record_generalized_loop_backedge(bb)` | Promotes the loop: copies `activeGeneralizedLoopControlFieldState` into the per-header archive, marks the address generalized. |
 
 ## Phi construction at the header
 
-`make_generalized_loop_backup(bb, canonical, backedge)` calls `mergeValue` for every register and flag slot:
+`make_generalized_loop_backup(bb, canonical, ArrayRef<backup_point> sources)` calls `mergeValue` for every register and flag slot. With one canonical source and N backedge sources, it produces a `(1 + N)`-incoming phi (one incoming per distinct `sources[i].sourceBlock`). Sources duplicating `canonical.sourceBlock` are filtered before phi construction.
 
 ```cpp
-auto mergeValue = [&](Value* canonicalValue, Value* backedgeValue,
+auto mergeValue = [&](Value* canonicalValue,
+                      ArrayRef<Value*> backedgeValues,
                       const char* name, PHINode*& phiOut,
                       bool widenFirstBackedge) -> Value* {
-  if (!canonicalValue || !backedgeValue ||
-      types differ || canonical == backedge) {
-    return backedgeValue;          // no phi needed
-  }
-  auto* phi = phiBuilder.CreatePHI(canonicalValue->getType(), 2, name);
+  // Require canonical + all backedges present and type-matched. Any
+  // mismatch falls back to backedgeValues.front(), preserving the
+  // pre-N-way single-backedge semantics for the 2-way case.
+  auto* phi = phiBuilder.CreatePHI(canonicalValue->getType(),
+                                   1 + backedgeValues.size(), name);
   phi->addIncoming(canonicalValue, canonicalSource);
-  phi->addIncoming(widenFirstBackedge
-                       ? UndefValue::get(backedgeValue->getType())
-                       : backedgeValue,
-                   backedgeSource);
+  for (size_t i = 0; i < backedgeValues.size(); ++i) {
+    phi->addIncoming(widenFirstBackedge
+                         ? UndefValue::get(backedgeValues[i]->getType())
+                         : backedgeValues[i],
+                     sources[i]->sourceBlock);
+  }
   phiOut = phi;
   return phi;
 };
@@ -184,4 +189,3 @@ and inspect `output_diagnostics.json` for `lift_stats.instructions_lifted == 254
 | `REP`/`REPE`/`REPNE`-prefixed `SCAS` | Rejected as `not_implemented`; needs a model for repeated-scan termination. |
 | `INT 2` continuation under VMP 3.6 | Naive architectural fallthrough is wrong; recovery requires modeling the dispatcher / exception-mediated control flow. See `VMP_TESTING_NOTES.md`. |
 | Loop unrolling / loop-invariant code motion | Not implemented. The lifter relies on LLVM's downstream optimization passes for this once the IR is in shape. |
-| Multi-way backedges (≥3 paths to the same header) | Not exercised by the current generalized-loop machinery; the canonical/backedge model assumes exactly two incoming paths. |

--- a/lifter/core/LifterClass_Concolic.hpp
+++ b/lifter/core/LifterClass_Concolic.hpp
@@ -195,7 +195,13 @@ public:
   };
 
   llvm::DenseMap<BasicBlock*, backup_point> BBbackup;
-  llvm::DenseMap<BasicBlock*, backup_point> generalizedLoopBackedgeBackup;
+  // Backedge-side state is a variable-width vector keyed by header. A loop
+  // header may be reached from multiple backedges - each distinct backedge
+  // sourceBlock contributes its own backup_point. Size 1 is the common
+  // 2-way loop case (canonical + single backedge). Size >=2 is a multi-way
+  // loop (e.g. a VM dispatcher whose body has several handler tails that
+  // all jump back to the same header).
+  llvm::DenseMap<BasicBlock*, llvm::SmallVector<backup_point, 2>> generalizedLoopBackedgeBackup;
 
   llvm::DenseMap<BasicBlock*, std::array<llvm::PHINode*, REGISTER_COUNT>>
       generalizedLoopRegisterPhis;
@@ -206,11 +212,12 @@ public:
     bool valid = false;
     llvm::BasicBlock* headerBlock = nullptr;
     llvm::BasicBlock* canonicalSource = nullptr;
-    llvm::BasicBlock* backedgeSource = nullptr;
+    // Backedge side is variable-width; see generalizedLoopBackedgeBackup.
+    llvm::SmallVector<llvm::BasicBlock*, 2> backedgeSources;
     uint64_t canonicalControl = 0;
-    uint64_t backedgeControl = 0;
+    llvm::SmallVector<uint64_t, 2> backedgeControls;
     llvm::DenseMap<uint64_t, ValueByteReference> canonicalBuffer;
-    llvm::DenseMap<uint64_t, ValueByteReference> backedgeBuffer;
+    llvm::SmallVector<llvm::DenseMap<uint64_t, ValueByteReference>, 2> backedgeBuffers;
   } activeGeneralizedLoopControlFieldState;
   llvm::DenseMap<llvm::BasicBlock*, GeneralizedLoopControlFieldState>
       generalizedLoopControlFieldStates;
@@ -329,11 +336,11 @@ public:
     activeGeneralizedLoopControlFieldState.valid = false;
     activeGeneralizedLoopControlFieldState.headerBlock = nullptr;
     activeGeneralizedLoopControlFieldState.canonicalSource = nullptr;
-    activeGeneralizedLoopControlFieldState.backedgeSource = nullptr;
+    activeGeneralizedLoopControlFieldState.backedgeSources.clear();
     activeGeneralizedLoopControlFieldState.canonicalControl = 0;
-    activeGeneralizedLoopControlFieldState.backedgeControl = 0;
+    activeGeneralizedLoopControlFieldState.backedgeControls.clear();
     activeGeneralizedLoopControlFieldState.canonicalBuffer.clear();
-    activeGeneralizedLoopControlFieldState.backedgeBuffer.clear();
+    activeGeneralizedLoopControlFieldState.backedgeBuffers.clear();
   }
   bool evaluateConcreteGeneralizedLoopInt(llvm::Value* candidate,
                                           llvm::BasicBlock* incomingBlock,
@@ -511,11 +518,31 @@ public:
 
   backup_point make_generalized_loop_backup(BasicBlock* bb,
                                             const backup_point& canonical,
-                                            const backup_point& source) {
-    backup_point generalized = source;
+                                            llvm::ArrayRef<backup_point> sources) {
+    // Use the first source as the base for the generalized snapshot shape
+    // (buffer, counter, etc.). For 2-way loops this matches the original
+    // single-source behavior exactly; for N-way we pick sources[0] as the
+    // representative snapshot since the caller must restore a coherent view.
+    // No backedges: canonical-only path. Return canonical with local-stack
+    // addresses filtered, matching the pre-N-way fallback where
+    // make_generalized_loop_backup was called with canonical as both args.
+    if (sources.empty()) {
+      backup_point generalized = canonical;
+      llvm::DenseMap<uint64_t, ValueByteReference> filteredBuffer;
+      for (const auto& entry : canonical.buffer) {
+        if (!this->isTrackedLocalStackAddress(entry.first)) {
+          filteredBuffer[entry.first] = entry.second;
+        }
+      }
+      generalized.buffer = std::move(filteredBuffer);
+      generalized.cache = InstructionCache();
+      generalized.assumptions.clear();
+      return generalized;
+    }
+    backup_point generalized = sources.front();
     llvm::DenseMap<uint64_t, ValueByteReference> filteredBuffer;
-    filteredBuffer.reserve(source.buffer.size());
-    for (const auto& entry : source.buffer) {
+    filteredBuffer.reserve(sources.front().buffer.size());
+    for (const auto& entry : sources.front().buffer) {
       if (!this->isTrackedLocalStackAddress(entry.first)) {
         filteredBuffer[entry.first] = entry.second;
       }
@@ -525,30 +552,51 @@ public:
     generalized.assumptions.clear();
 
     auto* canonicalSource = canonical.sourceBlock;
-    auto* backedgeSource = source.sourceBlock;
-    if (!bb || !canonicalSource || !backedgeSource ||
-        canonicalSource == backedgeSource) {
+    if (!bb || !canonicalSource) {
+      return generalized;
+    }
+    // Filter backedges: drop any that duplicate canonicalSource. This
+    // preserves the existing 2-way "canonicalSource == backedgeSource"
+    // bailout for the trivial degenerate case.
+    llvm::SmallVector<const backup_point*, 2> effectiveSources;
+    effectiveSources.reserve(sources.size());
+    for (const auto& src : sources) {
+      if (src.sourceBlock && src.sourceBlock != canonicalSource) {
+        effectiveSources.push_back(&src);
+      }
+    }
+    if (effectiveSources.empty()) {
       return generalized;
     }
 
     std::array<llvm::PHINode*, REGISTER_COUNT> registerPhis{};
     std::array<llvm::PHINode*, FLAGS_END> flagPhis{};
     llvm::IRBuilder<> phiBuilder(bb, bb->begin());
-    auto mergeValue = [&](llvm::Value* canonicalValue, llvm::Value* backedgeValue,
+    auto mergeValue = [&](llvm::Value* canonicalValue,
+                          llvm::ArrayRef<llvm::Value*> backedgeValues,
                           const char* name, llvm::PHINode*& phiOut,
-                          bool widenFirstBackedge)
-        -> llvm::Value* {
-      if (!canonicalValue || !backedgeValue ||
-          canonicalValue->getType() != backedgeValue->getType() ||
-          canonicalValue == backedgeValue) {
-        return backedgeValue;
+                          bool widenFirstBackedge) -> llvm::Value* {
+      // Require canonical + all backedges present and type-matched. Any
+      // type mismatch or nullptr falls back to the first backedge value,
+      // preserving the pre-N-way single-backedge semantics.
+      if (!canonicalValue || backedgeValues.empty()) {
+        return backedgeValues.empty() ? nullptr : backedgeValues.front();
       }
-      auto* phi = phiBuilder.CreatePHI(canonicalValue->getType(), 2, name);
+      for (auto* beValue : backedgeValues) {
+        if (!beValue || beValue->getType() != canonicalValue->getType() ||
+            beValue == canonicalValue) {
+          return backedgeValues.front();
+        }
+      }
+      auto* phi = phiBuilder.CreatePHI(canonicalValue->getType(),
+                                       1 + backedgeValues.size(), name);
       phi->addIncoming(canonicalValue, canonicalSource);
-      phi->addIncoming(widenFirstBackedge
-                           ? llvm::UndefValue::get(backedgeValue->getType())
-                           : backedgeValue,
-                       backedgeSource);
+      for (size_t i = 0; i < backedgeValues.size(); ++i) {
+        phi->addIncoming(widenFirstBackedge
+                             ? llvm::UndefValue::get(backedgeValues[i]->getType())
+                             : backedgeValues[i],
+                         effectiveSources[i]->sourceBlock);
+      }
       phiOut = phi;
       return phi;
     };
@@ -559,16 +607,26 @@ public:
         Register::R12, Register::R13, Register::R14, Register::R15,
     };
 
+    llvm::SmallVector<llvm::Value*, 2> regValues;
+    llvm::SmallVector<llvm::Value*, 2> flagValues;
     for (size_t i = 0; i < REGISTER_COUNT; ++i) {
       const bool widenFirstBackedge =
           !shouldPreserveGeneralizedBackedgeRegisterIndex(i);
-      generalized.vec[i] = mergeValue(canonical.vec[i], source.vec[i],
+      regValues.clear();
+      for (auto* src : effectiveSources) {
+        regValues.push_back(src->vec[i]);
+      }
+      generalized.vec[i] = mergeValue(canonical.vec[i], regValues,
                                       "loop_reg_phi", registerPhis[i],
                                       widenFirstBackedge);
     }
     for (size_t i = 0; i < FLAGS_END; ++i) {
+      flagValues.clear();
+      for (auto* src : effectiveSources) {
+        flagValues.push_back(src->vecflag[i]);
+      }
       generalized.vecflag[i] =
-          mergeValue(canonical.vecflag[i], source.vecflag[i], "loop_flag_phi",
+          mergeValue(canonical.vecflag[i], flagValues, "loop_flag_phi",
                      flagPhis[i], false);
     }
     generalizedLoopRegisterPhis[bb] = registerPhis;
@@ -596,7 +654,17 @@ public:
       if (!BBbackup.contains(bb)) {
         BBbackup[bb] = snapshot;
       }
-      generalizedLoopBackedgeBackup[bb] = std::move(snapshot);
+      // Append per-source; a repeat call from the same sourceBlock replaces
+      // that block's entry in place, preserving uniqueness without growing
+      // the vector unboundedly on iterative lift passes.
+      auto& backedges = generalizedLoopBackedgeBackup[bb];
+      for (auto& existing : backedges) {
+        if (existing.sourceBlock == snapshot.sourceBlock) {
+          existing = std::move(snapshot);
+          return;
+        }
+      }
+      backedges.push_back(std::move(snapshot));
       return;
     }
 
@@ -624,9 +692,8 @@ public:
     clearGeneralizedLoopControlFieldState();
     if (generalizedLoopBackedgeBackup.contains(bb) && BBbackup.contains(bb)) {
       printvalue2("loading generalized backup");
-      auto snapshot =
-          make_generalized_loop_backup(bb, BBbackup[bb],
-                                       generalizedLoopBackedgeBackup[bb]);
+      auto& backedges = generalizedLoopBackedgeBackup[bb];
+      auto snapshot = make_generalized_loop_backup(bb, BBbackup[bb], backedges);
       if (this->liftProgressDiagEnabled) {
         auto formatHex = [](uint64_t value) {
           std::ostringstream os;
@@ -634,34 +701,29 @@ public:
           return os.str();
         };
         uint64_t canonicalControl = 0;
-        uint64_t backedgeControl = 0;
         const bool hasCanonicalControl = readConstantTrackedQword(
             BBbackup[bb].buffer, kThemidaControlCursorSlot, canonicalControl);
-        const bool hasBackedgeControl =
-            readConstantTrackedQword(generalizedLoopBackedgeBackup[bb].buffer,
-                                     kThemidaControlCursorSlot, backedgeControl);
         std::cout << "[diag] load_generalized_backup bb=" << bb->getName().str()
                   << " sourceCanonical="
                   << (BBbackup[bb].sourceBlock
                           ? BBbackup[bb].sourceBlock->getName().str()
                           : std::string("<null>"))
-                  << " sourceBackedge="
-                  << (generalizedLoopBackedgeBackup[bb].sourceBlock
-                          ? generalizedLoopBackedgeBackup[bb].sourceBlock->getName().str()
-                          : std::string("<null>"))
-                  << " backedge14fca0="
-                  << (generalizedLoopBackedgeBackup[bb].buffer.contains(1375392) ? 1 : 0)
-                  << " backedge14fca8="
-                  << (generalizedLoopBackedgeBackup[bb].buffer.contains(1375400) ? 1 : 0)
-                  << " backedge14fcb0="
-                  << (generalizedLoopBackedgeBackup[bb].buffer.contains(1375408) ? 1 : 0)
+                  << " backedgeCount=" << backedges.size()
                   << " canonicalControl="
                   << (hasCanonicalControl ? formatHex(canonicalControl)
-                                          : std::string("na"))
-                  << " backedgeControl="
-                  << (hasBackedgeControl ? formatHex(backedgeControl)
-                                         : std::string("na"))
-                  << "\n";
+                                          : std::string("na"));
+        for (size_t i = 0; i < backedges.size(); ++i) {
+          uint64_t be = 0;
+          const bool hasBE = readConstantTrackedQword(backedges[i].buffer,
+                                                      kThemidaControlCursorSlot, be);
+          std::cout << " backedge[" << i << "]source="
+                    << (backedges[i].sourceBlock
+                            ? backedges[i].sourceBlock->getName().str()
+                            : std::string("<null>"))
+                    << " backedge[" << i << "]control="
+                    << (hasBE ? formatHex(be) : std::string("na"));
+        }
+        std::cout << "\n";
       }
       restore_backup_point(snapshot);
       auto storedStateIt = generalizedLoopControlFieldStates.find(bb);
@@ -669,38 +731,66 @@ public:
           storedStateIt->second.valid) {
         activeGeneralizedLoopControlFieldState = storedStateIt->second;
         activeGeneralizedLoopEntrySourceBlock =
-            activeGeneralizedLoopControlFieldState.backedgeSource;
-        activeGeneralizedLoopLocalBuffer = extractLocalStackBuffer(
-            activeGeneralizedLoopControlFieldState.backedgeBuffer);
+            activeGeneralizedLoopControlFieldState.backedgeSources.empty()
+                ? nullptr
+                : activeGeneralizedLoopControlFieldState.backedgeSources.front();
+        if (!activeGeneralizedLoopControlFieldState.backedgeBuffers.empty()) {
+          activeGeneralizedLoopLocalBuffer = extractLocalStackBuffer(
+              activeGeneralizedLoopControlFieldState.backedgeBuffers.front());
+        } else {
+          activeGeneralizedLoopLocalBuffer.clear();
+        }
       } else {
         activeGeneralizedLoopEntrySourceBlock =
-            generalizedLoopBackedgeBackup[bb].sourceBlock;
-        uint64_t canonicalControl = 0;
-        uint64_t backedgeControl = 0;
+            backedges.empty() ? nullptr : backedges.front().sourceBlock;
         activeGeneralizedLoopLocalBuffer =
-            extractLocalStackBuffer(generalizedLoopBackedgeBackup[bb].buffer);
-        if (readConstantTrackedQword(BBbackup[bb].buffer, kThemidaControlCursorSlot,
-                                     canonicalControl) &&
-            readConstantTrackedQword(generalizedLoopBackedgeBackup[bb].buffer,
-                                     kThemidaControlCursorSlot, backedgeControl) &&
-            canonicalControl != backedgeControl && BBbackup[bb].sourceBlock &&
-            generalizedLoopBackedgeBackup[bb].sourceBlock &&
-            BBbackup[bb].sourceBlock != generalizedLoopBackedgeBackup[bb].sourceBlock) {
-          activeGeneralizedLoopControlFieldState.valid = true;
-          activeGeneralizedLoopControlFieldState.headerBlock = bb;
-          activeGeneralizedLoopControlFieldState.canonicalSource =
-              BBbackup[bb].sourceBlock;
-          activeGeneralizedLoopControlFieldState.backedgeSource =
-              generalizedLoopBackedgeBackup[bb].sourceBlock;
-          activeGeneralizedLoopControlFieldState.canonicalControl =
-              canonicalControl;
-          activeGeneralizedLoopControlFieldState.backedgeControl =
-              backedgeControl;
-          activeGeneralizedLoopControlFieldState.canonicalBuffer = BBbackup[bb].buffer;
-          activeGeneralizedLoopControlFieldState.backedgeBuffer =
-              generalizedLoopBackedgeBackup[bb].buffer;
-          generalizedLoopControlFieldStates[bb] =
-              activeGeneralizedLoopControlFieldState;
+            backedges.empty()
+                ? llvm::DenseMap<uint64_t, ValueByteReference>{}
+                : extractLocalStackBuffer(backedges.front().buffer);
+        uint64_t canonicalControl = 0;
+        const bool hasCanonical = readConstantTrackedQword(
+            BBbackup[bb].buffer, kThemidaControlCursorSlot, canonicalControl);
+        if (hasCanonical && BBbackup[bb].sourceBlock && !backedges.empty()) {
+          // Collect backedges whose sourceBlock is distinct from canonical
+          // AND whose control value differs from canonical. At least one
+          // such backedge is required to activate the state.
+          llvm::SmallVector<llvm::BasicBlock*, 2> sources;
+          llvm::SmallVector<uint64_t, 2> controls;
+          llvm::SmallVector<llvm::DenseMap<uint64_t, ValueByteReference>, 2> buffers;
+          for (const auto& be : backedges) {
+            if (!be.sourceBlock || be.sourceBlock == BBbackup[bb].sourceBlock) {
+              continue;
+            }
+            uint64_t beControl = 0;
+            if (!readConstantTrackedQword(be.buffer, kThemidaControlCursorSlot,
+                                          beControl)) {
+              continue;
+            }
+            if (beControl == canonicalControl) {
+              continue;
+            }
+            sources.push_back(be.sourceBlock);
+            controls.push_back(beControl);
+            buffers.push_back(be.buffer);
+          }
+          if (!sources.empty()) {
+            activeGeneralizedLoopControlFieldState.valid = true;
+            activeGeneralizedLoopControlFieldState.headerBlock = bb;
+            activeGeneralizedLoopControlFieldState.canonicalSource =
+                BBbackup[bb].sourceBlock;
+            activeGeneralizedLoopControlFieldState.canonicalControl =
+                canonicalControl;
+            activeGeneralizedLoopControlFieldState.canonicalBuffer =
+                BBbackup[bb].buffer;
+            activeGeneralizedLoopControlFieldState.backedgeSources =
+                std::move(sources);
+            activeGeneralizedLoopControlFieldState.backedgeControls =
+                std::move(controls);
+            activeGeneralizedLoopControlFieldState.backedgeBuffers =
+                std::move(buffers);
+            generalizedLoopControlFieldStates[bb] =
+                activeGeneralizedLoopControlFieldState;
+          }
         }
       }
       if (this->liftProgressDiagEnabled && bb && bb->getName() == "bb_solved_const282") {
@@ -722,14 +812,16 @@ public:
         for (size_t i = 0; i < tracedIndices.size(); ++i) {
           size_t regIndex = tracedIndices[i];
           std::cout << " " << tracedNames[i] << " canonical="
-                    << valueToString(BBbackup[bb].vec[regIndex])
-                    << " backedge="
-                    << valueToString(generalizedLoopBackedgeBackup[bb].vec[regIndex]);
+                    << valueToString(BBbackup[bb].vec[regIndex]);
+          for (size_t j = 0; j < backedges.size(); ++j) {
+            std::cout << " backedge[" << j << "]="
+                      << valueToString(backedges[j].vec[regIndex]);
+          }
         }
         std::cout << "\n";
       }
       auto seedInvariantLocalQwords = [&](const backup_point& canonicalSnapshot,
-                                          const backup_point& backedgeSnapshot) {
+                                          llvm::ArrayRef<backup_point> backedgeSnapshots) {
         std::set<uint64_t> seededQwordStarts;
         for (const auto& entry : activeGeneralizedLoopLocalBuffer) {
           uint64_t qwordStart = entry.first & ~0x7ULL;
@@ -740,12 +832,22 @@ public:
             continue;
           }
           uint64_t canonicalValue = 0;
-          uint64_t backedgeValue = 0;
           if (!readConstantTrackedQword(canonicalSnapshot.buffer, qwordStart,
-                                        canonicalValue) ||
-              !readConstantTrackedQword(backedgeSnapshot.buffer, qwordStart,
-                                        backedgeValue) ||
-              canonicalValue != backedgeValue) {
+                                        canonicalValue)) {
+            continue;
+          }
+          // All backedges must read the same concrete qword value for
+          // the invariant to hold. Any mismatch disqualifies the qword.
+          bool allMatch = true;
+          for (const auto& be : backedgeSnapshots) {
+            uint64_t beValue = 0;
+            if (!readConstantTrackedQword(be.buffer, qwordStart, beValue) ||
+                beValue != canonicalValue) {
+              allMatch = false;
+              break;
+            }
+          }
+          if (!allMatch) {
             continue;
           }
           for (uint8_t i = 0; i < 8; ++i) {
@@ -754,12 +856,13 @@ public:
           }
         }
       };
-      seedInvariantLocalQwords(BBbackup[bb], generalizedLoopBackedgeBackup[bb]);
+      seedInvariantLocalQwords(BBbackup[bb], backedges);
       return;
     }
     if (BBbackup.contains(bb)) {
       printvalue2("loading generalized backup");
-      auto snapshot = make_generalized_loop_backup(bb, BBbackup[bb], BBbackup[bb]);
+      auto snapshot = make_generalized_loop_backup(
+          bb, BBbackup[bb], llvm::ArrayRef<backup_point>{});
       restore_backup_point(snapshot);
     }
   }
@@ -810,7 +913,7 @@ public:
       loadOffset = castInst->getOperand(0);
     }
     auto* phi = llvm::dyn_cast<llvm::PHINode>(loadOffset);
-    if (!phi || phi->getNumIncomingValues() != 2) {
+    if (!phi || phi->getNumIncomingValues() < 2) {
       return nullptr;
     }
     auto* state = getGeneralizedLoopStateForHeader(phi->getParent());
@@ -833,9 +936,11 @@ public:
         return retrieveBufferedOrConcreteValue(state->canonicalBuffer, address,
                                               byteCount);
       }
-      if (incomingBlock == state->backedgeSource) {
-        return retrieveBufferedOrConcreteValue(state->backedgeBuffer, address,
-                                              byteCount);
+      for (size_t i = 0; i < state->backedgeSources.size(); ++i) {
+        if (incomingBlock == state->backedgeSources[i]) {
+          return retrieveBufferedOrConcreteValue(state->backedgeBuffers[i],
+                                                 address, byteCount);
+        }
       }
       return nullptr;
     };
@@ -922,7 +1027,7 @@ public:
       }
     }
     auto* phi = llvm::dyn_cast<llvm::PHINode>(loadOffset);
-    if (!phi || phi->getNumIncomingValues() != 2) {
+    if (!phi || phi->getNumIncomingValues() < 2) {
       return nullptr;
     }
     auto* state = getGeneralizedLoopStateForHeader(phi->getParent());
@@ -951,9 +1056,11 @@ public:
         return retrieveBufferedOrConcreteValue(state->canonicalBuffer, address,
                                               byteCount);
       }
-      if (incomingBlock == state->backedgeSource) {
-        return retrieveBufferedOrConcreteValue(state->backedgeBuffer, address,
-                                              byteCount);
+      for (size_t i = 0; i < state->backedgeSources.size(); ++i) {
+        if (incomingBlock == state->backedgeSources[i]) {
+          return retrieveBufferedOrConcreteValue(state->backedgeBuffers[i],
+                                                 address, byteCount);
+        }
       }
       return nullptr;
     };
@@ -1000,23 +1107,38 @@ public:
     }
     auto* canonicalValue = this->builder->getIntN(
         byteCount * 8, state.canonicalControl & llvm::maskTrailingOnes<uint64_t>(byteCount * 8));
-    auto* backedgeValue = this->builder->getIntN(
-        byteCount * 8, state.backedgeControl & llvm::maskTrailingOnes<uint64_t>(byteCount * 8));
     if (this->liftProgressDiagEnabled) {
       std::cout << "[diag] control_slot current=0x" << std::hex
                 << this->current_address << " start=0x" << startAddress
-                << " canonical=0x" << state.canonicalControl
-                << " backedge=0x" << state.backedgeControl << std::dec
+                << " canonical=0x" << state.canonicalControl << std::dec
+                << " backedgeCount=" << state.backedgeControls.size()
                 << " bytes=" << static_cast<unsigned>(byteCount) << "\n";
     }
-    if (canonicalValue == backedgeValue) {
+    if (state.backedgeSources.empty()) {
+      return canonicalValue;
+    }
+    // Build the canonical + N backedge values. If everything collapses to
+    // a single value, skip phi construction.
+    llvm::SmallVector<llvm::Value*, 2> backedgeValues;
+    backedgeValues.reserve(state.backedgeControls.size());
+    bool allSameAsCanonical = true;
+    for (uint64_t be : state.backedgeControls) {
+      auto* v = this->builder->getIntN(
+          byteCount * 8, be & llvm::maskTrailingOnes<uint64_t>(byteCount * 8));
+      if (v != canonicalValue) allSameAsCanonical = false;
+      backedgeValues.push_back(v);
+    }
+    if (allSameAsCanonical) {
       return canonicalValue;
     }
     llvm::IRBuilder<> phiBuilder(state.headerBlock, state.headerBlock->begin());
-    auto* phi = phiBuilder.CreatePHI(canonicalValue->getType(), 2,
+    auto* phi = phiBuilder.CreatePHI(canonicalValue->getType(),
+                                     1 + backedgeValues.size(),
                                      "generalized_control_slot_phi");
     phi->addIncoming(canonicalValue, state.canonicalSource);
-    phi->addIncoming(backedgeValue, state.backedgeSource);
+    for (size_t i = 0; i < backedgeValues.size(); ++i) {
+      phi->addIncoming(backedgeValues[i], state.backedgeSources[i]);
+    }
     return phi;
   }
 
@@ -1027,34 +1149,40 @@ public:
         startAddress != this->kThemidaLoopCarriedSlot || byteCount == 0) {
       return nullptr;
     }
-    auto* canonicalValue = retrieveBufferedOrConcreteValue(
-        activeGeneralizedLoopControlFieldState.canonicalBuffer, startAddress,
-        byteCount);
-    auto* backedgeValue = retrieveBufferedOrConcreteValue(
-        activeGeneralizedLoopControlFieldState.backedgeBuffer, startAddress,
-        byteCount);
+    auto& state = activeGeneralizedLoopControlFieldState;
+    auto* canonicalValue = retrieveBufferedOrConcreteValue(state.canonicalBuffer,
+                                                           startAddress, byteCount);
+    if (!canonicalValue) return nullptr;
     if (this->liftProgressDiagEnabled) {
       std::cout << "[diag] target_slot current=0x" << std::hex
                 << this->current_address << " start=0x" << startAddress
                 << std::dec << " bytes=" << static_cast<unsigned>(byteCount)
-                << "\n";
+                << " backedgeCount=" << state.backedgeBuffers.size() << "\n";
     }
-    if (!canonicalValue || !backedgeValue ||
-        canonicalValue->getType() != backedgeValue->getType()) {
-      return nullptr;
+    // Collect all backedge values, require type match; any missing/mismatch
+    // bails the helper (caller falls through).
+    llvm::SmallVector<llvm::Value*, 2> backedgeValues;
+    backedgeValues.reserve(state.backedgeBuffers.size());
+    bool allSame = true;
+    for (const auto& beBuf : state.backedgeBuffers) {
+      auto* v = retrieveBufferedOrConcreteValue(beBuf, startAddress, byteCount);
+      if (!v || v->getType() != canonicalValue->getType()) {
+        return nullptr;
+      }
+      if (v != canonicalValue) allSame = false;
+      backedgeValues.push_back(v);
     }
-    if (canonicalValue == backedgeValue) {
+    if (state.backedgeSources.empty() || allSame) {
       return canonicalValue;
     }
-    llvm::IRBuilder<> phiBuilder(activeGeneralizedLoopControlFieldState.headerBlock,
-                                 activeGeneralizedLoopControlFieldState.headerBlock
-                                     ->begin());
-    auto* phi = phiBuilder.CreatePHI(canonicalValue->getType(), 2,
+    llvm::IRBuilder<> phiBuilder(state.headerBlock, state.headerBlock->begin());
+    auto* phi = phiBuilder.CreatePHI(canonicalValue->getType(),
+                                     1 + backedgeValues.size(),
                                      "generalized_local_slot_phi");
-    phi->addIncoming(canonicalValue,
-                     activeGeneralizedLoopControlFieldState.canonicalSource);
-    phi->addIncoming(backedgeValue,
-                     activeGeneralizedLoopControlFieldState.backedgeSource);
+    phi->addIncoming(canonicalValue, state.canonicalSource);
+    for (size_t i = 0; i < backedgeValues.size(); ++i) {
+      phi->addIncoming(backedgeValues[i], state.backedgeSources[i]);
+    }
     return phi;
   }
 
@@ -1070,43 +1198,42 @@ public:
     if (!matchGeneralizedLoopControlFieldAddress(loadOffset, fieldOffset)) {
       return nullptr;
     }
+    auto& state = activeGeneralizedLoopControlFieldState;
     auto* canonicalValue = retrieveBufferedOrConcreteValue(
-        activeGeneralizedLoopControlFieldState.canonicalBuffer,
-        activeGeneralizedLoopControlFieldState.canonicalControl + fieldOffset,
-        byteCount);
-    auto* backedgeValue = retrieveBufferedOrConcreteValue(
-        activeGeneralizedLoopControlFieldState.backedgeBuffer,
-        activeGeneralizedLoopControlFieldState.backedgeControl + fieldOffset,
-        byteCount);
-    if (!canonicalValue || !backedgeValue ||
-        canonicalValue->getType() != backedgeValue->getType()) {
-      return nullptr;
-    }
+        state.canonicalBuffer, state.canonicalControl + fieldOffset, byteCount);
+    if (!canonicalValue) return nullptr;
     if (this->liftProgressDiagEnabled) {
       std::cout << "[diag] generalized control-field match block="
-                << activeGeneralizedLoopControlFieldState.headerBlock->getName().str()
+                << state.headerBlock->getName().str()
                 << " fieldOffset=0x" << std::hex << fieldOffset
-                << " canonical=0x"
-                << (activeGeneralizedLoopControlFieldState.canonicalControl +
-                    fieldOffset)
-                << " backedge=0x"
-                << (activeGeneralizedLoopControlFieldState.backedgeControl +
-                    fieldOffset)
+                << " canonical=0x" << (state.canonicalControl + fieldOffset)
                 << std::dec << " bytes=" << static_cast<unsigned>(byteCount)
-                << "\n";
+                << " backedgeCount=" << state.backedgeControls.size() << "\n";
     }
-    if (canonicalValue == backedgeValue) {
+    llvm::SmallVector<llvm::Value*, 2> backedgeValues;
+    backedgeValues.reserve(state.backedgeControls.size());
+    bool allSame = true;
+    for (size_t i = 0; i < state.backedgeControls.size(); ++i) {
+      auto* v = retrieveBufferedOrConcreteValue(
+          state.backedgeBuffers[i],
+          state.backedgeControls[i] + fieldOffset, byteCount);
+      if (!v || v->getType() != canonicalValue->getType()) {
+        return nullptr;
+      }
+      if (v != canonicalValue) allSame = false;
+      backedgeValues.push_back(v);
+    }
+    if (state.backedgeSources.empty() || allSame) {
       return canonicalValue;
     }
-    llvm::IRBuilder<> phiBuilder(activeGeneralizedLoopControlFieldState.headerBlock,
-                                 activeGeneralizedLoopControlFieldState.headerBlock
-                                     ->begin());
-    auto* phi =
-        phiBuilder.CreatePHI(canonicalValue->getType(), 2, "loop_control_field_phi");
-    phi->addIncoming(canonicalValue,
-                     activeGeneralizedLoopControlFieldState.canonicalSource);
-    phi->addIncoming(backedgeValue,
-                     activeGeneralizedLoopControlFieldState.backedgeSource);
+    llvm::IRBuilder<> phiBuilder(state.headerBlock, state.headerBlock->begin());
+    auto* phi = phiBuilder.CreatePHI(canonicalValue->getType(),
+                                     1 + backedgeValues.size(),
+                                     "loop_control_field_phi");
+    phi->addIncoming(canonicalValue, state.canonicalSource);
+    for (size_t i = 0; i < backedgeValues.size(); ++i) {
+      phi->addIncoming(backedgeValues[i], state.backedgeSources[i]);
+    }
     return phi;
   }
   void migrate_generalized_loop_block_impl(BasicBlock* oldBlock,
@@ -1172,8 +1299,19 @@ public:
     }
     auto stateIt = generalizedLoopControlFieldStates.find(bb);
     if (stateIt == generalizedLoopControlFieldStates.end() ||
-        !stateIt->second.valid || !stateIt->second.backedgeSource ||
-        sourceBlock == stateIt->second.backedgeSource) {
+        !stateIt->second.valid) {
+      return;
+    }
+    // The rolled-control promotion semantics (move current backedge into
+    // canonical, install new source as backedge) are only well-defined for
+    // the 1-backedge case. Multi-way loops do not have a single obvious
+    // "current backedge" to promote, so skip the rotation; the existing
+    // N-way state remains valid.
+    if (stateIt->second.backedgeSources.size() != 1) {
+      return;
+    }
+    auto* existingBackedgeSource = stateIt->second.backedgeSources.front();
+    if (!existingBackedgeSource || sourceBlock == existingBackedgeSource) {
       return;
     }
     auto* currentControlValue =
@@ -1181,31 +1319,31 @@ public:
     uint64_t rolledBackedgeControl = 0;
     if (!currentControlValue ||
         !evaluateConcreteGeneralizedLoopInt(currentControlValue,
-                                            stateIt->second.backedgeSource,
+                                            existingBackedgeSource,
                                             rolledBackedgeControl) ||
-        rolledBackedgeControl == stateIt->second.backedgeControl) {
+        rolledBackedgeControl == stateIt->second.backedgeControls.front()) {
       return;
     }
-    auto previousBackedgeSource = stateIt->second.backedgeSource;
-    auto previousBackedgeControl = stateIt->second.backedgeControl;
-    auto previousBackedgeBuffer = stateIt->second.backedgeBuffer;
+    auto previousBackedgeSource = existingBackedgeSource;
+    auto previousBackedgeControl = stateIt->second.backedgeControls.front();
+    auto previousBackedgeBuffer = stateIt->second.backedgeBuffers.front();
     stateIt->second.canonicalSource = previousBackedgeSource;
     stateIt->second.canonicalControl = previousBackedgeControl;
     stateIt->second.canonicalBuffer = previousBackedgeBuffer;
-    stateIt->second.backedgeSource = sourceBlock;
-    stateIt->second.backedgeControl = rolledBackedgeControl;
-    stateIt->second.backedgeBuffer = this->buffer;
+    stateIt->second.backedgeSources.front() = sourceBlock;
+    stateIt->second.backedgeControls.front() = rolledBackedgeControl;
+    stateIt->second.backedgeBuffers.front() = this->buffer;
     if (bb == activeGeneralizedLoopControlFieldState.headerBlock) {
       activeGeneralizedLoopControlFieldState = stateIt->second;
       activeGeneralizedLoopEntrySourceBlock = sourceBlock;
-      activeGeneralizedLoopLocalBuffer =
-          extractLocalStackBuffer(activeGeneralizedLoopControlFieldState.backedgeBuffer);
+      activeGeneralizedLoopLocalBuffer = extractLocalStackBuffer(
+          activeGeneralizedLoopControlFieldState.backedgeBuffers.front());
     }
     if (this->liftProgressDiagEnabled) {
       std::cout << "[diag] roll_generalized_backedge bb=" << bb->getName().str()
                 << " canonical=0x" << std::hex
                 << stateIt->second.canonicalControl << " backedge=0x"
-                << stateIt->second.backedgeControl << std::dec
+                << stateIt->second.backedgeControls.front() << std::dec
                 << " source=" << sourceBlock->getName().str() << "\n";
     }
   }

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -1594,26 +1594,14 @@ bool runSolveLoadPhiAddressWithDisplacementCreatesPhiOfLoadedValues(
 }
 
 
-// KNOWN-LIMITATION (multi-way backedges, ≥3 paths into the same header).
+// Multi-way backedges (>=3 paths into the same header).
 //
-// `branch_backup(bb, /*generalized=*/true)` unconditionally overwrites
-// `generalizedLoopBackedgeBackup[bb]` (see LifterClass_Concolic.hpp,
-// comment `generalizedLoopBackedgeBackup[bb] = std::move(snapshot);`).
-// When a loop header has three or more incoming backedges, the second
-// and any further generalized snapshots silently replace the first -
-// their sourceBlock, buffer, register, and flag state are lost before
-// `load_generalized_backup` builds its canonical/backedge phi.
-//
-// The two tests below pin the CURRENT broken behavior:
-//   1. The raw map after three generalized backups retains only the
-//      third source; the second's buffer markers are gone.
-//   2. The control-slot load at the header yields a two-incoming phi,
-//      not the three-incoming phi a correct multi-way model would emit.
-//
-// When multi-way backedge support lands, both tests MUST fail and be
-// rewritten to assert the new N-way merge contract. That failure is
-// the intended signal to the implementer - do not suppress it.
-bool runGeneralizedLoopThirdBackedgeOverwritesPriorBackedgeSilently(
+// branch_backup(bb, /*generalized=*/true) appends each distinct backedge
+// snapshot to generalizedLoopBackedgeBackup[bb] (dedup by sourceBlock).
+// load_generalized_backup then builds (1 + N)-incoming phis carrying
+// canonical + every backedge. The two tests below exercise the N-way
+// contract end-to-end at N=3.
+bool runGeneralizedLoopThirdBackedgePreservesAllThreeSnapshots(
     std::string& details) {
   LifterUnderTest lifter;
   auto& context = lifter.context;
@@ -1660,35 +1648,31 @@ bool runGeneralizedLoopThirdBackedgeOverwritesPriorBackedgeSilently(
               "three generalized branch_backup calls\n";
     return false;
   }
-  if (it->second.sourceBlock != thirdBackedge) {
+  // All three backedge snapshots must survive in the vector, one per
+  // distinct sourceBlock; earlier calls must not be overwritten.
+  if (it->second.size() != 3) {
     std::ostringstream os;
-    os << "  generalizedLoopBackedgeBackup retained sourceBlock="
-       << (it->second.sourceBlock
-               ? it->second.sourceBlock->getName().str()
-               : std::string("<null>"))
-       << ", expected third_backedge (current silent-overwrite behavior);"
-       << " if multi-way backedges now merge, rewrite this test.\n";
+    os << "  generalizedLoopBackedgeBackup[loopHeader] size="
+       << it->second.size() << ", expected 3 (one per distinct backedge)\n";
     details = os.str();
     return false;
   }
-  // The map holds one backup_point per header; three generalized backups
-  // still collapse into a single entry. When multi-way merge lands, the
-  // representation will need to change (e.g. vector of backup_points, or
-  // an N-way merge recorded up front), and this size invariant will no
-  // longer hold.
-  if (lifter.generalizedLoopBackedgeBackup.size() != 1) {
-    std::ostringstream os;
-    os << "  generalizedLoopBackedgeBackup size="
-       << lifter.generalizedLoopBackedgeBackup.size()
-       << ", expected 1 (current silent-overwrite behavior); if multi-way"
-       << " merge now records each backedge, rewrite this test.\n";
-    details = os.str();
+  bool sawFirst = false, sawSecond = false, sawThird = false;
+  for (const auto& be : it->second) {
+    if (be.sourceBlock == firstBackedge) sawFirst = true;
+    else if (be.sourceBlock == secondBackedge) sawSecond = true;
+    else if (be.sourceBlock == thirdBackedge) sawThird = true;
+  }
+  if (!sawFirst || !sawSecond || !sawThird) {
+    details =
+        "  generalizedLoopBackedgeBackup should hold one entry for each of "
+        "firstBackedge, secondBackedge, thirdBackedge\n";
     return false;
   }
   return true;
 }
 
-bool runGeneralizedLoopLoadBackupWithThreeBackedgesProducesTwoWayPhiOnly(
+bool runGeneralizedLoopLoadBackupWithThreeBackedgesProducesFourWayPhi(
     std::string& details) {
   LifterUnderTest lifter;
   auto& context = lifter.context;
@@ -1739,39 +1723,31 @@ bool runGeneralizedLoopLoadBackupWithThreeBackedgesProducesTwoWayPhiOnly(
               "generalized loop mode\n";
     return false;
   }
-  // Pins current behavior: only canonical + last-seen backedge survive.
-  // A correct multi-way implementation would yield 4 incomings
-  // (canonical + three backedges). When that lands, flip this assertion.
-  if (phi->getNumIncomingValues() != 2) {
+  // 1 canonical + 3 backedges = 4 incomings.
+  if (phi->getNumIncomingValues() != 4) {
     std::ostringstream os;
     os << "  control-slot phi carries " << phi->getNumIncomingValues()
-       << " incomings, expected 2 (current silent-overwrite behavior);"
-       << " if multi-way backedges now produce an N-way phi, rewrite this test.\n";
+       << " incomings, expected 4 (canonical + three backedges)\n";
     details = os.str();
     return false;
   }
-  // Incomings must be exactly canonicalControl and thirdControl - the
-  // first two backedges' control values are silently dropped.
   bool sawCanonical = false;
+  bool sawFirst = false;
+  bool sawSecond = false;
   bool sawThird = false;
-  bool sawDroppedValue = false;
   for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
     auto actual = readConstantAPInt(phi->getIncomingValue(i));
     if (!actual.has_value()) continue;
     const uint64_t v = actual->getZExtValue();
     if (v == canonicalControl) sawCanonical = true;
+    else if (v == firstControl) sawFirst = true;
+    else if (v == secondControl) sawSecond = true;
     else if (v == thirdControl) sawThird = true;
-    else if (v == firstControl || v == secondControl) sawDroppedValue = true;
   }
-  if (!sawCanonical || !sawThird) {
-    details = "  control-slot phi should carry canonicalControl and "
-              "thirdControl (current silent-overwrite behavior)\n";
-    return false;
-  }
-  if (sawDroppedValue) {
-    details = "  control-slot phi unexpectedly carries a dropped-backedge "
-              "control value - multi-way merge may have landed; rewrite "
-              "this test.\n";
+  if (!sawCanonical || !sawFirst || !sawSecond || !sawThird) {
+    details =
+        "  control-slot phi should carry canonicalControl, firstControl, "
+        "secondControl, and thirdControl as concrete incomings\n";
     return false;
   }
   return true;
@@ -3243,10 +3219,10 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runGeneralizedLoopBypassTagClearsAfterPromotion);
     runCustom("promoted_generalized_loop_restores_canonical_backup",
              &InstructionTester::runPromotedGeneralizedLoopRestoresCanonicalBackup);
-    runCustom("generalized_loop_third_backedge_overwrites_prior_backedge_silently",
-             &InstructionTester::runGeneralizedLoopThirdBackedgeOverwritesPriorBackedgeSilently);
-    runCustom("generalized_loop_load_backup_with_three_backedges_produces_two_way_phi_only",
-             &InstructionTester::runGeneralizedLoopLoadBackupWithThreeBackedgesProducesTwoWayPhiOnly);
+    runCustom("generalized_loop_third_backedge_preserves_all_three_snapshots",
+             &InstructionTester::runGeneralizedLoopThirdBackedgePreservesAllThreeSnapshots);
+    runCustom("generalized_loop_load_backup_with_three_backedges_produces_four_way_phi",
+             &InstructionTester::runGeneralizedLoopLoadBackupWithThreeBackedgesProducesFourWayPhi);
     runCustom("generalized_loop_non_themida_control_slot_produces_no_phi",
              &InstructionTester::runGeneralizedLoopNonThemidaControlSlotProducesNoPhi);
     runCustom("generalized_loop_nested_inner_overwrites_outer_active_state",


### PR DESCRIPTION
## Summary

Fixes the multi-way backedge silent-drop bug pinned by #121. `branch_backup(bb, /*generalized=*/true)` previously overwrote a single `backup_point` per header, silently dropping every generalized snapshot except the most recent. This PR widens the entire generalized-loop machinery to `1 canonical + N backedges` end-to-end.

## Changes

### Storage + state
- `generalizedLoopBackedgeBackup` is now `DenseMap<BB*, SmallVector<backup_point, 2>>`. `branch_backup_impl` appends, deduplicated by `sourceBlock` (repeat call from the same source replaces its entry in place - keeps iterative lift passes bounded).
- `GeneralizedLoopControlFieldState`'s `backedgeSource` / `backedgeControl` / `backedgeBuffer` become parallel `SmallVector`s sized N per header.

### Phi construction
- `make_generalized_loop_backup(bb, canonical, ArrayRef<backup_point> sources)`: `mergeValue` widened to accept `ArrayRef<Value*>` backedge values; constructs `(1 + N)`-incoming phis. Sources duplicating `canonicalSource` are filtered before phi construction. The N=1 path produces the same 2-incoming phi as before (**determinism gate: 42/42 golden hashes match**).
- `retrieve_generalized_loop_control_slot_value_impl`, `retrieve_generalized_loop_target_slot_value_impl`, and `retrieve_generalized_loop_control_field_value_impl` each emit `(1 + N)`-incoming phis from the state's vectors.
- `retrieve_generalized_loop_phi_address_value_impl` and `retrieve_generalized_loop_local_phi_address_value_impl` relax their `phi->getNumIncomingValues() != 2` sanity check to accept `>= 2`, and match each incoming against `canonicalSource` or any `state->backedgeSources[i]`.

### Load path
- `load_generalized_backup_impl` collects backedges whose `sourceBlock` differs from canonical AND whose `controlCursor` value differs from canonical; activates state only if at least one such backedge exists.
- `seedInvariantLocalQwords` requires the qword to read identically from `canonicalBuffer` AND every `backedgeBuffer` to qualify.

### Rolled control
- `record_generalized_loop_backedge_impl`'s rotation (move current backedge into canonical, install new source as backedge) is only well-defined for the 1-backedge case; now guards on `backedgeSources.size() == 1` and becomes a no-op for multi-way. Extending rolled-control semantics to multi-way loops is left as follow-up when a real sample exercises it.

## Tests (#121 flipped)

| Before (#121 pinned bug) | After (this PR) |
|---|---|
| `generalized_loop_third_backedge_overwrites_prior_backedge_silently` | `generalized_loop_third_backedge_preserves_all_three_snapshots` - asserts the vector holds one entry per `sourceBlock` |
| `generalized_loop_load_backup_with_three_backedges_produces_two_way_phi_only` | `generalized_loop_load_backup_with_three_backedges_produces_four_way_phi` - asserts `GetMemoryValue(controlSlot)` yields a 4-incoming phi carrying canonical + all three backedge control values |

## Docs

`docs/LOOP_HANDLING.md`: struct and `mergeValue` snippets updated to N-way shapes, `branch_backup` state-transition row describes append+dedup, multi-way backedge row removed from Known limitations.

## Verification

- `python test.py micro`: all pass, including both flipped tests
- `python test.py baseline`: all rewrite regression checks passed, **determinism check passed (42 golden files match)** - 2-way loop IR shape unchanged
- Themida reference sample: **2544 instructions lifted, 0 warnings, 0 errors**

## Diff

3 files, +364 / -246.