### PR TITLE
lifter: expand loop microtest coverage (+2 tests, batch 23)

### DIFF
--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -2554,6 +2554,114 @@ bool runGeneralizedLoopLoadGeneralizedBackupPrefersStoredStateOverFreshBackedgeB
   return true;
 }
 
+// load_generalized_backup stored-state branch chooses the FIRST
+// backedgeSources entry as activeGeneralizedLoopEntrySourceBlock and seeds
+// activeGeneralizedLoopLocalBuffer from the FIRST backedgeBuffers entry.
+// This is a direct pin of the stored-state branch's current policy.
+bool runGeneralizedLoopLoadGeneralizedBackupStoredStateUsesFirstBackedgeAsActiveEntry(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* preheader = llvm::BasicBlock::Create(context, "preheader", lifter.fnc);
+  auto* backedge = llvm::BasicBlock::Create(context, "backedge", lifter.fnc);
+  auto* loopHeader = llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
+  auto* firstStoredBackedge = llvm::BasicBlock::Create(context, "first_stored_backedge", lifter.fnc);
+  auto* secondStoredBackedge = llvm::BasicBlock::Create(context, "second_stored_backedge", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t canonicalControl = 0x1401AF740ULL;
+  constexpr uint64_t originalBackedgeControl = 0x1401AF0F6ULL;
+  constexpr uint64_t localA = STACKP_VALUE - 0x20;
+  constexpr uint64_t localB = STACKP_VALUE - 0x28;
+
+  // Seed minimal snapshots so load_generalized_backup enters the stored-state branch.
+  lifter.builder->SetInsertPoint(preheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot), makeI64(context, canonicalControl));
+  lifter.branch_backup(loopHeader);
+  lifter.builder->SetInsertPoint(backedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot), makeI64(context, originalBackedgeControl));
+  lifter.branch_backup(loopHeader, /*generalized=*/true);
+  lifter.load_generalized_backup(loopHeader);
+
+  // Replace the archived state with a hand-crafted 2-backedge state.
+  LifterUnderTest::GeneralizedLoopControlFieldState stored;
+  stored.valid = true;
+  stored.headerBlock = loopHeader;
+  stored.canonicalSource = preheader;
+  stored.canonicalControl = canonicalControl;
+  stored.canonicalBuffer = lifter.BBbackup[loopHeader].buffer;
+  stored.backedgeSources = {firstStoredBackedge, secondStoredBackedge};
+  stored.backedgeControls = {0x1111ULL, 0x2222ULL};
+  stored.backedgeBuffers.resize(2);
+  stored.backedgeBuffers[0][localA] = ValueByteReference(
+      llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), 0xAA), 0);
+  stored.backedgeBuffers[1][localB] = ValueByteReference(
+      llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), 0xBB), 0);
+  lifter.generalizedLoopControlFieldStates[loopHeader] = stored;
+
+  lifter.load_generalized_backup(loopHeader);
+
+  if (lifter.activeGeneralizedLoopEntrySourceBlock != firstStoredBackedge) {
+    details = "  stored-state branch should choose backedgeSources.front() as activeGeneralizedLoopEntrySourceBlock\n";
+    return false;
+  }
+  if (!lifter.activeGeneralizedLoopLocalBuffer.contains(localA) ||
+      lifter.activeGeneralizedLoopLocalBuffer.contains(localB)) {
+    details = "  stored-state branch should seed activeGeneralizedLoopLocalBuffer from backedgeBuffers.front() only\n";
+    return false;
+  }
+  return true;
+}
+
+// If the stored archived state is valid but has NO backedgeBuffers,
+// load_generalized_backup clears activeGeneralizedLoopLocalBuffer and sets
+// activeGeneralizedLoopEntrySourceBlock to nullptr. This is the empty-vector
+// branch of the stored-state path.
+bool runGeneralizedLoopLoadGeneralizedBackupStoredStateWithoutBackedgesClearsActiveLocalBuffer(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* preheader = llvm::BasicBlock::Create(context, "preheader", lifter.fnc);
+  auto* backedge = llvm::BasicBlock::Create(context, "backedge", lifter.fnc);
+  auto* loopHeader = llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t canonicalControl = 0x1401AF740ULL;
+  constexpr uint64_t backedgeControl = 0x1401AF0F6ULL;
+  constexpr uint64_t staleLocal = STACKP_VALUE - 0x30;
+
+  lifter.builder->SetInsertPoint(preheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot), makeI64(context, canonicalControl));
+  lifter.branch_backup(loopHeader);
+  lifter.builder->SetInsertPoint(backedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot), makeI64(context, backedgeControl));
+  lifter.branch_backup(loopHeader, /*generalized=*/true);
+  lifter.load_generalized_backup(loopHeader);
+
+  // Seed stale local state to prove it gets cleared.
+  lifter.activeGeneralizedLoopLocalBuffer[staleLocal] = ValueByteReference(
+      llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), 0xCC), 0);
+
+  LifterUnderTest::GeneralizedLoopControlFieldState stored;
+  stored.valid = true;
+  stored.headerBlock = loopHeader;
+  stored.canonicalSource = preheader;
+  stored.canonicalControl = canonicalControl;
+  lifter.generalizedLoopControlFieldStates[loopHeader] = stored;
+
+  lifter.load_generalized_backup(loopHeader);
+
+  if (lifter.activeGeneralizedLoopEntrySourceBlock != nullptr) {
+    details = "  stored-state branch with no backedges should set activeGeneralizedLoopEntrySourceBlock to nullptr\n";
+    return false;
+  }
+  if (!lifter.activeGeneralizedLoopLocalBuffer.empty()) {
+    details = "  stored-state branch with no backedgeBuffers should clear activeGeneralizedLoopLocalBuffer\n";
+    return false;
+  }
+  return true;
+}
+
 // getMostRecentGeneralizedLoopState prefers the ACTIVE state over any
 // archived entries. This is the direct state-getter counterpart to the
 // load_generalized_backup stored-state precedence test.
@@ -7906,6 +8014,10 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runGeneralizedLoopStateGetterReturnsNullWhenNoStateExists);
     runCustom("generalized_loop_state_getter_by_header_rejects_invalid_stored_entry",
              &InstructionTester::runGeneralizedLoopStateGetterByHeaderRejectsInvalidStoredEntry);
+    runCustom("generalized_loop_load_generalized_backup_stored_state_uses_first_backedge_as_active_entry",
+             &InstructionTester::runGeneralizedLoopLoadGeneralizedBackupStoredStateUsesFirstBackedgeAsActiveEntry);
+    runCustom("generalized_loop_load_generalized_backup_stored_state_without_backedges_clears_active_local_buffer",
+             &InstructionTester::runGeneralizedLoopLoadGeneralizedBackupStoredStateWithoutBackedgesClearsActiveLocalBuffer);
     runCustom("make_generalized_loop_backup_widens_rax_to_undef_on_first_backedge",
              &InstructionTester::runMakeGeneralizedLoopBackupWidensRaxToUndefOnFirstBackedge);
     runCustom("generalized_phi_address_with_negative_displacement_resolves_loaded_values",

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -771,6 +771,49 @@ private:
     return true;
   }
 
+
+  bool runStructuredLoopHeaderRejectsPartialChainWithoutTrampoline(
+      std::string& details) {
+    LifterUnderTest lifter;
+    lifter.currentPathSolveContext =
+        LifterUnderTest::PathSolveContext::ConditionalBranch;
+
+    auto* current = llvm::BasicBlock::Create(lifter.context, "current", lifter.fnc);
+    auto* header = llvm::BasicBlock::Create(lifter.context, "header", lifter.fnc);
+    auto* partialLift =
+        llvm::BasicBlock::Create(lifter.context, "partial_lift", lifter.fnc);
+
+    llvm::IRBuilder<> currentBuilder(current);
+    currentBuilder.CreateBr(header);
+
+    // Header is NOT a trampoline: give it a non-branch instruction first,
+    // then an unconditional br. That defeats the size()==1 trampoline test.
+    llvm::IRBuilder<> headerBuilder(header);
+    headerBuilder.CreateAdd(
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 1),
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 2),
+        "not_a_trampoline");
+    headerBuilder.CreateBr(partialLift);
+
+    // Same partial successor shape as above: non-empty, no terminator.
+    llvm::IRBuilder<> partialBuilder(partialLift);
+    partialBuilder.CreateAdd(
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 3),
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 4),
+        "partial_mid_lift");
+
+    lifter.blockInfo = BBInfo(0x2000, current);
+    lifter.visitedAddresses.insert(0x1000);
+    lifter.addrToBB[0x1000] = header;
+
+    if (lifter.canGeneralizeStructuredLoopHeader(0x1000)) {
+      details =
+          "  partial mid-lift successor must reject when the entry block is not a single unconditional-br trampoline\n";
+      return false;
+    }
+    return true;
+  }
+
   bool runStructuredLoopHeaderRejectsAcyclicBackwardBranch(
       std::string& details) {
     LifterUnderTest lifter;
@@ -5084,6 +5127,59 @@ bool runGeneralizedLoopRestoreFlagPhiCarriesConcreteBackedgeOnDivergence(
   return true;
 }
 
+// control_slot helper at byteCount=1 returns an i8 phi carrying the
+// masked low byte of canonical and backedge controlCursor values.
+// Complements the existing byteCount=2 control_slot test.
+bool runGeneralizedLoopControlSlotByteCountOneReturnsMaskedPhi(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* preheader =
+      llvm::BasicBlock::Create(context, "preheader", lifter.fnc);
+  auto* backedge =
+      llvm::BasicBlock::Create(context, "backedge", lifter.fnc);
+  auto* loopHeader =
+      llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t canonicalControl = 0x1401AABBCCULL;
+  constexpr uint64_t backedgeControl = 0x1401DDEEFFULL;
+  constexpr uint8_t loCanonical = static_cast<uint8_t>(canonicalControl & 0xFFULL);
+  constexpr uint8_t loBackedge = static_cast<uint8_t>(backedgeControl & 0xFFULL);
+
+  lifter.builder->SetInsertPoint(preheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, canonicalControl));
+  lifter.branch_backup(loopHeader);
+
+  lifter.builder->SetInsertPoint(backedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, backedgeControl));
+  lifter.branch_backup(loopHeader, /*generalized=*/true);
+
+  lifter.load_generalized_backup(loopHeader);
+  lifter.builder->SetInsertPoint(loopHeader);
+  auto* result = lifter.GetMemoryValue(makeI64(context, controlSlot), 8);
+  auto* phi = llvm::dyn_cast<llvm::PHINode>(result);
+  if (!phi || !phi->getType()->isIntegerTy(8)) {
+    details = "  control_slot byteCount=1 should produce an i8 phi\n";
+    return false;
+  }
+  bool sawC = false, sawB = false;
+  for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
+    auto actual = readConstantAPInt(phi->getIncomingValue(i));
+    if (!actual.has_value()) continue;
+    const uint64_t v = actual->getZExtValue();
+    if (v == loCanonical) sawC = true;
+    else if (v == loBackedge) sawB = true;
+  }
+  if (!sawC || !sawB) {
+    details = "  control_slot byteCount=1 phi should carry masked low-byte canonical and backedge values\n";
+    return false;
+  }
+  return true;
+}
+
 // Preserved-register coverage: RDI at index 7 in
 // shouldPreserveGeneralizedBackedgeRegisterIndex. Completes the remaining
 // hot loop_reg_phi lane not yet covered by earlier RCX/RSP/R9/R10/R12/R14 tests.
@@ -5212,6 +5308,7 @@ bool runGeneralizedLoopTargetSlotByteCountTwoReturnsMaskedPhi(
   }
   return true;
 }
+
 
 // retrieve_generalized_loop_control_field_value_impl with byteCount=1
 // yields an i8 phi carrying the masked low byte of canonical and
@@ -6880,6 +6977,8 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runMakeGeneralizedLoopBackupPreservesConcreteRspWhenValuesDiffer);
     runCustom("generalized_loop_control_slot_byte_count_two_returns_masked_phi",
              &InstructionTester::runGeneralizedLoopControlSlotByteCountTwoReturnsMaskedPhi);
+    runCustom("generalized_loop_control_slot_byte_count_one_returns_masked_phi",
+             &InstructionTester::runGeneralizedLoopControlSlotByteCountOneReturnsMaskedPhi);
     runCustom("make_generalized_loop_backup_populates_register_phis_map",
              &InstructionTester::runMakeGeneralizedLoopBackupPopulatesRegisterPhisMap);
     runCustom("make_generalized_loop_backup_populates_flag_phis_map",


### PR DESCRIPTION
Additive coverage only.

## Tests added
- `generalized_loop_load_generalized_backup_stored_state_uses_first_backedge_as_active_entry`
- `generalized_loop_load_generalized_backup_stored_state_without_backedges_clears_active_local_buffer`

These pin the explicit branch behavior in `load_generalized_backup` when a valid archived `GeneralizedLoopControlFieldState` entry already exists for the header.

## Verification
- `python test.py micro`: all 175 pass (was 173)
- `python test.py baseline`: rewrite regression + determinism 42/42 pass
- Themida reference sample: 2544 / 0 / 0 (unchanged)

## Session cumulative total
Baseline 36 -> current branch 126: **+90 loop-related microtests** across this autoresearch session.