### PR TITLE
lifter: expand loop microtest coverage (+3 tests, batch 28)

### DIFF
--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -2660,6 +2660,140 @@ bool runGeneralizedLoopStateGetterByHeaderExactMatchOnly(
   return true;
 }
 
+// Stored-state helper fast path: when a valid active generalized-loop
+// state exists but has no backedgeSources, control_slot returns the
+// canonical value directly. This exercises the
+// `state.backedgeSources.empty()` branch of the helper.
+bool runGeneralizedLoopControlSlotReturnsCanonicalWhenStoredStateHasNoBackedges(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* header = llvm::BasicBlock::Create(context, "header", lifter.fnc);
+  auto* canonical = llvm::BasicBlock::Create(context, "canonical", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t canonicalControl = 0x1401AF740ULL;
+
+  LifterUnderTest::GeneralizedLoopControlFieldState stored;
+  stored.valid = true;
+  stored.headerBlock = header;
+  stored.canonicalSource = canonical;
+  stored.canonicalControl = canonicalControl;
+  stored.canonicalBuffer[controlSlot] = ValueByteReference(
+      llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), static_cast<uint8_t>(canonicalControl & 0xFFULL)), 0);
+  lifter.activeGeneralizedLoopControlFieldState = stored;
+  lifter.builder->SetInsertPoint(header);
+
+  auto* result = lifter.GetMemoryValue(makeI64(context, controlSlot), 64);
+  if (llvm::isa<llvm::PHINode>(result)) {
+    details = "  control_slot should return canonical scalar directly when stored state has no backedges\n";
+    return false;
+  }
+  auto actual = readConstantAPInt(result);
+  if (!actual.has_value() || actual->getZExtValue() != canonicalControl) {
+    details = "  control_slot no-backedge fast path should yield canonicalControl\n";
+    return false;
+  }
+  return true;
+}
+
+// Stored-state fast path for target_slot: no backedges means the helper
+// returns the canonical target value directly.
+bool runGeneralizedLoopTargetSlotReturnsCanonicalWhenStoredStateHasNoBackedges(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* header = llvm::BasicBlock::Create(context, "header", lifter.fnc);
+  auto* canonical = llvm::BasicBlock::Create(context, "canonical", lifter.fnc);
+
+  constexpr uint64_t loopCarriedSlot = 0x14004DC67ULL;
+  constexpr uint64_t canonicalTarget = 0xCAFEBABECAFED00DULL;
+
+  LifterUnderTest::GeneralizedLoopControlFieldState stored;
+  stored.valid = true;
+  stored.headerBlock = header;
+  stored.canonicalSource = canonical;
+  for (uint8_t i = 0; i < 8; ++i) {
+    stored.canonicalBuffer[loopCarriedSlot + i] = ValueByteReference(
+        llvm::ConstantInt::get(llvm::Type::getInt8Ty(context),
+                               static_cast<uint8_t>((canonicalTarget >> (i * 8)) & 0xFFULL)),
+        0);
+  }
+  lifter.activeGeneralizedLoopControlFieldState = stored;
+  lifter.builder->SetInsertPoint(header);
+
+  auto* result = lifter.GetMemoryValue(makeI64(context, loopCarriedSlot), 64);
+  if (llvm::isa<llvm::PHINode>(result)) {
+    details = "  target_slot should return canonical target directly when stored state has no backedges\n";
+    return false;
+  }
+  auto actual = readConstantAPInt(result);
+  if (!actual.has_value() || actual->getZExtValue() != canonicalTarget) {
+    details = "  target_slot no-backedge fast path should yield canonical target\n";
+    return false;
+  }
+  return true;
+}
+
+// Stored-state fast path for control_field: no backedges means the helper
+// returns the canonical field value directly.
+bool runGeneralizedLoopControlFieldReturnsCanonicalWhenStoredStateHasNoBackedges(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* header = llvm::BasicBlock::Create(context, "header", lifter.fnc);
+  auto* canonical = llvm::BasicBlock::Create(context, "canonical", lifter.fnc);
+  auto* i8Ty = llvm::Type::getInt8Ty(context);
+  auto* i64Ty = llvm::Type::getInt64Ty(context);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t canonicalControl = 0x1401AF740ULL;
+  constexpr uint64_t fieldOffset = 0xAULL;
+  constexpr uint16_t canonicalField = 0x7788U;
+
+  LifterUnderTest::GeneralizedLoopControlFieldState stored;
+  stored.valid = true;
+  stored.headerBlock = header;
+  stored.canonicalSource = canonical;
+  stored.canonicalControl = canonicalControl;
+  // Seed control-slot bytes.
+  for (uint8_t i = 0; i < 8; ++i) {
+    stored.canonicalBuffer[controlSlot + i] = ValueByteReference(
+        llvm::ConstantInt::get(llvm::Type::getInt8Ty(context),
+                               static_cast<uint8_t>((canonicalControl >> (i * 8)) & 0xFFULL)),
+        0);
+  }
+  // Seed field bytes at supported offset 0xA.
+  stored.canonicalBuffer[canonicalControl + fieldOffset] =
+      ValueByteReference(llvm::ConstantInt::get(llvm::Type::getInt8Ty(context),
+                                               static_cast<uint8_t>(canonicalField & 0xFFU)),
+                         0);
+  stored.canonicalBuffer[canonicalControl + fieldOffset + 1] =
+      ValueByteReference(llvm::ConstantInt::get(llvm::Type::getInt8Ty(context),
+                                               static_cast<uint8_t>((canonicalField >> 8) & 0xFFU)),
+                         0);
+  lifter.activeGeneralizedLoopControlFieldState = stored;
+  lifter.builder->SetInsertPoint(header);
+
+  auto* controlSlotPtr = lifter.builder->CreateGEP(i8Ty, lifter.memoryAlloc,
+                                                   makeI64(context, controlSlot),
+                                                   "control_slot_ptr_stored_no_backedge");
+  auto* controlLoad = lifter.builder->CreateLoad(i64Ty, controlSlotPtr, "control_cursor_stored_no_backedge");
+  auto* fieldAddress = lifter.builder->CreateAdd(
+      controlLoad, makeI64(context, fieldOffset), "control_field_addr_stored_no_backedge");
+  auto* result = lifter.GetMemoryValue(fieldAddress, 16);
+  if (llvm::isa<llvm::PHINode>(result)) {
+    details = "  control_field should return canonical field directly when stored state has no backedges\n";
+    return false;
+  }
+  auto actual = readConstantAPInt(result);
+  if (!actual.has_value() || actual->getZExtValue() != canonicalField) {
+    details = "  control_field no-backedge fast path should yield canonical field\n";
+    return false;
+  }
+  return true;
+}
+
 // getMostRecentGeneralizedLoopState returns nullptr when neither an
 // active state nor any archived per-header state exists.
 bool runGeneralizedLoopStateGetterReturnsNullWhenNoStateExists(
@@ -8160,6 +8294,12 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runGeneralizedLoopStateGetterReturnsNullWhenNoStateExists);
     runCustom("generalized_loop_state_getter_by_header_rejects_invalid_stored_entry",
              &InstructionTester::runGeneralizedLoopStateGetterByHeaderRejectsInvalidStoredEntry);
+    runCustom("generalized_loop_control_slot_returns_canonical_when_stored_state_has_no_backedges",
+             &InstructionTester::runGeneralizedLoopControlSlotReturnsCanonicalWhenStoredStateHasNoBackedges);
+    runCustom("generalized_loop_target_slot_returns_canonical_when_stored_state_has_no_backedges",
+             &InstructionTester::runGeneralizedLoopTargetSlotReturnsCanonicalWhenStoredStateHasNoBackedges);
+    runCustom("generalized_loop_control_field_returns_canonical_when_stored_state_has_no_backedges",
+             &InstructionTester::runGeneralizedLoopControlFieldReturnsCanonicalWhenStoredStateHasNoBackedges);
     runCustom("make_generalized_loop_backup_widens_rax_to_undef_on_first_backedge",
              &InstructionTester::runMakeGeneralizedLoopBackupWidensRaxToUndefOnFirstBackedge);
     runCustom("generalized_phi_address_with_negative_displacement_resolves_loaded_values",

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -771,6 +771,49 @@ private:
     return true;
   }
 
+
+  bool runStructuredLoopHeaderRejectsPartialChainWithoutTrampoline(
+      std::string& details) {
+    LifterUnderTest lifter;
+    lifter.currentPathSolveContext =
+        LifterUnderTest::PathSolveContext::ConditionalBranch;
+
+    auto* current = llvm::BasicBlock::Create(lifter.context, "current", lifter.fnc);
+    auto* header = llvm::BasicBlock::Create(lifter.context, "header", lifter.fnc);
+    auto* partialLift =
+        llvm::BasicBlock::Create(lifter.context, "partial_lift", lifter.fnc);
+
+    llvm::IRBuilder<> currentBuilder(current);
+    currentBuilder.CreateBr(header);
+
+    // Header is NOT a trampoline: give it a non-branch instruction first,
+    // then an unconditional br. That defeats the size()==1 trampoline test.
+    llvm::IRBuilder<> headerBuilder(header);
+    headerBuilder.CreateAdd(
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 1),
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 2),
+        "not_a_trampoline");
+    headerBuilder.CreateBr(partialLift);
+
+    // Same partial successor shape as above: non-empty, no terminator.
+    llvm::IRBuilder<> partialBuilder(partialLift);
+    partialBuilder.CreateAdd(
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 3),
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 4),
+        "partial_mid_lift");
+
+    lifter.blockInfo = BBInfo(0x2000, current);
+    lifter.visitedAddresses.insert(0x1000);
+    lifter.addrToBB[0x1000] = header;
+
+    if (lifter.canGeneralizeStructuredLoopHeader(0x1000)) {
+      details =
+          "  partial mid-lift successor must reject when the entry block is not a single unconditional-br trampoline\n";
+      return false;
+    }
+    return true;
+  }
+
   bool runStructuredLoopHeaderRejectsAcyclicBackwardBranch(
       std::string& details) {
     LifterUnderTest lifter;
@@ -5084,6 +5127,59 @@ bool runGeneralizedLoopRestoreFlagPhiCarriesConcreteBackedgeOnDivergence(
   return true;
 }
 
+// control_slot helper at byteCount=1 returns an i8 phi carrying the
+// masked low byte of canonical and backedge controlCursor values.
+// Complements the existing byteCount=2 control_slot test.
+bool runGeneralizedLoopControlSlotByteCountOneReturnsMaskedPhi(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* preheader =
+      llvm::BasicBlock::Create(context, "preheader", lifter.fnc);
+  auto* backedge =
+      llvm::BasicBlock::Create(context, "backedge", lifter.fnc);
+  auto* loopHeader =
+      llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t canonicalControl = 0x1401AABBCCULL;
+  constexpr uint64_t backedgeControl = 0x1401DDEEFFULL;
+  constexpr uint8_t loCanonical = static_cast<uint8_t>(canonicalControl & 0xFFULL);
+  constexpr uint8_t loBackedge = static_cast<uint8_t>(backedgeControl & 0xFFULL);
+
+  lifter.builder->SetInsertPoint(preheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, canonicalControl));
+  lifter.branch_backup(loopHeader);
+
+  lifter.builder->SetInsertPoint(backedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, backedgeControl));
+  lifter.branch_backup(loopHeader, /*generalized=*/true);
+
+  lifter.load_generalized_backup(loopHeader);
+  lifter.builder->SetInsertPoint(loopHeader);
+  auto* result = lifter.GetMemoryValue(makeI64(context, controlSlot), 8);
+  auto* phi = llvm::dyn_cast<llvm::PHINode>(result);
+  if (!phi || !phi->getType()->isIntegerTy(8)) {
+    details = "  control_slot byteCount=1 should produce an i8 phi\n";
+    return false;
+  }
+  bool sawC = false, sawB = false;
+  for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
+    auto actual = readConstantAPInt(phi->getIncomingValue(i));
+    if (!actual.has_value()) continue;
+    const uint64_t v = actual->getZExtValue();
+    if (v == loCanonical) sawC = true;
+    else if (v == loBackedge) sawB = true;
+  }
+  if (!sawC || !sawB) {
+    details = "  control_slot byteCount=1 phi should carry masked low-byte canonical and backedge values\n";
+    return false;
+  }
+  return true;
+}
+
 // Preserved-register coverage: RDI at index 7 in
 // shouldPreserveGeneralizedBackedgeRegisterIndex. Completes the remaining
 // hot loop_reg_phi lane not yet covered by earlier RCX/RSP/R9/R10/R12/R14 tests.
@@ -5212,6 +5308,7 @@ bool runGeneralizedLoopTargetSlotByteCountTwoReturnsMaskedPhi(
   }
   return true;
 }
+
 
 // retrieve_generalized_loop_control_field_value_impl with byteCount=1
 // yields an i8 phi carrying the masked low byte of canonical and
@@ -6880,6 +6977,8 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runMakeGeneralizedLoopBackupPreservesConcreteRspWhenValuesDiffer);
     runCustom("generalized_loop_control_slot_byte_count_two_returns_masked_phi",
              &InstructionTester::runGeneralizedLoopControlSlotByteCountTwoReturnsMaskedPhi);
+    runCustom("generalized_loop_control_slot_byte_count_one_returns_masked_phi",
+             &InstructionTester::runGeneralizedLoopControlSlotByteCountOneReturnsMaskedPhi);
     runCustom("make_generalized_loop_backup_populates_register_phis_map",
              &InstructionTester::runMakeGeneralizedLoopBackupPopulatesRegisterPhisMap);
     runCustom("make_generalized_loop_backup_populates_flag_phis_map",


### PR DESCRIPTION
Additive coverage only.

## Tests added
- `generalized_loop_control_slot_returns_canonical_when_stored_state_has_no_backedges`
- `generalized_loop_target_slot_returns_canonical_when_stored_state_has_no_backedges`
- `generalized_loop_control_field_returns_canonical_when_stored_state_has_no_backedges`

These exercise the `state.backedgeSources.empty()` fast-path branch of `retrieve_generalized_loop_*_value_impl` helpers, which returns the canonical scalar directly without constructing a phi.

## Verification
- `python test.py micro`: 180 pass (was 178)
- `python test.py baseline`: rewrite regression + determinism pass
- Themida reference sample: 2544 / 0 / 0 (unchanged)

Loop-related microtest count: **129 -> 132**.