### PR TITLE
lifter: expand loop microtest coverage (+2 tests, batch 50)

### DIFF
--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -814,6 +814,38 @@ private:
     return true;
   }
 
+  bool runStructuredLoopHeaderAllowsPartialChainAfterTrampoline(
+      std::string& details) {
+    LifterUnderTest lifter;
+    lifter.currentPathSolveContext =
+        LifterUnderTest::PathSolveContext::DirectJump;
+
+    auto* trampoline =
+        llvm::BasicBlock::Create(lifter.context, "loop_trampoline", lifter.fnc);
+    auto* partialLift =
+        llvm::BasicBlock::Create(lifter.context, "partial_lift", lifter.fnc);
+
+    llvm::IRBuilder<> trampolineBuilder(trampoline);
+    trampolineBuilder.CreateBr(partialLift);
+
+    // Non-empty but unterminated: this mirrors a mid-lift successor reached
+    // through a one-instruction trampoline header.
+    llvm::IRBuilder<> partialBuilder(partialLift);
+    partialBuilder.CreateAlloca(
+        llvm::Type::getInt64Ty(lifter.context), nullptr, "partial_mid_lift");
+
+    lifter.blockInfo = BBInfo(0x2000, partialLift);
+    lifter.visitedAddresses.insert(0x1000);
+    lifter.addrToBB[0x1000] = trampoline;
+
+    if (!lifter.canGeneralizeStructuredLoopHeader(0x1000)) {
+      details =
+          "  partial mid-lift successor should be accepted after a single unconditional-br trampoline\n";
+      return false;
+    }
+    return true;
+  }
+
   bool runStructuredLoopHeaderRejectsAcyclicBackwardBranch(
       std::string& details) {
     LifterUnderTest lifter;
@@ -10446,6 +10478,10 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runGeneralizedLocalPhiAddressByteCountTwoReturnsMaskedPhi);
     runCustom("structured_loop_header_allows_jump_chain",
              &InstructionTester::runStructuredLoopHeaderAllowsJumpChain);
+    runCustom("structured_loop_header_rejects_partial_chain_without_trampoline",
+             &InstructionTester::runStructuredLoopHeaderRejectsPartialChainWithoutTrampoline);
+    runCustom("structured_loop_header_allows_partial_chain_after_trampoline",
+             &InstructionTester::runStructuredLoopHeaderAllowsPartialChainAfterTrampoline);
 
     runCustom("structured_loop_header_rejects_acyclic_backward_branch",
              &InstructionTester::runStructuredLoopHeaderRejectsAcyclicBackwardBranch);


### PR DESCRIPTION
Adds/activates two structured-loop microtests in lifter/test/Tester.hpp:\n\n- structured_loop_header_rejects_partial_chain_without_trampoline registers the existing rejection test for partial mid-lift successors without a trampoline header.\n- structured_loop_header_allows_partial_chain_after_trampoline adds the positive counterpart for the trampoline-header relaxation with a non-empty unterminated mid-lift successor.\n\nVerification:\n- bash autoresearch.sh -> METRIC loop_test_count=170, METRIC microtest_pass_count=219\n- CLANG_CL_EXE=C:/Program Files/LLVM/bin/clang-cl.exe bash autoresearch.checks.sh -> baseline + determinism OK\n\nNote: run_experiment stdout/check capture is still empty in this harness, so run #74 was logged as checks_failed with proxy_bash ground truth.