### PR TITLE
lifter: expand loop microtest coverage (+2 tests, batch 42)

### DIFF
--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -2984,6 +2984,135 @@ bool runGeneralizedLoopControlFieldIgnoresBaseCandidate(std::string& details) {
   return true;
 }
 
+// KNOWN-LIMITATION (control_slot helper does not require the current block
+// to be the active generalized-loop header).
+//
+// retrieve_generalized_loop_control_slot_value_impl reads only the scalar
+// active state and builds its phi into state.headerBlock. A read from an
+// unrelated block still returns the generalized control-slot phi instead of
+// falling through.
+//
+// When control_slot starts validating the current insertion block against the
+// active header (or otherwise scopes helper use correctly), this test MUST
+// fail and be rewritten to assert the fixed contract.
+bool runGeneralizedLoopControlSlotUsesActiveStateFromUnrelatedBlock(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* preheader =
+      llvm::BasicBlock::Create(context, "preheader", lifter.fnc);
+  auto* backedge =
+      llvm::BasicBlock::Create(context, "backedge", lifter.fnc);
+  auto* loopHeader =
+      llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
+  auto* unrelated =
+      llvm::BasicBlock::Create(context, "unrelated", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t canonicalControl = 0x1401AF740ULL;
+  constexpr uint64_t backedgeControl = 0x1401AF0F6ULL;
+
+  lifter.builder->SetInsertPoint(preheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, canonicalControl));
+  lifter.branch_backup(loopHeader);
+
+  lifter.builder->SetInsertPoint(backedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, backedgeControl));
+  lifter.branch_backup(loopHeader, /*generalized=*/true);
+  lifter.load_generalized_backup(loopHeader);
+
+  lifter.builder->SetInsertPoint(unrelated);
+  auto* result = lifter.GetMemoryValue(makeI64(context, controlSlot), 64);
+  auto* phi = llvm::dyn_cast<llvm::PHINode>(result);
+  if (!phi) {
+    details = "  current control_slot limitation should still produce a generalized phi from an unrelated block\n";
+    return false;
+  }
+  bool sawCanonical = false, sawBackedge = false;
+  for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
+    auto actual = readConstantAPInt(phi->getIncomingValue(i));
+    if (!actual.has_value()) continue;
+    const uint64_t v = actual->getZExtValue();
+    if (v == canonicalControl) sawCanonical = true;
+    else if (v == backedgeControl) sawBackedge = true;
+  }
+  if (!sawCanonical || !sawBackedge) {
+    details = "  unrelated-block control_slot limitation should still use canonical/backedge active-state values\n";
+    return false;
+  }
+  return true;
+}
+
+// KNOWN-LIMITATION (target_slot helper does not require the current block
+// to be the active generalized-loop header).
+//
+// retrieve_generalized_loop_target_slot_value_impl also reads only the
+// scalar active state. A carried-slot read from an unrelated block still
+// returns the generalized target-slot phi instead of falling through.
+//
+// When target_slot starts validating the current insertion block against the
+// active header (or otherwise scopes helper use correctly), this test MUST
+// fail and be rewritten to assert the fixed contract.
+bool runGeneralizedLoopTargetSlotUsesActiveStateFromUnrelatedBlock(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* preheader =
+      llvm::BasicBlock::Create(context, "preheader", lifter.fnc);
+  auto* backedge =
+      llvm::BasicBlock::Create(context, "backedge", lifter.fnc);
+  auto* loopHeader =
+      llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
+  auto* unrelated =
+      llvm::BasicBlock::Create(context, "unrelated", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t loopCarriedSlot = 0x14004DC67ULL;
+  constexpr uint64_t canonicalControl = 0x1401AF740ULL;
+  constexpr uint64_t backedgeControl = 0x1401AF0F6ULL;
+  constexpr uint64_t canonicalTarget = 0x1111222233334444ULL;
+  constexpr uint64_t backedgeTarget = 0xAAAABBBBCCCCDDDDULL;
+
+  lifter.builder->SetInsertPoint(preheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, canonicalControl));
+  lifter.SetMemoryValue(makeI64(context, loopCarriedSlot),
+                        makeI64(context, canonicalTarget));
+  lifter.branch_backup(loopHeader);
+
+  lifter.builder->SetInsertPoint(backedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, backedgeControl));
+  lifter.SetMemoryValue(makeI64(context, loopCarriedSlot),
+                        makeI64(context, backedgeTarget));
+  lifter.branch_backup(loopHeader, /*generalized=*/true);
+  lifter.load_generalized_backup(loopHeader);
+
+  lifter.builder->SetInsertPoint(unrelated);
+  auto* result = lifter.GetMemoryValue(makeI64(context, loopCarriedSlot), 64);
+  auto* phi = llvm::dyn_cast<llvm::PHINode>(result);
+  if (!phi) {
+    details = "  current target_slot limitation should still produce a generalized phi from an unrelated block\n";
+    return false;
+  }
+  bool sawCanonical = false, sawBackedge = false;
+  for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
+    auto actual = readConstantAPInt(phi->getIncomingValue(i));
+    if (!actual.has_value()) continue;
+    const uint64_t v = actual->getZExtValue();
+    if (v == canonicalTarget) sawCanonical = true;
+    else if (v == backedgeTarget) sawBackedge = true;
+  }
+  if (!sawCanonical || !sawBackedge) {
+    details = "  unrelated-block target_slot limitation should still use canonical/backedge carried values\n";
+    return false;
+  }
+  return true;
+}
+
+
 
 
 
@@ -9933,6 +10062,10 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runGeneralizedLoopNestedInnerTargetSlotUsesInnerState);
     runCustom("generalized_loop_nested_inner_control_slot_uses_inner_state",
              &InstructionTester::runGeneralizedLoopNestedInnerControlSlotUsesInnerState);
+    runCustom("generalized_loop_control_slot_uses_active_state_from_unrelated_block",
+             &InstructionTester::runGeneralizedLoopControlSlotUsesActiveStateFromUnrelatedBlock);
+    runCustom("generalized_loop_target_slot_uses_active_state_from_unrelated_block",
+             &InstructionTester::runGeneralizedLoopTargetSlotUsesActiveStateFromUnrelatedBlock);
     runCustom("record_generalized_loop_backedge_multiway_appends_new_body_source",
              &InstructionTester::runRecordGeneralizedLoopBackedgeMultiwayAppendsNewBodySource);
     runCustom("generalized_phi_address_three_way_resolves_all_incomings",

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -2847,6 +2847,81 @@ bool runGeneralizedLoopNestedInnerControlSlotUsesInnerState(
   return true;
 }
 
+// KNOWN-LIMITATION (nested loops make local_value read the inner active
+// local buffer, not the queried outer loop state).
+//
+// retrieve_generalized_loop_local_value_impl() reads only
+// activeGeneralizedLoopLocalBuffer. After an inner load_generalized_backup
+// overwrites that buffer, a local stack-slot read at the outer header
+// resolves using the inner loop's tracked local bytes.
+//
+// When local-value lookup gains per-header lazy lookup (or nested active
+// local-buffer stacking), this test MUST fail and be rewritten to assert the
+// fixed contract.
+bool runGeneralizedLoopNestedInnerLocalValueUsesInnerState(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* outerPreheader =
+      llvm::BasicBlock::Create(context, "outer_preheader", lifter.fnc);
+  auto* outerBackedge =
+      llvm::BasicBlock::Create(context, "outer_backedge", lifter.fnc);
+  auto* outerHeader =
+      llvm::BasicBlock::Create(context, "outer_header", lifter.fnc);
+  auto* innerPreheader =
+      llvm::BasicBlock::Create(context, "inner_preheader", lifter.fnc);
+  auto* innerBackedge =
+      llvm::BasicBlock::Create(context, "inner_backedge", lifter.fnc);
+  auto* innerHeader =
+      llvm::BasicBlock::Create(context, "inner_header", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t outerCanonicalControl = 0x1401AF740ULL;
+  constexpr uint64_t outerBackedgeControl = 0x1401AF0F6ULL;
+  constexpr uint64_t innerCanonicalControl = 0x1401BA72CULL;
+  constexpr uint64_t innerBackedgeControl = 0x1401BA97FULL;
+  constexpr uint64_t localAddr = STACKP_VALUE + 24;
+  constexpr uint64_t outerLocalValue = 0x1111222233334444ULL;
+  constexpr uint64_t innerLocalValue = 0xAAAABBBBCCCCDDDDULL;
+
+  lifter.builder->SetInsertPoint(outerPreheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, outerCanonicalControl));
+  lifter.branch_backup(outerHeader);
+
+  lifter.builder->SetInsertPoint(outerBackedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, outerBackedgeControl));
+  lifter.SetMemoryValue(makeI64(context, localAddr),
+                        makeI64(context, outerLocalValue));
+  lifter.branch_backup(outerHeader, /*generalized=*/true);
+  lifter.load_generalized_backup(outerHeader);
+
+  lifter.builder->SetInsertPoint(innerPreheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, innerCanonicalControl));
+  lifter.branch_backup(innerHeader);
+
+  lifter.builder->SetInsertPoint(innerBackedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, innerBackedgeControl));
+  lifter.SetMemoryValue(makeI64(context, localAddr),
+                        makeI64(context, innerLocalValue));
+  lifter.branch_backup(innerHeader, /*generalized=*/true);
+  lifter.load_generalized_backup(innerHeader);
+
+  lifter.builder->SetInsertPoint(outerHeader);
+  auto* result = lifter.GetMemoryValue(makeI64(context, localAddr), 64);
+  auto actual = readConstantAPInt(result);
+  if (!actual.has_value() || actual->getZExtValue() != innerLocalValue) {
+    details =
+        "  nested local_value limitation should read the inner active local buffer's value, not the outer loop's value\n";
+    return false;
+  }
+  return true;
+}
+
+
 
 
 // Multi-way rolled-control: record_generalized_loop_backedge appends or
@@ -9876,6 +9951,8 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runGeneralizedLoopLocalValueReturnsConcreteStackBufferValue);
     runCustom("generalized_loop_local_value_returns_concrete_stack_buffer_value_byte_count_one",
              &InstructionTester::runGeneralizedLoopLocalValueReturnsConcreteStackBufferValueByteCountOne);
+    runCustom("generalized_loop_nested_inner_local_value_uses_inner_state",
+             &InstructionTester::runGeneralizedLoopNestedInnerLocalValueUsesInnerState);
     runCustom("generalized_loop_load_generalized_backup_moves_local_bytes_to_active_local_buffer",
              &InstructionTester::runGeneralizedLoopLoadGeneralizedBackupMovesLocalBytesToActiveLocalBuffer);
     runCustom("generalized_loop_load_generalized_backup_seeds_invariant_local_qword",

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -771,6 +771,49 @@ private:
     return true;
   }
 
+
+  bool runStructuredLoopHeaderRejectsPartialChainWithoutTrampoline(
+      std::string& details) {
+    LifterUnderTest lifter;
+    lifter.currentPathSolveContext =
+        LifterUnderTest::PathSolveContext::ConditionalBranch;
+
+    auto* current = llvm::BasicBlock::Create(lifter.context, "current", lifter.fnc);
+    auto* header = llvm::BasicBlock::Create(lifter.context, "header", lifter.fnc);
+    auto* partialLift =
+        llvm::BasicBlock::Create(lifter.context, "partial_lift", lifter.fnc);
+
+    llvm::IRBuilder<> currentBuilder(current);
+    currentBuilder.CreateBr(header);
+
+    // Header is NOT a trampoline: give it a non-branch instruction first,
+    // then an unconditional br. That defeats the size()==1 trampoline test.
+    llvm::IRBuilder<> headerBuilder(header);
+    headerBuilder.CreateAdd(
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 1),
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 2),
+        "not_a_trampoline");
+    headerBuilder.CreateBr(partialLift);
+
+    // Same partial successor shape as above: non-empty, no terminator.
+    llvm::IRBuilder<> partialBuilder(partialLift);
+    partialBuilder.CreateAdd(
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 3),
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(lifter.context), 4),
+        "partial_mid_lift");
+
+    lifter.blockInfo = BBInfo(0x2000, current);
+    lifter.visitedAddresses.insert(0x1000);
+    lifter.addrToBB[0x1000] = header;
+
+    if (lifter.canGeneralizeStructuredLoopHeader(0x1000)) {
+      details =
+          "  partial mid-lift successor must reject when the entry block is not a single unconditional-br trampoline\n";
+      return false;
+    }
+    return true;
+  }
+
   bool runStructuredLoopHeaderRejectsAcyclicBackwardBranch(
       std::string& details) {
     LifterUnderTest lifter;
@@ -5084,6 +5127,59 @@ bool runGeneralizedLoopRestoreFlagPhiCarriesConcreteBackedgeOnDivergence(
   return true;
 }
 
+// control_slot helper at byteCount=1 returns an i8 phi carrying the
+// masked low byte of canonical and backedge controlCursor values.
+// Complements the existing byteCount=2 control_slot test.
+bool runGeneralizedLoopControlSlotByteCountOneReturnsMaskedPhi(
+    std::string& details) {
+  LifterUnderTest lifter;
+  auto& context = lifter.context;
+  auto* preheader =
+      llvm::BasicBlock::Create(context, "preheader", lifter.fnc);
+  auto* backedge =
+      llvm::BasicBlock::Create(context, "backedge", lifter.fnc);
+  auto* loopHeader =
+      llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
+
+  constexpr uint64_t controlSlot = 0x14004DD19ULL;
+  constexpr uint64_t canonicalControl = 0x1401AABBCCULL;
+  constexpr uint64_t backedgeControl = 0x1401DDEEFFULL;
+  constexpr uint8_t loCanonical = static_cast<uint8_t>(canonicalControl & 0xFFULL);
+  constexpr uint8_t loBackedge = static_cast<uint8_t>(backedgeControl & 0xFFULL);
+
+  lifter.builder->SetInsertPoint(preheader);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, canonicalControl));
+  lifter.branch_backup(loopHeader);
+
+  lifter.builder->SetInsertPoint(backedge);
+  lifter.SetMemoryValue(makeI64(context, controlSlot),
+                        makeI64(context, backedgeControl));
+  lifter.branch_backup(loopHeader, /*generalized=*/true);
+
+  lifter.load_generalized_backup(loopHeader);
+  lifter.builder->SetInsertPoint(loopHeader);
+  auto* result = lifter.GetMemoryValue(makeI64(context, controlSlot), 8);
+  auto* phi = llvm::dyn_cast<llvm::PHINode>(result);
+  if (!phi || !phi->getType()->isIntegerTy(8)) {
+    details = "  control_slot byteCount=1 should produce an i8 phi\n";
+    return false;
+  }
+  bool sawC = false, sawB = false;
+  for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
+    auto actual = readConstantAPInt(phi->getIncomingValue(i));
+    if (!actual.has_value()) continue;
+    const uint64_t v = actual->getZExtValue();
+    if (v == loCanonical) sawC = true;
+    else if (v == loBackedge) sawB = true;
+  }
+  if (!sawC || !sawB) {
+    details = "  control_slot byteCount=1 phi should carry masked low-byte canonical and backedge values\n";
+    return false;
+  }
+  return true;
+}
+
 // Preserved-register coverage: RDI at index 7 in
 // shouldPreserveGeneralizedBackedgeRegisterIndex. Completes the remaining
 // hot loop_reg_phi lane not yet covered by earlier RCX/RSP/R9/R10/R12/R14 tests.
@@ -5212,6 +5308,7 @@ bool runGeneralizedLoopTargetSlotByteCountTwoReturnsMaskedPhi(
   }
   return true;
 }
+
 
 // retrieve_generalized_loop_control_field_value_impl with byteCount=1
 // yields an i8 phi carrying the masked low byte of canonical and
@@ -6880,6 +6977,8 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runMakeGeneralizedLoopBackupPreservesConcreteRspWhenValuesDiffer);
     runCustom("generalized_loop_control_slot_byte_count_two_returns_masked_phi",
              &InstructionTester::runGeneralizedLoopControlSlotByteCountTwoReturnsMaskedPhi);
+    runCustom("generalized_loop_control_slot_byte_count_one_returns_masked_phi",
+             &InstructionTester::runGeneralizedLoopControlSlotByteCountOneReturnsMaskedPhi);
     runCustom("make_generalized_loop_backup_populates_register_phis_map",
              &InstructionTester::runMakeGeneralizedLoopBackupPopulatesRegisterPhisMap);
     runCustom("make_generalized_loop_backup_populates_flag_phis_map",


### PR DESCRIPTION
Additive coverage only.

Tests added:
- `generalized_loop_control_slot_uses_active_state_from_unrelated_block`
- `generalized_loop_target_slot_uses_active_state_from_unrelated_block`

These are helper-scoping known-limitation tests. The current control_slot and target_slot helpers consult only the scalar active generalized-loop state and do not validate that the current insertion block is the active header. Reads from unrelated blocks therefore still return generalized loop phis instead of falling through.

Verification:
- `bash autoresearch.sh`: `loop_test_count=160`, `microtest_pass_count=209`
- `bash autoresearch.checks.sh` with `CLANG_CL_EXE='C:/Program Files/LLVM/bin/clang-cl.exe'`: baseline + determinism OK

Loop-related microtest count: **158 -> 160**.