### PR TITLE
lifter: extend record_generalized_loop_backedge for multi-way rolled control

### DIFF
--- a/lifter/core/LifterClass_Concolic.hpp
+++ b/lifter/core/LifterClass_Concolic.hpp
@@ -1302,49 +1302,101 @@ public:
         !stateIt->second.valid) {
       return;
     }
-    // The rolled-control promotion semantics (move current backedge into
-    // canonical, install new source as backedge) are only well-defined for
-    // the 1-backedge case. Multi-way loops do not have a single obvious
-    // "current backedge" to promote, so skip the rotation; the existing
-    // N-way state remains valid.
-    if (stateIt->second.backedgeSources.size() != 1) {
+    auto& sources = stateIt->second.backedgeSources;
+    auto& controls = stateIt->second.backedgeControls;
+    auto& buffers = stateIt->second.backedgeBuffers;
+
+    if (sources.size() == 1) {
+      // 2-way loop: preserve the original rotation semantics - move the
+      // current backedge into canonical and install the new body source
+      // as the single backedge. This matches the reference Themida flow
+      // where body exploration rolls the control cursor forward.
+      auto* existingBackedgeSource = sources.front();
+      if (!existingBackedgeSource || sourceBlock == existingBackedgeSource) {
+        return;
+      }
+      auto* currentControlValue =
+          retrieveContiguousBufferedValue(this->buffer, kThemidaControlCursorSlot, 8);
+      uint64_t rolledBackedgeControl = 0;
+      if (!currentControlValue ||
+          !evaluateConcreteGeneralizedLoopInt(currentControlValue,
+                                              existingBackedgeSource,
+                                              rolledBackedgeControl) ||
+          rolledBackedgeControl == controls.front()) {
+        return;
+      }
+      auto previousBackedgeSource = existingBackedgeSource;
+      auto previousBackedgeControl = controls.front();
+      auto previousBackedgeBuffer = buffers.front();
+      stateIt->second.canonicalSource = previousBackedgeSource;
+      stateIt->second.canonicalControl = previousBackedgeControl;
+      stateIt->second.canonicalBuffer = previousBackedgeBuffer;
+      sources.front() = sourceBlock;
+      controls.front() = rolledBackedgeControl;
+      buffers.front() = this->buffer;
+      if (bb == activeGeneralizedLoopControlFieldState.headerBlock) {
+        activeGeneralizedLoopControlFieldState = stateIt->second;
+        activeGeneralizedLoopEntrySourceBlock = sourceBlock;
+        activeGeneralizedLoopLocalBuffer = extractLocalStackBuffer(
+            activeGeneralizedLoopControlFieldState.backedgeBuffers.front());
+      }
+      if (this->liftProgressDiagEnabled) {
+        std::cout << "[diag] roll_generalized_backedge bb=" << bb->getName().str()
+                  << " canonical=0x" << std::hex
+                  << stateIt->second.canonicalControl << " backedge=0x"
+                  << controls.front() << std::dec
+                  << " source=" << sourceBlock->getName().str() << "\n";
+      }
       return;
     }
-    auto* existingBackedgeSource = stateIt->second.backedgeSources.front();
-    if (!existingBackedgeSource || sourceBlock == existingBackedgeSource) {
+
+    // Multi-way loop (size > 1): append-or-update the body source to the
+    // backedge list. Each distinct body block contributes at most one
+    // entry (dedup by sourceBlock). This preserves the original N
+    // backedges and records the body's rolled state alongside them;
+    // unbounded growth is prevented by the per-sourceBlock dedup.
+    // Rotation (promoting a backedge to canonical) is undefined for
+    // multi-way - no single backedge is "the" one to promote.
+    if (sourceBlock == stateIt->second.canonicalSource) {
       return;
     }
     auto* currentControlValue =
         retrieveContiguousBufferedValue(this->buffer, kThemidaControlCursorSlot, 8);
-    uint64_t rolledBackedgeControl = 0;
+    uint64_t newControl = 0;
     if (!currentControlValue ||
-        !evaluateConcreteGeneralizedLoopInt(currentControlValue,
-                                            existingBackedgeSource,
-                                            rolledBackedgeControl) ||
-        rolledBackedgeControl == stateIt->second.backedgeControls.front()) {
+        !evaluateConcreteGeneralizedLoopInt(currentControlValue, sourceBlock,
+                                            newControl)) {
       return;
     }
-    auto previousBackedgeSource = existingBackedgeSource;
-    auto previousBackedgeControl = stateIt->second.backedgeControls.front();
-    auto previousBackedgeBuffer = stateIt->second.backedgeBuffers.front();
-    stateIt->second.canonicalSource = previousBackedgeSource;
-    stateIt->second.canonicalControl = previousBackedgeControl;
-    stateIt->second.canonicalBuffer = previousBackedgeBuffer;
-    stateIt->second.backedgeSources.front() = sourceBlock;
-    stateIt->second.backedgeControls.front() = rolledBackedgeControl;
-    stateIt->second.backedgeBuffers.front() = this->buffer;
-    if (bb == activeGeneralizedLoopControlFieldState.headerBlock) {
-      activeGeneralizedLoopControlFieldState = stateIt->second;
-      activeGeneralizedLoopEntrySourceBlock = sourceBlock;
-      activeGeneralizedLoopLocalBuffer = extractLocalStackBuffer(
-          activeGeneralizedLoopControlFieldState.backedgeBuffers.front());
+    bool mutated = false;
+    bool isNew = true;
+    for (size_t i = 0; i < sources.size(); ++i) {
+      if (sources[i] == sourceBlock) {
+        isNew = false;
+        if (controls[i] == newControl) {
+          return;  // no progress; nothing to record
+        }
+        controls[i] = newControl;
+        buffers[i] = this->buffer;
+        mutated = true;
+        break;
+      }
     }
-    if (this->liftProgressDiagEnabled) {
-      std::cout << "[diag] roll_generalized_backedge bb=" << bb->getName().str()
-                << " canonical=0x" << std::hex
-                << stateIt->second.canonicalControl << " backedge=0x"
-                << stateIt->second.backedgeControls.front() << std::dec
-                << " source=" << sourceBlock->getName().str() << "\n";
+    if (isNew) {
+      sources.push_back(sourceBlock);
+      controls.push_back(newControl);
+      buffers.push_back(this->buffer);
+      mutated = true;
+    }
+    if (mutated && bb == activeGeneralizedLoopControlFieldState.headerBlock) {
+      activeGeneralizedLoopControlFieldState = stateIt->second;
+    }
+    if (mutated && this->liftProgressDiagEnabled) {
+      std::cout << "[diag] roll_generalized_backedge_multiway bb="
+                << bb->getName().str()
+                << " backedgeCount=" << sources.size()
+                << " source=" << sourceBlock->getName().str() << std::dec
+                << "\n";
     }
   }
 

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -1889,6 +1889,123 @@ bool runGeneralizedLoopNestedInnerOverwritesOuterActiveState(std::string& detail
   return true;
 }
 
+// Multi-way rolled-control: record_generalized_loop_backedge appends or
+// updates per body source when the header has >=2 backedges. 1-backedge
+// loops keep the original rotation semantics (promote backedge into
+// canonical, install new source as backedge); multi-way loops dedup by
+// sourceBlock and grow the backedge list as distinct body paths roll.
+bool runRecordGeneralizedLoopBackedgeMultiwayAppendsNewBodySource(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* preheader =
+      llvm::BasicBlock::Create(context, "preheader", lifter.fnc);
+  auto* firstBackedge =
+      llvm::BasicBlock::Create(context, "first_backedge", lifter.fnc);
+  auto* secondBackedge =
+      llvm::BasicBlock::Create(context, "second_backedge", lifter.fnc);
+  auto* loopHeader =
+      llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
+  auto* bodyBlock =
+      llvm::BasicBlock::Create(context, "body_block", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t canonicalControl = 0x1401AF740ULL;
+  constexpr uint64_t firstControl = 0x1401AF0F6ULL;
+  constexpr uint64_t secondControl = 0x1401AEB43ULL;
+  constexpr uint64_t bodyRolledControl = 0x1401AEC37ULL;
+
+  lifter.builder->SetInsertPoint(preheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, canonicalControl));
+  lifter.branch_backup(loopHeader);
+
+  lifter.builder->SetInsertPoint(firstBackedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, firstControl));
+  lifter.branch_backup(loopHeader, /*generalized=*/true);
+
+  lifter.builder->SetInsertPoint(secondBackedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, secondControl));
+  lifter.branch_backup(loopHeader, /*generalized=*/true);
+
+  lifter.load_generalized_backup(loopHeader);
+  if (!lifter.activeGeneralizedLoopControlFieldState.valid) {
+    details = "  multi-way activation failed\n";
+    return false;
+  }
+  if (lifter.activeGeneralizedLoopControlFieldState.backedgeSources.size() != 2) {
+    details = "  setup should have 2 backedges before record\n";
+    return false;
+  }
+
+  // Simulate body lifting: a new body block advances the control cursor.
+  lifter.builder->SetInsertPoint(bodyBlock);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, bodyRolledControl));
+  lifter.record_generalized_loop_backedge(loopHeader);
+
+  auto& backedgeSources =
+      lifter.activeGeneralizedLoopControlFieldState.backedgeSources;
+  auto& backedgeControls =
+      lifter.activeGeneralizedLoopControlFieldState.backedgeControls;
+  if (backedgeSources.size() != 3) {
+    std::ostringstream os;
+    os << "  record_generalized_loop_backedge (multi-way) should append body "
+          "source, got backedge count " << backedgeSources.size()
+       << " expected 3\n";
+    details = os.str();
+    return false;
+  }
+  bool sawBody = false;
+  for (size_t i = 0; i < backedgeSources.size(); ++i) {
+    if (backedgeSources[i] == bodyBlock &&
+        backedgeControls[i] == bodyRolledControl) {
+      sawBody = true;
+      break;
+    }
+  }
+  if (!sawBody) {
+    details = "  appended body backedge missing from multi-way state\n";
+    return false;
+  }
+
+  // Calling record again from the same body with the SAME control must
+  // be a no-op (no progress - size stays at 3).
+  lifter.record_generalized_loop_backedge(loopHeader);
+  if (backedgeSources.size() != 3) {
+    details = "  repeat record (same control) should not grow multi-way state\n";
+    return false;
+  }
+
+  // Calling record with a NEW control from the same body must update
+  // in place - size stays at 3, but the body entry's control advances.
+  constexpr uint64_t bodyRolledControl2 = 0x1401AED41ULL;
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, bodyRolledControl2));
+  lifter.record_generalized_loop_backedge(loopHeader);
+  if (backedgeSources.size() != 3) {
+    details = "  repeat record (new control, same source) should dedup and "
+              "not grow multi-way state\n";
+    return false;
+  }
+  bool sawUpdatedControl = false;
+  for (size_t i = 0; i < backedgeSources.size(); ++i) {
+    if (backedgeSources[i] == bodyBlock &&
+        backedgeControls[i] == bodyRolledControl2) {
+      sawUpdatedControl = true;
+      break;
+    }
+  }
+  if (!sawUpdatedControl) {
+    details = "  multi-way body entry should reflect latest rolled control "
+              "after repeat record\n";
+    return false;
+  }
+  return true;
+}
+
 bool runSolvePathResolvesGeneralizedPhiLoadTarget(std::string& details) {
   LifterUnderTest lifter;
   auto& context = lifter.context;
@@ -3227,6 +3344,8 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runGeneralizedLoopNonThemidaControlSlotProducesNoPhi);
     runCustom("generalized_loop_nested_inner_overwrites_outer_active_state",
              &InstructionTester::runGeneralizedLoopNestedInnerOverwritesOuterActiveState);
+    runCustom("record_generalized_loop_backedge_multiway_appends_new_body_source",
+             &InstructionTester::runRecordGeneralizedLoopBackedgeMultiwayAppendsNewBodySource);
     runCustom("generalized_loop_restore_merges_backedge_flag_state",
              &InstructionTester::runGeneralizedLoopRestoreMergesBackedgeFlagState);
     runCustom("generalized_loop_restore_merges_backedge_register_state",


### PR DESCRIPTION
Follow-up to #123 (multi-way backedge N-way phi construction).

## What this does

`record_generalized_loop_backedge_impl` previously guarded on `backedgeSources.size() == 1` and was a no-op for multi-way loops. The 1-backedge rotation (promote the existing backedge into canonical, install the new body source as the backedge) does not generalize to multi-way - no single backedge is 'the' one to promote.

This replaces the guard with two code paths:

| Case | Behavior |
|---|---|
| `size == 1` | Unchanged rotation. Preserves Themida semantics where body exploration rolls the cursor forward through a sequence of canonical -> backedge states. |
| `size >= 2` | Append-or-update by sourceBlock. New body source contributes a fresh backedge alongside the original N. Repeat call from the same body source with the same control is a no-op; with a new control, updates that source's entry in place. Per-sourceBlock dedup prevents unbounded growth. |

## New test

`record_generalized_loop_backedge_multiway_appends_new_body_source`:
- 2-backedge loop, activate, simulate body lift rolling the cursor, call `record` -> backedges grow to 3, body source reflected.
- Repeat call (same control): no-op, size stays 3.
- Repeat call (new control, same source): updates in place, size stays 3, entry reflects latest control.

## Also considered and dropped this session

**Non-Themida control slot generalization.** Initial attempt to drop the hardcoded `kThemidaControlCursorSlot` gate in retrieve helpers in favor of buffer lookups was too aggressive: every memory address with distinct canonical/backedge constants produced a phi, which over-fired on the Themida sample (2544 -> 108444 instructions, 1 error). Proper fix needs per-function control-slot detection. Left as follow-up; #122 test continues to pin the current behavior.

## Verification

- `python test.py micro`: all pass
- `python test.py baseline`: all rewrite regression checks passed, determinism 42/42 match
- Themida reference sample: **2544 / 0 / 0** (unchanged)

## Diff

`lifter/core/LifterClass_Concolic.hpp`: +84/-32
`lifter/test/Tester.hpp`: +119/-0