### PR TITLE
lifter: expand loop microtest coverage (+3 tests, batch 17)

### DIFF
--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -2554,6 +2554,112 @@ bool runGeneralizedLoopLoadGeneralizedBackupPrefersStoredStateOverFreshBackedgeB
   return true;
 }
 
+// getMostRecentGeneralizedLoopState prefers the ACTIVE state over any
+// archived entries. This is the direct state-getter counterpart to the
+// load_generalized_backup stored-state precedence test.
+bool runGeneralizedLoopStateGetterPrefersActiveStateOverArchive(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto* activeHeader =
+      llvm::BasicBlock::Create(lifter.context, "active_header", lifter.fnc);
+  auto* archivedHeader =
+      llvm::BasicBlock::Create(lifter.context, "archived_header", lifter.fnc);
+  auto* canonical =
+      llvm::BasicBlock::Create(lifter.context, "canonical", lifter.fnc);
+  auto* activeBackedge =
+      llvm::BasicBlock::Create(lifter.context, "active_backedge", lifter.fnc);
+  auto* archivedBackedge =
+      llvm::BasicBlock::Create(lifter.context, "archived_backedge", lifter.fnc);
+
+  lifter.activeGeneralizedLoopControlFieldState.valid = true;
+  lifter.activeGeneralizedLoopControlFieldState.headerBlock = activeHeader;
+  lifter.activeGeneralizedLoopControlFieldState.canonicalSource = canonical;
+  lifter.activeGeneralizedLoopControlFieldState.canonicalControl = 0x1111;
+  lifter.activeGeneralizedLoopControlFieldState.backedgeSources = {activeBackedge};
+  lifter.activeGeneralizedLoopControlFieldState.backedgeControls = {0x2222};
+
+  LifterUnderTest::GeneralizedLoopControlFieldState archived;
+  archived.valid = true;
+  archived.headerBlock = archivedHeader;
+  archived.canonicalSource = canonical;
+  archived.canonicalControl = 0x3333;
+  archived.backedgeSources = {archivedBackedge};
+  archived.backedgeControls = {0x4444};
+  lifter.generalizedLoopControlFieldStates[archivedHeader] = archived;
+
+  auto* state = lifter.getMostRecentGeneralizedLoopState();
+  if (!state || state->headerBlock != activeHeader ||
+      state->canonicalControl != 0x1111 ||
+      state->backedgeControls.front() != 0x2222) {
+    details = "  getMostRecentGeneralizedLoopState should prefer the active state over archived entries\n";
+    return false;
+  }
+  return true;
+}
+
+// getMostRecentGeneralizedLoopState falls back to the archived per-header
+// map when the active state is invalid.
+bool runGeneralizedLoopStateGetterFallsBackToArchivedState(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto* archivedHeader =
+      llvm::BasicBlock::Create(lifter.context, "archived_header", lifter.fnc);
+  auto* canonical =
+      llvm::BasicBlock::Create(lifter.context, "canonical", lifter.fnc);
+  auto* archivedBackedge =
+      llvm::BasicBlock::Create(lifter.context, "archived_backedge", lifter.fnc);
+
+  LifterUnderTest::GeneralizedLoopControlFieldState archived;
+  archived.valid = true;
+  archived.headerBlock = archivedHeader;
+  archived.canonicalSource = canonical;
+  archived.canonicalControl = 0x5555;
+  archived.backedgeSources = {archivedBackedge};
+  archived.backedgeControls = {0x6666};
+  lifter.generalizedLoopControlFieldStates[archivedHeader] = archived;
+
+  auto* state = lifter.getMostRecentGeneralizedLoopState();
+  if (!state || state->headerBlock != archivedHeader ||
+      state->canonicalControl != 0x5555 ||
+      state->backedgeControls.front() != 0x6666) {
+    details = "  getMostRecentGeneralizedLoopState should fall back to the archived map when active state is invalid\n";
+    return false;
+  }
+  return true;
+}
+
+// getGeneralizedLoopStateForHeader returns nullptr for null or missing
+// headers, and returns the stored valid entry for an exact header match.
+bool runGeneralizedLoopStateGetterByHeaderExactMatchOnly(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto* storedHeader =
+      llvm::BasicBlock::Create(lifter.context, "stored_header", lifter.fnc);
+  auto* otherHeader =
+      llvm::BasicBlock::Create(lifter.context, "other_header", lifter.fnc);
+
+  LifterUnderTest::GeneralizedLoopControlFieldState stored;
+  stored.valid = true;
+  stored.headerBlock = storedHeader;
+  stored.canonicalControl = 0x7777;
+  lifter.generalizedLoopControlFieldStates[storedHeader] = stored;
+
+  if (lifter.getGeneralizedLoopStateForHeader(nullptr) != nullptr) {
+    details = "  getGeneralizedLoopStateForHeader(nullptr) must return nullptr\n";
+    return false;
+  }
+  if (lifter.getGeneralizedLoopStateForHeader(otherHeader) != nullptr) {
+    details = "  getGeneralizedLoopStateForHeader(otherHeader) must return nullptr when no stored entry exists\n";
+    return false;
+  }
+  auto* state = lifter.getGeneralizedLoopStateForHeader(storedHeader);
+  if (!state || state->headerBlock != storedHeader || state->canonicalControl != 0x7777) {
+    details = "  getGeneralizedLoopStateForHeader should return the stored valid entry for an exact header match\n";
+    return false;
+  }
+  return true;
+}
+
 // Phi-address helper with 3-way phi (canonical + 2 distinct backedges).
 // After PR #123 relaxed the sanity check from `!= 2` to `< 2`, the helper
 // must match each incoming against canonicalSource or any of
@@ -7404,6 +7510,12 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runMigrateGeneralizedLoopBlockCopiesAllStateToNewBlock);
     runCustom("generalized_loop_load_generalized_backup_prefers_stored_state_over_fresh_backedge_backup",
              &InstructionTester::runGeneralizedLoopLoadGeneralizedBackupPrefersStoredStateOverFreshBackedgeBackup);
+    runCustom("generalized_loop_state_getter_prefers_active_state_over_archive",
+             &InstructionTester::runGeneralizedLoopStateGetterPrefersActiveStateOverArchive);
+    runCustom("generalized_loop_state_getter_falls_back_to_archived_state",
+             &InstructionTester::runGeneralizedLoopStateGetterFallsBackToArchivedState);
+    runCustom("generalized_loop_state_getter_by_header_exact_match_only",
+             &InstructionTester::runGeneralizedLoopStateGetterByHeaderExactMatchOnly);
     runCustom("make_generalized_loop_backup_widens_rax_to_undef_on_first_backedge",
              &InstructionTester::runMakeGeneralizedLoopBackupWidensRaxToUndefOnFirstBackedge);
     runCustom("generalized_phi_address_with_negative_displacement_resolves_loaded_values",

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -771,6 +771,49 @@ private:
     return true;
   }
 
+
+  bool runStructuredLoopHeaderRejectsPartialChainWithoutTrampoline(
+      std::string& details) {
+    LifterUnderTest lifter;
+    lifter.currentPathSolveContext =
+        LifterUnderTest::PathSolveContext::ConditionalBranch;
+
+    auto* current = llvm::BasicBlock::Create(lifter.context, "current", lifter.fnc);
+    auto* header = llvm::BasicBlock::Create(lifter.context, "header", lifter.fnc);
+    auto* partialLift =
+        llvm::BasicBlock::Create(lifter.context, "partial_lift", lifter.fnc);
+
+    llvm::IRBuilder<> currentBuilder(current);
+    currentBuilder.CreateBr(header);
+
+    // Header is NOT a trampoline: give it a non-branch instruction first,
+    // then an unconditional br. That defeats the size()==1 trampoline test.
+    llvm::IRBuilder<> headerBuilder(header);
+    headerBuilder.CreateAdd(
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 1),
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 2),
+        "not_a_trampoline");
+    headerBuilder.CreateBr(partialLift);
+
+    // Same partial successor shape as above: non-empty, no terminator.
+    llvm::IRBuilder<> partialBuilder(partialLift);
+    partialBuilder.CreateAdd(
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 3),
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 4),
+        "partial_mid_lift");
+
+    lifter.blockInfo = BBInfo(0x2000, current);
+    lifter.visitedAddresses.insert(0x1000);
+    lifter.addrToBB[0x1000] = header;
+
+    if (lifter.canGeneralizeStructuredLoopHeader(0x1000)) {
+      details =
+          "  partial mid-lift successor must reject when the entry block is not a single unconditional-br trampoline\n";
+      return false;
+    }
+    return true;
+  }
+
   bool runStructuredLoopHeaderRejectsAcyclicBackwardBranch(
       std::string& details) {
     LifterUnderTest lifter;
@@ -5084,6 +5127,59 @@ bool runGeneralizedLoopRestoreFlagPhiCarriesConcreteBackedgeOnDivergence(
   return true;
 }
 
+// control_slot helper at byteCount=1 returns an i8 phi carrying the
+// masked low byte of canonical and backedge controlCursor values.
+// Complements the existing byteCount=2 control_slot test.
+bool runGeneralizedLoopControlSlotByteCountOneReturnsMaskedPhi(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* preheader =
+      llvm::BasicBlock::Create(context, "preheader", lifter.fnc);
+  auto* backedge =
+      llvm::BasicBlock::Create(context, "backedge", lifter.fnc);
+  auto* loopHeader =
+      llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t canonicalControl = 0x1401AABBCCULL;
+  constexpr uint64_t backedgeControl = 0x1401DDEEFFULL;
+  constexpr uint8_t loCanonical = static_cast<uint8_t>(canonicalControl & 0xFFULL);
+  constexpr uint8_t loBackedge = static_cast<uint8_t>(backedgeControl & 0xFFULL);
+
+  lifter.builder->SetInsertPoint(preheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, canonicalControl));
+  lifter.branch_backup(loopHeader);
+
+  lifter.builder->SetInsertPoint(backedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, backedgeControl));
+  lifter.branch_backup(loopHeader, /*generalized=*/true);
+
+  lifter.load_generalized_backup(loopHeader);
+  lifter.builder->SetInsertPoint(loopHeader);
+  auto* result = lifter.GetMemoryValue(makeI64(context, controlSlot), 8);
+  auto* phi = llvm::dyn_cast<llvm::PHINode>(result);
+  if (!phi || !phi->getType()->isIntegerTy(8)) {
+    details = "  control_slot byteCount=1 should produce an i8 phi\n";
+    return false;
+  }
+  bool sawC = false, sawB = false;
+  for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
+    auto actual = readConstantAPInt(phi->getIncomingValue(i));
+    if (!actual.has_value()) continue;
+    const uint64_t v = actual->getZExtValue();
+    if (v == loCanonical) sawC = true;
+    else if (v == loBackedge) sawB = true;
+  }
+  if (!sawC || !sawB) {
+    details = "  control_slot byteCount=1 phi should carry masked low-byte canonical and backedge values\n";
+    return false;
+  }
+  return true;
+}
+
 // Preserved-register coverage: RDI at index 7 in
 // shouldPreserveGeneralizedBackedgeRegisterIndex. Completes the remaining
 // hot loop_reg_phi lane not yet covered by earlier RCX/RSP/R9/R10/R12/R14 tests.
@@ -5212,6 +5308,7 @@ bool runGeneralizedLoopTargetSlotByteCountTwoReturnsMaskedPhi(
   }
   return true;
 }
+
 
 // retrieve_generalized_loop_control_field_value_impl with byteCount=1
 // yields an i8 phi carrying the masked low byte of canonical and
@@ -6880,6 +6977,8 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runMakeGeneralizedLoopBackupPreservesConcreteRspWhenValuesDiffer);
     runCustom("generalized_loop_control_slot_byte_count_two_returns_masked_phi",
              &InstructionTester::runGeneralizedLoopControlSlotByteCountTwoReturnsMaskedPhi);
+    runCustom("generalized_loop_control_slot_byte_count_one_returns_masked_phi",
+             &InstructionTester::runGeneralizedLoopControlSlotByteCountOneReturnsMaskedPhi);
     runCustom("make_generalized_loop_backup_populates_register_phis_map",
              &InstructionTester::runMakeGeneralizedLoopBackupPopulatesRegisterPhisMap);
     runCustom("make_generalized_loop_backup_populates_flag_phis_map",


### PR DESCRIPTION
Additive coverage only.

## Tests added
- `generalized_loop_state_getter_prefers_active_state_over_archive`
- `generalized_loop_state_getter_falls_back_to_archived_state`
- `generalized_loop_state_getter_by_header_exact_match_only`

These cover the generalized-loop state getter helpers directly rather than only through downstream helper calls.

## Verification
- `python test.py micro`: all 165 pass (was 162)
- `python test.py baseline`: rewrite regression + determinism 42/42 pass
- Themida reference sample: 2544 / 0 / 0 (unchanged)

## Session cumulative total
Baseline 36 -> current branch 116: **+80 loop-related microtests** across this autoresearch session.