### PR TITLE
lifter: expand loop microtest coverage (+1 test, batch 49)

### DIFF
--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -1659,6 +1659,28 @@ bool runStructuredLoopHeaderRejectsCycleInChain(std::string& details) {
     return true;
   }
 
+  bool runComputePossibleValuesEmptyLoopPhiReturnsEmptySet(std::string& details) {
+    LifterUnderTest lifter;
+    auto& context = lifter.context;
+    auto* i64Ty = llvm::Type::getInt64Ty(context);
+    auto* header = llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
+
+    lifter.builder->SetInsertPoint(header);
+    llvm::IRBuilder<> phiBuilder(header, header->begin());
+    auto* emptyPhi = phiBuilder.CreatePHI(i64Ty, 0, "empty_loop_phi");
+    lifter.builder->CreateRetVoid();
+
+    auto values = lifter.computePossibleValues(emptyPhi, 0);
+    if (!values.empty()) {
+      std::ostringstream os;
+      os << "  empty loop phi should produce no possible values, got size "
+         << values.size() << "\n";
+      details = os.str();
+      return false;
+    }
+    return true;
+  }
+
   bool runComputePossibleValuesTruncToI1PreservesWidth(std::string& details) {
     LifterUnderTest lifter;
     auto& context = lifter.context;
@@ -10713,6 +10735,8 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runComputePossibleValuesEnumeratesPhiIncomings);
     runCustom("compute_possible_values_circular_phi_bails_via_depth_guard",
              &InstructionTester::runComputePossibleValuesCircularPhiBailsViaDepthGuard);
+    runCustom("compute_possible_values_empty_loop_phi_returns_empty_set",
+             &InstructionTester::runComputePossibleValuesEmptyLoopPhiReturnsEmptySet);
     runCustom("compute_possible_values_trunc_to_i1_preserves_width",
              &InstructionTester::runComputePossibleValuesTruncToI1PreservesWidth);
     runCustom("generalized_loop_control_field_load_creates_phi",


### PR DESCRIPTION
Adds one focused loop/value-tracking microtest in lifter/test/Tester.hpp:\n\n- compute_possible_values_empty_loop_phi_returns_empty_set covers the PHINode path in computePossibleValues for a loop-header PHI with zero incoming values, verifying it returns an empty set instead of inventing a target or crashing.\n\nVerification:\n- bash autoresearch.sh -> METRIC loop_test_count=168, METRIC microtest_pass_count=216\n- CLANG_CL_EXE=C:/Program Files/LLVM/bin/clang-cl.exe bash autoresearch.checks.sh -> baseline + determinism OK\n\nNote: run_experiment stdout/check capture is still empty in this harness, so run #72 was logged as checks_failed with proxy_bash ground truth.