### PR TITLE
lifter: expand loop microtest coverage (+1 test, batch 54)

### DIFF
--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -520,6 +520,21 @@ private:
     return true;
   }
 
+  bool runLoopGeneralizationUnknownContextBlocked(std::string& details) {
+    LifterUnderTest lifter;
+    lifter.currentPathSolveContext = LifterUnderTest::PathSolveContext::Unknown;
+    if (lifter.currentPathSolveAllowsStructuredLoopGeneralization()) {
+      details = "  unknown path-solve context must not generalize loop state\n";
+      return false;
+    }
+    if (lifter.currentPathSolveAllowsStructuredLoopGeneralizationForResolvedTarget()) {
+      details =
+          "  resolved-target widening must not admit unknown loop context\n";
+      return false;
+    }
+    return true;
+  }
+
   bool runPendingGeneralizedLoopByContext(
       LifterUnderTest::PathSolveContext context, const char* contextName,
       bool expectReuse, std::string& details) {
@@ -10585,6 +10600,8 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runLoopGeneralizationIndirectJumpAllowedWhenResolved);
     runCustom("loop_generalization_ret_blocked",
              &InstructionTester::runLoopGeneralizationRetBlocked);
+    runCustom("loop_generalization_unknown_context_blocked",
+             &InstructionTester::runLoopGeneralizationUnknownContextBlocked);
     runCustom("pending_generalized_loop_indirect_jump_allowed_when_resolved",
              &InstructionTester::runPendingGeneralizedLoopIndirectJumpAllowedWhenResolved);
     runCustom("pending_generalized_loop_ret_blocked",


### PR DESCRIPTION
Adds one focused loop-context microtest in lifter/test/Tester.hpp:\n\n- loop_generalization_unknown_context_blocked covers the Unknown PathSolveContext, verifying it remains excluded from both the normal structured-loop generalization predicate and the resolved-target widening that admits indirect jumps.\n\nVerification:\n- bash autoresearch.sh -> METRIC loop_test_count=174, METRIC microtest_pass_count=223\n- CLANG_CL_EXE=C:/Program Files/LLVM/bin/clang-cl.exe bash autoresearch.checks.sh -> baseline + determinism OK\n\nNote: run_experiment stdout/check capture is still empty in this harness, so run #78 was logged as checks_failed with proxy_bash ground truth.