### PR TITLE
lifter: expand loop microtest coverage (+4 tests, batch 32)

### DIFF
--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -3884,6 +3884,188 @@ bool runGeneralizedLoopTargetSlotCollapsesToCanonicalWhenValuesMatch(
   return true;
 }
 
+// target_slot helper with byteCount=1 collapses to a scalar i8 when
+// canonical and backedge buffers hold the same carried value.
+bool runGeneralizedLoopTargetSlotByteCountOneCollapsesWhenValuesMatch(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* preheader =
+      llvm::BasicBlock::Create(context, "preheader", lifter.fnc);
+  auto* backedge =
+      llvm::BasicBlock::Create(context, "backedge", lifter.fnc);
+  auto* loopHeader =
+      llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t loopCarriedSlot = 0x14004DC67ULL;
+  constexpr uint64_t canonicalControl = 0x1401AF740ULL;
+  constexpr uint64_t backedgeControl = 0x1401AF0F6ULL;
+  constexpr uint64_t sharedCarriedValue = 0xDEADBEEFCAFEBA77ULL;
+  constexpr uint8_t lowShared = static_cast<uint8_t>(sharedCarriedValue & 0xFFULL);
+
+  lifter.builder->SetInsertPoint(preheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, canonicalControl));
+  lifter.SetMemoryValue(makeI64(context, loopCarriedSlot),
+                        makeI64(context, sharedCarriedValue));
+  lifter.branch_backup(loopHeader);
+
+  lifter.builder->SetInsertPoint(backedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, backedgeControl));
+  lifter.SetMemoryValue(makeI64(context, loopCarriedSlot),
+                        makeI64(context, sharedCarriedValue));
+  lifter.branch_backup(loopHeader, /*generalized=*/true);
+
+  lifter.load_generalized_backup(loopHeader);
+  lifter.builder->SetInsertPoint(loopHeader);
+  auto* carried = lifter.GetMemoryValue(makeI64(context, loopCarriedSlot), 8);
+  if (llvm::isa<llvm::PHINode>(carried)) {
+    details = "  target_slot byteCount=1 should collapse matching values to a scalar, not a phi\n";
+    return false;
+  }
+  auto actual = readConstantAPInt(carried);
+  if (!actual.has_value() || actual->getZExtValue() != lowShared) {
+    details = "  collapsed target_slot byteCount=1 should carry the shared low byte\n";
+    return false;
+  }
+  return true;
+}
+
+// target_slot helper with byteCount=2 collapses to a scalar i16 when
+// canonical and backedge buffers hold the same carried value.
+bool runGeneralizedLoopTargetSlotByteCountTwoCollapsesWhenValuesMatch(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* preheader =
+      llvm::BasicBlock::Create(context, "preheader", lifter.fnc);
+  auto* backedge =
+      llvm::BasicBlock::Create(context, "backedge", lifter.fnc);
+  auto* loopHeader =
+      llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t loopCarriedSlot = 0x14004DC67ULL;
+  constexpr uint64_t canonicalControl = 0x1401AF740ULL;
+  constexpr uint64_t backedgeControl = 0x1401AF0F6ULL;
+  constexpr uint64_t sharedCarriedValue = 0xDEADBEEFCAFEBA77ULL;
+  constexpr uint16_t lowShared = static_cast<uint16_t>(sharedCarriedValue & 0xFFFFULL);
+
+  lifter.builder->SetInsertPoint(preheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, canonicalControl));
+  lifter.SetMemoryValue(makeI64(context, loopCarriedSlot),
+                        makeI64(context, sharedCarriedValue));
+  lifter.branch_backup(loopHeader);
+
+  lifter.builder->SetInsertPoint(backedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, backedgeControl));
+  lifter.SetMemoryValue(makeI64(context, loopCarriedSlot),
+                        makeI64(context, sharedCarriedValue));
+  lifter.branch_backup(loopHeader, /*generalized=*/true);
+
+  lifter.load_generalized_backup(loopHeader);
+  lifter.builder->SetInsertPoint(loopHeader);
+  auto* carried = lifter.GetMemoryValue(makeI64(context, loopCarriedSlot), 16);
+  if (llvm::isa<llvm::PHINode>(carried)) {
+    details = "  target_slot byteCount=2 should collapse matching values to a scalar, not a phi\n";
+    return false;
+  }
+  auto actual = readConstantAPInt(carried);
+  if (!actual.has_value() || actual->getZExtValue() != lowShared) {
+    details = "  collapsed target_slot byteCount=2 should carry the shared low 16 bits\n";
+    return false;
+  }
+  return true;
+}
+
+// control_slot helper with byteCount=1 collapses to a scalar i8 when
+// canonical and backedge controls match (low byte is shared).
+bool runGeneralizedLoopControlSlotByteCountOneCollapsesWhenValuesMatch(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* preheader =
+      llvm::BasicBlock::Create(context, "preheader", lifter.fnc);
+  auto* backedge =
+      llvm::BasicBlock::Create(context, "backedge", lifter.fnc);
+  auto* loopHeader =
+      llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t sharedControl = 0x1401AF740ULL;
+  constexpr uint8_t lowShared = static_cast<uint8_t>(sharedControl & 0xFFULL);
+
+  lifter.builder->SetInsertPoint(preheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, sharedControl));
+  lifter.branch_backup(loopHeader);
+
+  lifter.builder->SetInsertPoint(backedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, sharedControl));
+  lifter.branch_backup(loopHeader, /*generalized=*/true);
+
+  lifter.load_generalized_backup(loopHeader);
+  lifter.builder->SetInsertPoint(loopHeader);
+  auto* result = lifter.GetMemoryValue(makeI64(context, controlSlot), 8);
+  if (llvm::isa<llvm::PHINode>(result)) {
+    details = "  control_slot byteCount=1 should collapse matching values to a scalar, not a phi\n";
+    return false;
+  }
+  auto actual = readConstantAPInt(result);
+  if (!actual.has_value() || actual->getZExtValue() != lowShared) {
+    details = "  collapsed control_slot byteCount=1 should carry the shared low byte\n";
+    return false;
+  }
+  return true;
+}
+
+// control_slot helper with byteCount=2 collapses to a scalar i16 when
+// canonical and backedge controls match (low 16 bits shared).
+bool runGeneralizedLoopControlSlotByteCountTwoCollapsesWhenValuesMatch(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* preheader =
+      llvm::BasicBlock::Create(context, "preheader", lifter.fnc);
+  auto* backedge =
+      llvm::BasicBlock::Create(context, "backedge", lifter.fnc);
+  auto* loopHeader =
+      llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t sharedControl = 0x1401AF740ULL;
+  constexpr uint16_t lowShared = static_cast<uint16_t>(sharedControl & 0xFFFFULL);
+
+  lifter.builder->SetInsertPoint(preheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, sharedControl));
+  lifter.branch_backup(loopHeader);
+
+  lifter.builder->SetInsertPoint(backedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, sharedControl));
+  lifter.branch_backup(loopHeader, /*generalized=*/true);
+
+  lifter.load_generalized_backup(loopHeader);
+  lifter.builder->SetInsertPoint(loopHeader);
+  auto* result = lifter.GetMemoryValue(makeI64(context, controlSlot), 16);
+  if (llvm::isa<llvm::PHINode>(result)) {
+    details = "  control_slot byteCount=2 should collapse matching values to a scalar, not a phi\n";
+    return false;
+  }
+  auto actual = readConstantAPInt(result);
+  if (!actual.has_value() || actual->getZExtValue() != lowShared) {
+    details = "  collapsed control_slot byteCount=2 should carry the shared low 16 bits\n";
+    return false;
+  }
+  return true;
+}
+
 // retrieve_generalized_loop_local_value_impl returns the concrete local
 // stack-buffer value directly (no phi) when the active buffer contains
 // a tracked value at the address. Exercises the retrieveValueFromBufferSlice
@@ -8607,6 +8789,10 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runMakeGeneralizedLoopBackupPreservesConcreteR12OnFirstBackedge);
     runCustom("generalized_loop_target_slot_collapses_to_canonical_when_values_match",
              &InstructionTester::runGeneralizedLoopTargetSlotCollapsesToCanonicalWhenValuesMatch);
+    runCustom("generalized_loop_target_slot_byte_count_one_collapses_when_values_match",
+             &InstructionTester::runGeneralizedLoopTargetSlotByteCountOneCollapsesWhenValuesMatch);
+    runCustom("generalized_loop_target_slot_byte_count_two_collapses_when_values_match",
+             &InstructionTester::runGeneralizedLoopTargetSlotByteCountTwoCollapsesWhenValuesMatch);
     runCustom("generalized_loop_local_value_returns_concrete_stack_buffer_value",
              &InstructionTester::runGeneralizedLoopLocalValueReturnsConcreteStackBufferValue);
     runCustom("generalized_loop_local_value_returns_concrete_stack_buffer_value_byte_count_one",
@@ -8665,6 +8851,10 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runRecordGeneralizedLoopBackedgeMultiwayNoOpWhenSourceMatchesCanonical);
     runCustom("generalized_loop_control_slot_collapses_when_canonical_matches_backedge_value",
              &InstructionTester::runGeneralizedLoopControlSlotCollapsesWhenCanonicalMatchesBackedgeValue);
+    runCustom("generalized_loop_control_slot_byte_count_one_collapses_when_values_match",
+             &InstructionTester::runGeneralizedLoopControlSlotByteCountOneCollapsesWhenValuesMatch);
+    runCustom("generalized_loop_control_slot_byte_count_two_collapses_when_values_match",
+             &InstructionTester::runGeneralizedLoopControlSlotByteCountTwoCollapsesWhenValuesMatch);
     runCustom("generalized_loop_control_slot_bails_when_canonical_buffer_lacks_slot",
              &InstructionTester::runGeneralizedLoopControlSlotBailsWhenCanonicalBufferLacksSlot);
     runCustom("generalized_loop_control_slot_bails_when_backedge_buffer_lacks_slot",

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -771,6 +771,49 @@ private:
     return true;
   }
 
+
+  bool runStructuredLoopHeaderRejectsPartialChainWithoutTrampoline(
+      std::string& details) {
+    LifterUnderTest lifter;
+    lifter.currentPathSolveContext =
+        LifterUnderTest::PathSolveContext::ConditionalBranch;
+
+    auto* current = llvm::BasicBlock::Create(lifter.context, "current", lifter.fnc);
+    auto* header = llvm::BasicBlock::Create(lifter.context, "header", lifter.fnc);
+    auto* partialLift =
+        llvm::BasicBlock::Create(lifter.context, "partial_lift", lifter.fnc);
+
+    llvm::IRBuilder<> currentBuilder(current);
+    currentBuilder.CreateBr(header);
+
+    // Header is NOT a trampoline: give it a non-branch instruction first,
+    // then an unconditional br. That defeats the size()==1 trampoline test.
+    llvm::IRBuilder<> headerBuilder(header);
+    headerBuilder.CreateAdd(
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 1),
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 2),
+        "not_a_trampoline");
+    headerBuilder.CreateBr(partialLift);
+
+    // Same partial successor shape as above: non-empty, no terminator.
+    llvm::IRBuilder<> partialBuilder(partialLift);
+    partialBuilder.CreateAdd(
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 3),
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 4),
+        "partial_mid_lift");
+
+    lifter.blockInfo = BBInfo(0x2000, current);
+    lifter.visitedAddresses.insert(0x1000);
+    lifter.addrToBB[0x1000] = header;
+
+    if (lifter.canGeneralizeStructuredLoopHeader(0x1000)) {
+      details =
+          "  partial mid-lift successor must reject when the entry block is not a single unconditional-br trampoline\n";
+      return false;
+    }
+    return true;
+  }
+
   bool runStructuredLoopHeaderRejectsAcyclicBackwardBranch(
       std::string& details) {
     LifterUnderTest lifter;
@@ -5084,6 +5127,59 @@ bool runGeneralizedLoopRestoreFlagPhiCarriesConcreteBackedgeOnDivergence(
   return true;
 }
 
+// control_slot helper at byteCount=1 returns an i8 phi carrying the
+// masked low byte of canonical and backedge controlCursor values.
+// Complements the existing byteCount=2 control_slot test.
+bool runGeneralizedLoopControlSlotByteCountOneReturnsMaskedPhi(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* preheader =
+      llvm::BasicBlock::Create(context, "preheader", lifter.fnc);
+  auto* backedge =
+      llvm::BasicBlock::Create(context, "backedge", lifter.fnc);
+  auto* loopHeader =
+      llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t canonicalControl = 0x1401AABBCCULL;
+  constexpr uint64_t backedgeControl = 0x1401DDEEFFULL;
+  constexpr uint8_t loCanonical = static_cast<uint8_t>(canonicalControl & 0xFFULL);
+  constexpr uint8_t loBackedge = static_cast<uint8_t>(backedgeControl & 0xFFULL);
+
+  lifter.builder->SetInsertPoint(preheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, canonicalControl));
+  lifter.branch_backup(loopHeader);
+
+  lifter.builder->SetInsertPoint(backedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, backedgeControl));
+  lifter.branch_backup(loopHeader, /*generalized=*/true);
+
+  lifter.load_generalized_backup(loopHeader);
+  lifter.builder->SetInsertPoint(loopHeader);
+  auto* result = lifter.GetMemoryValue(makeI64(context, controlSlot), 8);
+  auto* phi = llvm::dyn_cast<llvm::PHINode>(result);
+  if (!phi || !phi->getType()->isIntegerTy(8)) {
+    details = "  control_slot byteCount=1 should produce an i8 phi\n";
+    return false;
+  }
+  bool sawC = false, sawB = false;
+  for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
+    auto actual = readConstantAPInt(phi->getIncomingValue(i));
+    if (!actual.has_value()) continue;
+    const uint64_t v = actual->getZExtValue();
+    if (v == loCanonical) sawC = true;
+    else if (v == loBackedge) sawB = true;
+  }
+  if (!sawC || !sawB) {
+    details = "  control_slot byteCount=1 phi should carry masked low-byte canonical and backedge values\n";
+    return false;
+  }
+  return true;
+}
+
 // Preserved-register coverage: RDI at index 7 in
 // shouldPreserveGeneralizedBackedgeRegisterIndex. Completes the remaining
 // hot loop_reg_phi lane not yet covered by earlier RCX/RSP/R9/R10/R12/R14 tests.
@@ -5212,6 +5308,7 @@ bool runGeneralizedLoopTargetSlotByteCountTwoReturnsMaskedPhi(
   }
   return true;
 }
+
 
 // retrieve_generalized_loop_control_field_value_impl with byteCount=1
 // yields an i8 phi carrying the masked low byte of canonical and
@@ -6880,6 +6977,8 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runMakeGeneralizedLoopBackupPreservesConcreteRspWhenValuesDiffer);
     runCustom("generalized_loop_control_slot_byte_count_two_returns_masked_phi",
              &InstructionTester::runGeneralizedLoopControlSlotByteCountTwoReturnsMaskedPhi);
+    runCustom("generalized_loop_control_slot_byte_count_one_returns_masked_phi",
+             &InstructionTester::runGeneralizedLoopControlSlotByteCountOneReturnsMaskedPhi);
     runCustom("make_generalized_loop_backup_populates_register_phis_map",
              &InstructionTester::runMakeGeneralizedLoopBackupPopulatesRegisterPhisMap);
     runCustom("make_generalized_loop_backup_populates_flag_phis_map",


### PR DESCRIPTION
Additive coverage only.

## Tests added
- `generalized_loop_target_slot_byte_count_one_collapses_when_values_match`
- `generalized_loop_target_slot_byte_count_two_collapses_when_values_match`
- `generalized_loop_control_slot_byte_count_one_collapses_when_values_match`
- `generalized_loop_control_slot_byte_count_two_collapses_when_values_match`

Mirrors the control_field_load byte-width collapse matrix onto target_slot and control_slot helpers.

## Verification
- `python test.py micro`: all pass
- `python test.py baseline`: rewrite + determinism pass

Loop-related microtest count: **137 -> 141**.