### PR TITLE
lifter: expand loop microtest coverage (+2 tests, batch 27)

### DIFF
--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -5235,6 +5235,82 @@ bool runMakeGeneralizedLoopBackupPreservesConcreteR9OnFirstBackedge(
   return true;
 }
 
+// migrate_generalized_loop_block copies a multi-entry
+// generalizedLoopBackedgeBackup vector intact when newBlock has no entry.
+bool runMigrateGeneralizedLoopBlockCopiesMultiwayBackedgeVector(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* oldHeader = llvm::BasicBlock::Create(context, "old_header", lifter.fnc);
+  auto* newHeader = llvm::BasicBlock::Create(context, "new_header", lifter.fnc);
+  auto* beA = llvm::BasicBlock::Create(context, "beA", lifter.fnc);
+  auto* beB = llvm::BasicBlock::Create(context, "beB", lifter.fnc);
+
+  LifterUnderTest::backup_point a;
+  a.sourceBlock = beA;
+  LifterUnderTest::backup_point b;
+  b.sourceBlock = beB;
+  lifter.generalizedLoopBackedgeBackup[oldHeader].push_back(a);
+  lifter.generalizedLoopBackedgeBackup[oldHeader].push_back(b);
+
+  lifter.migrate_generalized_loop_block(oldHeader, newHeader);
+
+  if (lifter.generalizedLoopBackedgeBackup.count(newHeader) != 1 ||
+      lifter.generalizedLoopBackedgeBackup[newHeader].size() != 2) {
+    details = "  migrate_generalized_loop_block should copy the full multi-entry backedge vector to newHeader\n";
+    return false;
+  }
+  if (lifter.generalizedLoopBackedgeBackup[newHeader][0].sourceBlock != beA ||
+      lifter.generalizedLoopBackedgeBackup[newHeader][1].sourceBlock != beB) {
+    details = "  migrated multi-entry backedge vector should preserve entry order and source blocks\n";
+    return false;
+  }
+  return true;
+}
+
+// migrate_generalized_loop_block copies a multi-entry archived control-field
+// state and rewrites headerBlock to newHeader while preserving the vector
+// contents of backedgeSources/backedgeControls/backedgeBuffers.
+bool runMigrateGeneralizedLoopBlockCopiesMultiwayControlFieldState(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* oldHeader = llvm::BasicBlock::Create(context, "old_header", lifter.fnc);
+  auto* newHeader = llvm::BasicBlock::Create(context, "new_header", lifter.fnc);
+  auto* canonical = llvm::BasicBlock::Create(context, "canonical", lifter.fnc);
+  auto* beA = llvm::BasicBlock::Create(context, "beA", lifter.fnc);
+  auto* beB = llvm::BasicBlock::Create(context, "beB", lifter.fnc);
+
+  LifterUnderTest::GeneralizedLoopControlFieldState stored;
+  stored.valid = true;
+  stored.headerBlock = oldHeader;
+  stored.canonicalSource = canonical;
+  stored.canonicalControl = 0x1111;
+  stored.backedgeSources = {beA, beB};
+  stored.backedgeControls = {0x2222, 0x3333};
+  stored.backedgeBuffers.resize(2);
+  stored.backedgeBuffers[0][0x5000] = ValueByteReference(
+      llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), 0xAA), 0);
+  stored.backedgeBuffers[1][0x6000] = ValueByteReference(
+      llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), 0xBB), 0);
+  lifter.generalizedLoopControlFieldStates[oldHeader] = stored;
+
+  lifter.migrate_generalized_loop_block(oldHeader, newHeader);
+
+  if (lifter.generalizedLoopControlFieldStates.count(newHeader) != 1) {
+    details = "  migrate_generalized_loop_block should copy the archived control-field state to newHeader\n";
+    return false;
+  }
+  const auto& migrated = lifter.generalizedLoopControlFieldStates[newHeader];
+  if (migrated.headerBlock != newHeader || migrated.backedgeSources.size() != 2 ||
+      migrated.backedgeSources[0] != beA || migrated.backedgeSources[1] != beB ||
+      migrated.backedgeControls[0] != 0x2222 || migrated.backedgeControls[1] != 0x3333) {
+    details = "  migrated multi-entry control-field state should preserve vectors and rewrite headerBlock\n";
+    return false;
+  }
+  return true;
+}
+
 // retrieve_generalized_loop_target_slot_value_impl bails (returns
 // nullptr) when the canonical buffer has no tracked value at the
 // requested address, even when state is otherwise valid. The caller
@@ -8068,6 +8144,10 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runRecordGeneralizedLoopBackedgeSingleSourceNoOpWhenControlUnchanged);
     runCustom("migrate_generalized_loop_block_copies_all_state_to_new_block",
              &InstructionTester::runMigrateGeneralizedLoopBlockCopiesAllStateToNewBlock);
+    runCustom("migrate_generalized_loop_block_copies_multiway_backedge_vector",
+             &InstructionTester::runMigrateGeneralizedLoopBlockCopiesMultiwayBackedgeVector);
+    runCustom("generalized_loop_migrate_block_copies_multiway_control_field_state",
+             &InstructionTester::runMigrateGeneralizedLoopBlockCopiesMultiwayControlFieldState);
     runCustom("generalized_loop_load_generalized_backup_prefers_stored_state_over_fresh_backedge_backup",
              &InstructionTester::runGeneralizedLoopLoadGeneralizedBackupPrefersStoredStateOverFreshBackedgeBackup);
     runCustom("generalized_loop_state_getter_prefers_active_state_over_archive",

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -771,6 +771,49 @@ private:
     return true;
   }
 
+
+  bool runStructuredLoopHeaderRejectsPartialChainWithoutTrampoline(
+      std::string& details) {
+    LifterUnderTest lifter;
+    lifter.currentPathSolveContext =
+        LifterUnderTest::PathSolveContext::ConditionalBranch;
+
+    auto* current = llvm::BasicBlock::Create(lifter.context, "current", lifter.fnc);
+    auto* header = llvm::BasicBlock::Create(lifter.context, "header", lifter.fnc);
+    auto* partialLift =
+        llvm::BasicBlock::Create(lifter.context, "partial_lift", lifter.fnc);
+
+    llvm::IRBuilder<> currentBuilder(current);
+    currentBuilder.CreateBr(header);
+
+    // Header is NOT a trampoline: give it a non-branch instruction first,
+    // then an unconditional br. That defeats the size()==1 trampoline test.
+    llvm::IRBuilder<> headerBuilder(header);
+    headerBuilder.CreateAdd(
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 1),
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 2),
+        "not_a_trampoline");
+    headerBuilder.CreateBr(partialLift);
+
+    // Same partial successor shape as above: non-empty, no terminator.
+    llvm::IRBuilder<> partialBuilder(partialLift);
+    partialBuilder.CreateAdd(
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 3),
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 4),
+        "partial_mid_lift");
+
+    lifter.blockInfo = BBInfo(0x2000, current);
+    lifter.visitedAddresses.insert(0x1000);
+    lifter.addrToBB[0x1000] = header;
+
+    if (lifter.canGeneralizeStructuredLoopHeader(0x1000)) {
+      details =
+          "  partial mid-lift successor must reject when the entry block is not a single unconditional-br trampoline\n";
+      return false;
+    }
+    return true;
+  }
+
   bool runStructuredLoopHeaderRejectsAcyclicBackwardBranch(
       std::string& details) {
     LifterUnderTest lifter;
@@ -5084,6 +5127,59 @@ bool runGeneralizedLoopRestoreFlagPhiCarriesConcreteBackedgeOnDivergence(
   return true;
 }
 
+// control_slot helper at byteCount=1 returns an i8 phi carrying the
+// masked low byte of canonical and backedge controlCursor values.
+// Complements the existing byteCount=2 control_slot test.
+bool runGeneralizedLoopControlSlotByteCountOneReturnsMaskedPhi(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* preheader =
+      llvm::BasicBlock::Create(context, "preheader", lifter.fnc);
+  auto* backedge =
+      llvm::BasicBlock::Create(context, "backedge", lifter.fnc);
+  auto* loopHeader =
+      llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t canonicalControl = 0x1401AABBCCULL;
+  constexpr uint64_t backedgeControl = 0x1401DDEEFFULL;
+  constexpr uint8_t loCanonical = static_cast<uint8_t>(canonicalControl & 0xFFULL);
+  constexpr uint8_t loBackedge = static_cast<uint8_t>(backedgeControl & 0xFFULL);
+
+  lifter.builder->SetInsertPoint(preheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, canonicalControl));
+  lifter.branch_backup(loopHeader);
+
+  lifter.builder->SetInsertPoint(backedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, backedgeControl));
+  lifter.branch_backup(loopHeader, /*generalized=*/true);
+
+  lifter.load_generalized_backup(loopHeader);
+  lifter.builder->SetInsertPoint(loopHeader);
+  auto* result = lifter.GetMemoryValue(makeI64(context, controlSlot), 8);
+  auto* phi = llvm::dyn_cast<llvm::PHINode>(result);
+  if (!phi || !phi->getType()->isIntegerTy(8)) {
+    details = "  control_slot byteCount=1 should produce an i8 phi\n";
+    return false;
+  }
+  bool sawC = false, sawB = false;
+  for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
+    auto actual = readConstantAPInt(phi->getIncomingValue(i));
+    if (!actual.has_value()) continue;
+    const uint64_t v = actual->getZExtValue();
+    if (v == loCanonical) sawC = true;
+    else if (v == loBackedge) sawB = true;
+  }
+  if (!sawC || !sawB) {
+    details = "  control_slot byteCount=1 phi should carry masked low-byte canonical and backedge values\n";
+    return false;
+  }
+  return true;
+}
+
 // Preserved-register coverage: RDI at index 7 in
 // shouldPreserveGeneralizedBackedgeRegisterIndex. Completes the remaining
 // hot loop_reg_phi lane not yet covered by earlier RCX/RSP/R9/R10/R12/R14 tests.
@@ -5212,6 +5308,7 @@ bool runGeneralizedLoopTargetSlotByteCountTwoReturnsMaskedPhi(
   }
   return true;
 }
+
 
 // retrieve_generalized_loop_control_field_value_impl with byteCount=1
 // yields an i8 phi carrying the masked low byte of canonical and
@@ -6880,6 +6977,8 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runMakeGeneralizedLoopBackupPreservesConcreteRspWhenValuesDiffer);
     runCustom("generalized_loop_control_slot_byte_count_two_returns_masked_phi",
              &InstructionTester::runGeneralizedLoopControlSlotByteCountTwoReturnsMaskedPhi);
+    runCustom("generalized_loop_control_slot_byte_count_one_returns_masked_phi",
+             &InstructionTester::runGeneralizedLoopControlSlotByteCountOneReturnsMaskedPhi);
     runCustom("make_generalized_loop_backup_populates_register_phis_map",
              &InstructionTester::runMakeGeneralizedLoopBackupPopulatesRegisterPhisMap);
     runCustom("make_generalized_loop_backup_populates_flag_phis_map",


### PR DESCRIPTION
Additive coverage only.

## Tests added
- `migrate_generalized_loop_block_copies_multiway_backedge_vector`
- `generalized_loop_migrate_block_copies_multiway_control_field_state`

These exercise the widened SmallVector-based migration paths introduced by multi-way backedges, complementing the existing single-entry migration copy tests.

## Verification
- `python test.py micro`: all 178 pass (was 177)
- `python test.py baseline`: rewrite regression + determinism 42/42 pass
- Themida reference sample: 2544 / 0 / 0 (unchanged)

## Session cumulative total
Baseline 36 -> current branch 129: **+93 loop-related microtests** across this autoresearch session.