### PR TITLE
lifter: expand loop microtest coverage (+1 test, batch 39)

### DIFF
--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -2768,6 +2768,86 @@ bool runGeneralizedLoopNestedInnerTargetSlotUsesInnerState(
   return true;
 }
 
+// KNOWN-LIMITATION (nested loops make control_slot read the inner active
+// state, not the queried outer loop state).
+//
+// retrieve_generalized_loop_control_slot_value_impl also reads only the
+// scalar activeGeneralizedLoopControlFieldState. After an inner
+// load_generalized_backup overwrites that scalar, a control-slot read at the
+// outer header resolves using the inner loop's control values.
+//
+// When control_slot gains per-header lazy lookup (or nested active-state
+// stacking), this test MUST fail and be rewritten to assert the fixed
+// contract.
+bool runGeneralizedLoopNestedInnerControlSlotUsesInnerState(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* outerPreheader =
+      llvm::BasicBlock::Create(context, "outer_preheader", lifter.fnc);
+  auto* outerBackedge =
+      llvm::BasicBlock::Create(context, "outer_backedge", lifter.fnc);
+  auto* outerHeader =
+      llvm::BasicBlock::Create(context, "outer_header", lifter.fnc);
+  auto* innerPreheader =
+      llvm::BasicBlock::Create(context, "inner_preheader", lifter.fnc);
+  auto* innerBackedge =
+      llvm::BasicBlock::Create(context, "inner_backedge", lifter.fnc);
+  auto* innerHeader =
+      llvm::BasicBlock::Create(context, "inner_header", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t outerCanonicalControl = 0x1401AF740ULL;
+  constexpr uint64_t outerBackedgeControl = 0x1401AF0F6ULL;
+  constexpr uint64_t innerCanonicalControl = 0x1401BA72CULL;
+  constexpr uint64_t innerBackedgeControl = 0x1401BA97FULL;
+
+  lifter.builder->SetInsertPoint(outerPreheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, outerCanonicalControl));
+  lifter.branch_backup(outerHeader);
+
+  lifter.builder->SetInsertPoint(outerBackedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, outerBackedgeControl));
+  lifter.branch_backup(outerHeader, /*generalized=*/true);
+  lifter.load_generalized_backup(outerHeader);
+
+  lifter.builder->SetInsertPoint(innerPreheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, innerCanonicalControl));
+  lifter.branch_backup(innerHeader);
+
+  lifter.builder->SetInsertPoint(innerBackedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, innerBackedgeControl));
+  lifter.branch_backup(innerHeader, /*generalized=*/true);
+  lifter.load_generalized_backup(innerHeader);
+
+  lifter.builder->SetInsertPoint(outerHeader);
+  auto* control = lifter.GetMemoryValue(makeI64(context, controlSlot), 64);
+  auto* phi = llvm::dyn_cast<llvm::PHINode>(control);
+  if (!phi || phi->getNumIncomingValues() != 2) {
+    details = "  current nested control_slot limitation should still produce the inner 2-way phi\n";
+    return false;
+  }
+  bool sawInnerCanonical = false, sawInnerBackedge = false;
+  for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
+    auto actual = readConstantAPInt(phi->getIncomingValue(i));
+    if (!actual.has_value()) continue;
+    const uint64_t v = actual->getZExtValue();
+    if (v == innerCanonicalControl) sawInnerCanonical = true;
+    else if (v == innerBackedgeControl) sawInnerBackedge = true;
+  }
+  if (!sawInnerCanonical || !sawInnerBackedge) {
+    details =
+        "  nested control_slot limitation should read the inner active state's control values, not the outer state's values\n";
+    return false;
+  }
+  return true;
+}
+
+
 
 // Multi-way rolled-control: record_generalized_loop_backedge appends or
 // updates per body source when the header has >=2 backedges. 1-backedge
@@ -9712,6 +9792,8 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runGeneralizedLoopNestedInnerOverwritesOuterActiveState);
     runCustom("generalized_loop_nested_inner_target_slot_uses_inner_state",
              &InstructionTester::runGeneralizedLoopNestedInnerTargetSlotUsesInnerState);
+    runCustom("generalized_loop_nested_inner_control_slot_uses_inner_state",
+             &InstructionTester::runGeneralizedLoopNestedInnerControlSlotUsesInnerState);
     runCustom("record_generalized_loop_backedge_multiway_appends_new_body_source",
              &InstructionTester::runRecordGeneralizedLoopBackedgeMultiwayAppendsNewBodySource);
     runCustom("generalized_phi_address_three_way_resolves_all_incomings",

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -2674,6 +2674,101 @@ bool runGeneralizedLoopNestedInnerOverwritesOuterActiveState(std::string& detail
   return true;
 }
 
+// KNOWN-LIMITATION (nested loops make target_slot read the inner active
+// state, not the queried outer loop state).
+//
+// retrieve_generalized_loop_target_slot_value_impl reads only
+// activeGeneralizedLoopControlFieldState; unlike the phi-address helpers, it
+// does not do lazy per-header lookup through getGeneralizedLoopStateForHeader.
+// After an inner load_generalized_backup overwrites the scalar active state, a
+// target_slot read at the outer header resolves using the inner loop's
+// carried-slot values.
+//
+// When target_slot gains per-header lazy lookup (or nested active-state
+// stacking), this test MUST fail and be rewritten to assert the fixed
+// contract.
+bool runGeneralizedLoopNestedInnerTargetSlotUsesInnerState(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* outerPreheader =
+      llvm::BasicBlock::Create(context, "outer_preheader", lifter.fnc);
+  auto* outerBackedge =
+      llvm::BasicBlock::Create(context, "outer_backedge", lifter.fnc);
+  auto* outerHeader =
+      llvm::BasicBlock::Create(context, "outer_header", lifter.fnc);
+  auto* innerPreheader =
+      llvm::BasicBlock::Create(context, "inner_preheader", lifter.fnc);
+  auto* innerBackedge =
+      llvm::BasicBlock::Create(context, "inner_backedge", lifter.fnc);
+  auto* innerHeader =
+      llvm::BasicBlock::Create(context, "inner_header", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t loopCarriedSlot = 0x14004DC67ULL;
+  constexpr uint64_t outerCanonicalControl = 0x1401AF740ULL;
+  constexpr uint64_t outerBackedgeControl = 0x1401AF0F6ULL;
+  constexpr uint64_t innerCanonicalControl = 0x1401BA72CULL;
+  constexpr uint64_t innerBackedgeControl = 0x1401BA97FULL;
+  constexpr uint64_t outerCanonicalTarget = 0x1111111111111111ULL;
+  constexpr uint64_t outerBackedgeTarget = 0x2222222222222222ULL;
+  constexpr uint64_t innerCanonicalTarget = 0x3333333333333333ULL;
+  constexpr uint64_t innerBackedgeTarget = 0x4444444444444444ULL;
+
+  lifter.builder->SetInsertPoint(outerPreheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, outerCanonicalControl));
+  lifter.SetMemoryValue(makeI64(context, loopCarriedSlot),
+                        makeI64(context, outerCanonicalTarget));
+  lifter.branch_backup(outerHeader);
+
+  lifter.builder->SetInsertPoint(outerBackedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, outerBackedgeControl));
+  lifter.SetMemoryValue(makeI64(context, loopCarriedSlot),
+                        makeI64(context, outerBackedgeTarget));
+  lifter.branch_backup(outerHeader, /*generalized=*/true);
+  lifter.load_generalized_backup(outerHeader);
+
+  lifter.builder->SetInsertPoint(innerPreheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, innerCanonicalControl));
+  lifter.SetMemoryValue(makeI64(context, loopCarriedSlot),
+                        makeI64(context, innerCanonicalTarget));
+  lifter.branch_backup(innerHeader);
+
+  lifter.builder->SetInsertPoint(innerBackedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, innerBackedgeControl));
+  lifter.SetMemoryValue(makeI64(context, loopCarriedSlot),
+                        makeI64(context, innerBackedgeTarget));
+  lifter.branch_backup(innerHeader, /*generalized=*/true);
+  lifter.load_generalized_backup(innerHeader);
+
+  lifter.builder->SetInsertPoint(outerHeader);
+  auto* carried = lifter.GetMemoryValue(makeI64(context, loopCarriedSlot), 64);
+  auto* phi = llvm::dyn_cast<llvm::PHINode>(carried);
+  if (!phi || phi->getNumIncomingValues() != 2) {
+    details = "  current nested target_slot limitation should still produce the inner 2-way phi\n";
+    return false;
+  }
+  bool sawInnerCanonical = false, sawInnerBackedge = false;
+  for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
+    auto actual = readConstantAPInt(phi->getIncomingValue(i));
+    if (!actual.has_value()) continue;
+    const uint64_t v = actual->getZExtValue();
+    if (v == innerCanonicalTarget) sawInnerCanonical = true;
+    else if (v == innerBackedgeTarget) sawInnerBackedge = true;
+  }
+  if (!sawInnerCanonical || !sawInnerBackedge) {
+    details =
+        "  nested target_slot limitation should read the inner active state's carried values, not the outer state's values\n";
+    return false;
+  }
+  return true;
+}
+
+
 // Multi-way rolled-control: record_generalized_loop_backedge appends or
 // updates per body source when the header has >=2 backedges. 1-backedge
 // loops keep the original rotation semantics (promote backedge into
@@ -9615,6 +9710,8 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runGeneralizedLoopNonThemidaControlSlotProducesNoPhi);
     runCustom("generalized_loop_nested_inner_overwrites_outer_active_state",
              &InstructionTester::runGeneralizedLoopNestedInnerOverwritesOuterActiveState);
+    runCustom("generalized_loop_nested_inner_target_slot_uses_inner_state",
+             &InstructionTester::runGeneralizedLoopNestedInnerTargetSlotUsesInnerState);
     runCustom("record_generalized_loop_backedge_multiway_appends_new_body_source",
              &InstructionTester::runRecordGeneralizedLoopBackedgeMultiwayAppendsNewBodySource);
     runCustom("generalized_phi_address_three_way_resolves_all_incomings",

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -771,6 +771,49 @@ private:
     return true;
   }
 
+
+  bool runStructuredLoopHeaderRejectsPartialChainWithoutTrampoline(
+      std::string& details) {
+    LifterUnderTest lifter;
+    lifter.currentPathSolveContext =
+        LifterUnderTest::PathSolveContext::ConditionalBranch;
+
+    auto* current = llvm::BasicBlock::Create(lifter.context, "current", lifter.fnc);
+    auto* header = llvm::BasicBlock::Create(lifter.context, "header", lifter.fnc);
+    auto* partialLift =
+        llvm::BasicBlock::Create(lifter.context, "partial_lift", lifter.fnc);
+
+    llvm::IRBuilder<> currentBuilder(current);
+    currentBuilder.CreateBr(header);
+
+    // Header is NOT a trampoline: give it a non-branch instruction first,
+    // then an unconditional br. That defeats the size()==1 trampoline test.
+    llvm::IRBuilder<> headerBuilder(header);
+    headerBuilder.CreateAdd(
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 1),
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 2),
+        "not_a_trampoline");
+    headerBuilder.CreateBr(partialLift);
+
+    // Same partial successor shape as above: non-empty, no terminator.
+    llvm::IRBuilder<> partialBuilder(partialLift);
+    partialBuilder.CreateAdd(
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 3),
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 4),
+        "partial_mid_lift");
+
+    lifter.blockInfo = BBInfo(0x2000, current);
+    lifter.visitedAddresses.insert(0x1000);
+    lifter.addrToBB[0x1000] = header;
+
+    if (lifter.canGeneralizeStructuredLoopHeader(0x1000)) {
+      details =
+          "  partial mid-lift successor must reject when the entry block is not a single unconditional-br trampoline\n";
+      return false;
+    }
+    return true;
+  }
+
   bool runStructuredLoopHeaderRejectsAcyclicBackwardBranch(
       std::string& details) {
     LifterUnderTest lifter;
@@ -5084,6 +5127,59 @@ bool runGeneralizedLoopRestoreFlagPhiCarriesConcreteBackedgeOnDivergence(
   return true;
 }
 
+// control_slot helper at byteCount=1 returns an i8 phi carrying the
+// masked low byte of canonical and backedge controlCursor values.
+// Complements the existing byteCount=2 control_slot test.
+bool runGeneralizedLoopControlSlotByteCountOneReturnsMaskedPhi(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* preheader =
+      llvm::BasicBlock::Create(context, "preheader", lifter.fnc);
+  auto* backedge =
+      llvm::BasicBlock::Create(context, "backedge", lifter.fnc);
+  auto* loopHeader =
+      llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t canonicalControl = 0x1401AABBCCULL;
+  constexpr uint64_t backedgeControl = 0x1401DDEEFFULL;
+  constexpr uint8_t loCanonical = static_cast<uint8_t>(canonicalControl & 0xFFULL);
+  constexpr uint8_t loBackedge = static_cast<uint8_t>(backedgeControl & 0xFFULL);
+
+  lifter.builder->SetInsertPoint(preheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, canonicalControl));
+  lifter.branch_backup(loopHeader);
+
+  lifter.builder->SetInsertPoint(backedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, backedgeControl));
+  lifter.branch_backup(loopHeader, /*generalized=*/true);
+
+  lifter.load_generalized_backup(loopHeader);
+  lifter.builder->SetInsertPoint(loopHeader);
+  auto* result = lifter.GetMemoryValue(makeI64(context, controlSlot), 8);
+  auto* phi = llvm::dyn_cast<llvm::PHINode>(result);
+  if (!phi || !phi->getType()->isIntegerTy(8)) {
+    details = "  control_slot byteCount=1 should produce an i8 phi\n";
+    return false;
+  }
+  bool sawC = false, sawB = false;
+  for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
+    auto actual = readConstantAPInt(phi->getIncomingValue(i));
+    if (!actual.has_value()) continue;
+    const uint64_t v = actual->getZExtValue();
+    if (v == loCanonical) sawC = true;
+    else if (v == loBackedge) sawB = true;
+  }
+  if (!sawC || !sawB) {
+    details = "  control_slot byteCount=1 phi should carry masked low-byte canonical and backedge values\n";
+    return false;
+  }
+  return true;
+}
+
 // Preserved-register coverage: RDI at index 7 in
 // shouldPreserveGeneralizedBackedgeRegisterIndex. Completes the remaining
 // hot loop_reg_phi lane not yet covered by earlier RCX/RSP/R9/R10/R12/R14 tests.
@@ -5212,6 +5308,7 @@ bool runGeneralizedLoopTargetSlotByteCountTwoReturnsMaskedPhi(
   }
   return true;
 }
+
 
 // retrieve_generalized_loop_control_field_value_impl with byteCount=1
 // yields an i8 phi carrying the masked low byte of canonical and
@@ -6880,6 +6977,8 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runMakeGeneralizedLoopBackupPreservesConcreteRspWhenValuesDiffer);
     runCustom("generalized_loop_control_slot_byte_count_two_returns_masked_phi",
              &InstructionTester::runGeneralizedLoopControlSlotByteCountTwoReturnsMaskedPhi);
+    runCustom("generalized_loop_control_slot_byte_count_one_returns_masked_phi",
+             &InstructionTester::runGeneralizedLoopControlSlotByteCountOneReturnsMaskedPhi);
     runCustom("make_generalized_loop_backup_populates_register_phis_map",
              &InstructionTester::runMakeGeneralizedLoopBackupPopulatesRegisterPhisMap);
     runCustom("make_generalized_loop_backup_populates_flag_phis_map",


### PR DESCRIPTION
Additive coverage only.

## Tests added
- `generalized_loop_nested_inner_target_slot_uses_inner_state`
- `generalized_loop_nested_inner_control_slot_uses_inner_state`

These are helper-specific nested-loop known-limitation tests. `retrieve_generalized_loop_target_slot_value_impl()` and `retrieve_generalized_loop_control_slot_value_impl()` currently read only the scalar active generalized-loop state, so after an inner `load_generalized_backup()` overwrites that state, outer-header reads resolve using the inner loop's values.

## Verification
- `bash autoresearch.sh`: `loop_test_count=156`, `microtest_pass_count=205`
- `bash autoresearch.checks.sh` with `CLANG_CL_EXE='C:/Program Files/LLVM/bin/clang-cl.exe'`: baseline + determinism OK

Loop-related microtest count: **154 -> 156**.