### PR TITLE
themida: correctness gate, diagnostic tracer, ret-to-IAT recognition, gen revisit knob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ debug*.txt
 emu_*.py
 check_*.py
 !scripts/rewrite/check_semantic.py
+!scripts/rewrite/check_themida_equivalence.py
 .tmp*
 =*
 scriptsdev/

--- a/docs/LOOP_HANDLING.md
+++ b/docs/LOOP_HANDLING.md
@@ -174,13 +174,25 @@ python test.py micro
 python test.py baseline
 ```
 
-For changes that touch register/flag phi shape, also re-run the Themida sample to confirm the 2544-instruction benchmark holds:
+For changes that touch register/flag phi shape, also run the two Themida gates — a coverage gate and a correctness gate. Both must stay green (or at least not regress).
+
+**Coverage gate** — confirms the VM unrolls without crashing:
 
 ```
 build_iced\lifter.exe ..\testthemida\example2-virt.bin 0x140001000
 ```
 
-and inspect `output_diagnostics.json` for `lift_stats.instructions_lifted == 2544` and `summary.warning == 0`, `summary.error == 0`.
+Inspect `output_diagnostics.json` for `lift_stats.instructions_lifted == 2544` and `summary.warning == 0`, `summary.error == 0`. This only certifies that the lifter walked the VM's 2544 handler instructions without reporting errors — it does **not** certify that the recovered IR is semantically equivalent to the original function.
+
+**Correctness gate** — confirms the devirtualized IR calls the same external imports as the non-virtualized reference:
+
+```
+python test.py themida
+```
+
+Fails hard if any required import from `scripts/rewrite/themida_samples.json` is missing from the lifted IR. Required imports are pinned against a lift of the non-virt reference binary; regenerate with `python test.py themida --update` when the reference changes (not when the virt output changes). Passing this gate means the VM devirtualization recovered the guest program's external-call semantics, not just the VM's own state-machine activity.
+
+This gate is currently **red** on `example2-virt.bin`: the lifter unrolls the VM but does not surface the guest's `GetStdHandle` / `WriteConsoleA` / `ReadConsoleA` / `CharUpperA` calls. That gap is the active Themida-frontier work item — the coverage gate passing while the correctness gate fails is exactly the failure mode the two-gate split is designed to make visible.
 
 ## Known limitations
 

--- a/lifter/core/LifterClass.hpp
+++ b/lifter/core/LifterClass.hpp
@@ -775,6 +775,28 @@ public:
     if (!contextAllows) return reject("context-not-allowed");
     if (addr > blockInfo.block_address) return reject("forward-target");
     if (!visitedAddresses.contains(addr)) return reject("not-visited");
+    // Revisit-count threshold: let a structured-loop header execute
+    // concretely for the first N visits before switching to generalization.
+    // Short guest loops (< N iterations) fully unroll; long loops and VM
+    // dispatchers (which re-enter the header many times) still generalize.
+    // Tunable via MERGEN_GEN_MIN_REVISITS.
+    //
+    // Default 0 keeps the pre-existing behaviour (threshold never
+    // rejects). Non-zero values currently expose latent state-machinery
+    // bugs in the Themida VM dispatcher path (crashes at T=6/8/12 on
+    // example2-virt.bin) - experiment flag, not a production tuning yet.
+    unsigned revisitThreshold = 0;
+    if (const char* env = std::getenv("MERGEN_GEN_MIN_REVISITS")) {
+      char* end = nullptr;
+      unsigned long parsed = std::strtoul(env, &end, 10);
+      if (end != env && *end == '\0') {
+        revisitThreshold = static_cast<unsigned>(parsed);
+      }
+    }
+    auto attemptIt = liftAttemptCounts.find(addr);
+    const unsigned attempts =
+        attemptIt == liftAttemptCounts.end() ? 0 : attemptIt->second;
+    if (attempts < revisitThreshold) return reject("below-revisit-threshold");
     if (pendingLoopGeneralizationAddresses.contains(addr)) return reject("already-pending");
     if (generalizedLoopAddresses.contains(addr)) return reject("already-generalized");
     auto it = addrToBB.find(addr);
@@ -816,9 +838,7 @@ public:
 
   void liftBasicBlockFromAddress(uint64_t addr) {
     ++liftStats.blocks_attempted;
-    if (liftProgressDiagEnabled) {
-      ++liftAttemptCounts[addr];
-    }
+    ++liftAttemptCounts[addr];
     printvalue2(this->finished);
     printvalue2(this->run);
     this->run = 1;

--- a/lifter/core/LifterClass.hpp
+++ b/lifter/core/LifterClass.hpp
@@ -763,6 +763,14 @@ public:
       }
       return false;
     };
+    // Diagnostic toggle: MERGEN_NO_LOOP_GEN=1 disables the entire loop-
+    // generalization gate.  Use this to measure how much of a lift's
+    // coverage/reachability depends on generalization vs. pure concrete
+    // exploration.  Expected effect: more instructions visited, smaller
+    // loops (no phi widening), potentially runaway lifts on real loops.
+    if (const char* env = std::getenv("MERGEN_NO_LOOP_GEN")) {
+      if (env[0] == '1' && env[1] == 0) return reject("env-disabled");
+    }
     if (getControlFlow() != ControlFlow::Unflatten) return reject("not-unflatten");
     if (!contextAllows) return reject("context-not-allowed");
     if (addr > blockInfo.block_address) return reject("forward-target");

--- a/lifter/semantics/Semantics_ControlFlow.ipp
+++ b/lifter/semantics/Semantics_ControlFlow.ipp
@@ -432,6 +432,55 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_ret() { // fix
   }
 
   SetRegisterValue(Register::RSP, rsp_result);
+
+  // Ret-to-IAT import recognition.  If the value being popped resolves to
+  // a concrete IAT slot, this ret is actually a 'push target; ret'
+  // indirect-call gadget (VMP/Themida dispatcher idiom, or plain thunk).
+  // Emit the named external call, then simulate the external's own ret by
+  // popping the continuation address off the stack so control flow resumes
+  // at the VM's post-call handler instead of lifting IAT bytes as code.
+  //
+  // Try two routes to a concrete target: direct ConstantInt (the popped
+  // value was a SSA-folded load of an IAT slot) and computePossibleValues
+  // returning a single concrete value (obfuscation chains that fold to one
+  // address on this path).
+  {
+    uint64_t retTargetAddr = 0;
+    bool retTargetResolved = false;
+    if (auto* constInt = llvm::dyn_cast<llvm::ConstantInt>(realval)) {
+      retTargetAddr = constInt->getZExtValue();
+      retTargetResolved = true;
+    } else {
+      auto pvset = computePossibleValues(realval);
+      if (pvset.size() == 1) {
+        retTargetAddr = pvset.begin()->getZExtValue();
+        retTargetResolved = true;
+      }
+    }
+    if (retTargetResolved) {
+      retTargetAddr = normalizeRuntimeTargetAddress(retTargetAddr);
+      auto importIt = importMap.find(retTargetAddr);
+      if (importIt != importMap.end()) {
+        const auto& importName = importIt->second;
+        callFunctionIR(importName, nullptr);
+        diagnostics.info(
+            DiagCode::CallOutlinedImportThunk,
+            current_address - instruction.length,
+            "Resolved ret-to-IAT import: " + importName);
+        // Simulate the external callee's own ret by popping one more
+        // qword (the continuation address pre-staged by the caller).
+        // The new [rsp] now holds that continuation; feed it to solvePath
+        // so the lifter continues at the VM's post-call handler instead
+        // of the IAT pointer we just consumed.
+        auto* continuationValue = GetMemoryValue(getSPaddress(), 64);
+        rsp_result = createAddFolder(
+            rsp_result,
+            llvm::ConstantInt::get(rsp_result->getType(), ptrSize));
+        SetRegisterValue(Register::RSP, rsp_result);
+        realval = continuationValue;
+      }
+    }
+  }
   
   ScopedPathSolveContext pathSolveContext(this, PathSolveContext::Ret);
   auto pathResult = solvePath(function, destination, realval);

--- a/scripts/dev/trace_external_calls.py
+++ b/scripts/dev/trace_external_calls.py
@@ -35,6 +35,7 @@ try:
     import unicorn
     from unicorn import Uc, UC_ARCH_X86, UC_MODE_64
     from unicorn import UC_HOOK_CODE, UC_HOOK_MEM_UNMAPPED, UC_HOOK_INSN_INVALID
+    from unicorn import UC_HOOK_MEM_WRITE
     from unicorn import x86_const as ux
 except ImportError as exc:
     sys.exit(f"Missing dependency: {exc}. pip install unicorn capstone")
@@ -192,6 +193,7 @@ def trace(
     max_insns: int,
     max_hits: int,
     verbose_calls: bool,
+    dump_visited: Optional[Path] = None,
 ) -> int:
     data = binary.read_bytes()
     info = _parse_pe(data)
@@ -253,9 +255,24 @@ def trace(
         "last_pc": entry,
     }
 
+    # Ordered list of unique instruction PCs (each address recorded once, in
+    # the order the emulator first executes it). Useful for diffing against
+    # the lifter's reached-addresses list to find the divergence point.
+    visited_pcs: List[int] = []
+    visited_set: set = set()
+
+    # Every time a stack write stores a sentinel value, record
+    # (sentinel, writer_pc, stack_addr, insn_count). Themida obfuscates with
+    # push-pop swap gadgets so a single sentinel may be staged transiently
+    # multiple times before the final ret picks it up.
+    sentinel_pushes: List[Tuple[int, int, int, int]] = []
+
     def code_hook(_uc, addr, size, _ud):
         state["insns"] += 1
         state["last_pc"] = addr
+        if addr not in visited_set:
+            visited_set.add(addr)
+            visited_pcs.append(addr)
         if state["insns"] > max_insns:
             uc.emu_stop()
             return
@@ -339,6 +356,17 @@ def trace(
     uc.hook_add(UC_HOOK_CODE, code_hook)
     uc.hook_add(UC_HOOK_MEM_UNMAPPED, unmapped_hook)
 
+    def mem_write_hook(_uc, _access, addr, size, value, _ud):
+        if size != 8:
+            return
+        if not (STACK_BASE <= addr < STACK_BASE + STACK_SIZE):
+            return
+        uv = value & 0xFFFFFFFFFFFFFFFF
+        if uv in sentinel_to_name:
+            sentinel_pushes.append((uv, state["last_pc"], addr, state["insns"]))
+
+    uc.hook_add(UC_HOOK_MEM_WRITE, mem_write_hook)
+
     print(f"\n[run] starting emulation @ 0x{entry:x}, max_insns={max_insns}\n")
     try:
         uc.emu_start(entry, 0, count=max_insns)
@@ -353,6 +381,23 @@ def trace(
     print(f"sentinel hits         : {len(state['hits'])}")
     for callsite, mn, kind, target, name in state["hits"]:
         print(f"  @0x{callsite:x}  {mn:<4}  kind={kind:<24}  -> {name}")
+    if sentinel_pushes:
+        print(f"\n--- sentinel push history ({len(sentinel_pushes)} stack writes) ---")
+        from collections import defaultdict
+        per_sent: Dict[int, List[Tuple[int, int, int]]] = defaultdict(list)
+        for s, pc, a, n in sentinel_pushes:
+            per_sent[s].append((pc, a, n))
+        for sent, events in per_sent.items():
+            name = sentinel_to_name[sent]
+            print(f"  {name}: {len(events)} pushes; last 5:")
+            for pc, a, n in events[-5:]:
+                print(f"      insn={n:>7} @0x{pc:x} -> [0x{a:x}]")
+    if dump_visited is not None:
+        dump_visited.write_text(
+            "\n".join(f"0x{a:x}" for a in visited_pcs) + "\n",
+            encoding="utf-8",
+        )
+        print(f"dumped {len(visited_pcs)} unique PCs to {dump_visited}")
     return 0 if state["hits"] else 1
 
 
@@ -365,6 +410,8 @@ def main() -> None:
                     help="stop after this many distinct external-call observations")
     ap.add_argument("--verbose-calls", action="store_true",
                     help="log every call/jmp, not just the external ones")
+    ap.add_argument("--dump-visited", type=Path, default=None,
+                    help="write newline-separated unique PCs executed, in order")
     args = ap.parse_args()
     sys.exit(trace(
         args.binary,
@@ -372,6 +419,7 @@ def main() -> None:
         max_insns=args.max_insns,
         max_hits=args.max_hits,
         verbose_calls=args.verbose_calls,
+        dump_visited=args.dump_visited,
     ))
 
 

--- a/scripts/dev/trace_external_calls.py
+++ b/scripts/dev/trace_external_calls.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Emulate a PE binary and report where it issues external (IAT) calls.
+
+Diagnostic tool, not a regression check. Use it to answer one question on a
+specific lift target: "what x86 instruction in this binary issues the call to
+this external function, and through what addressing form?"
+
+Approach:
+- Parse the PE, walk the import directory, and patch every IAT slot with a
+  unique sentinel address (in an *unmapped* high page).
+- Map all PE sections into Unicorn at their virtual addresses.
+- Allocate a stack and a TEB so GS-relative reads behave.
+- Hook every code instruction; when the upcoming `call`/`jmp` resolves to a
+  sentinel address, log the call-site (the instruction's own VA) plus the
+  addressing form (direct / register / memory operand) and the import name.
+- Stop after the first N sentinel hits or after `--max-insns` instructions
+  total (default 1,000,000).
+
+This sees the *real* call mechanism the binary uses at runtime, regardless of
+how the lifter chooses to model it. Compare against what the lifter emits in
+`output_no_opts.ll` to localise where the lifter's import-resolution path
+either misses the callsite entirely or fails to recognise the addressing form.
+"""
+from __future__ import annotations
+
+import argparse
+import struct
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+try:
+    import capstone
+    from capstone import x86 as cs_x86
+    import unicorn
+    from unicorn import Uc, UC_ARCH_X86, UC_MODE_64
+    from unicorn import UC_HOOK_CODE, UC_HOOK_MEM_UNMAPPED, UC_HOOK_INSN_INVALID
+    from unicorn import x86_const as ux
+except ImportError as exc:
+    sys.exit(f"Missing dependency: {exc}. pip install unicorn capstone")
+
+
+# Map capstone X86 register ids -> Unicorn register ids by name.
+def _build_reg_translation(md: capstone.Cs) -> Dict[int, int]:
+    name_to_uc = {
+        attr.removeprefix("UC_X86_REG_").lower(): getattr(ux, attr)
+        for attr in dir(ux)
+        if attr.startswith("UC_X86_REG_") and attr != "UC_X86_REG_INVALID"
+    }
+    out: Dict[int, int] = {}
+    for cs_id in range(1, cs_x86.X86_REG_ENDING):
+        try:
+            name = md.reg_name(cs_id)
+        except Exception:
+            continue
+        if not name:
+            continue
+        uc_id = name_to_uc.get(name.lower())
+        if uc_id is not None:
+            out[cs_id] = uc_id
+    return out
+
+
+# ---------------------------------------------------------------------------
+# PE parsing — minimal, just enough to find sections and the import table.
+# ---------------------------------------------------------------------------
+
+
+def _parse_pe(data: bytes) -> dict:
+    pe_off = struct.unpack_from("<I", data, 0x3C)[0]
+    if data[pe_off : pe_off + 4] != b"PE\x00\x00":
+        raise SystemExit("Not a PE file")
+    nsec = struct.unpack_from("<H", data, pe_off + 6)[0]
+    sopt = struct.unpack_from("<H", data, pe_off + 20)[0]
+    opt = pe_off + 24
+    magic = struct.unpack_from("<H", data, opt)[0]
+    if magic != 0x20B:
+        raise SystemExit("PE32+ (x86_64) only")
+    image_base = struct.unpack_from("<Q", data, opt + 24)[0]
+    image_size = struct.unpack_from("<I", data, opt + 56)[0]
+    ddir_off = opt + 112  # IMAGE_OPTIONAL_HEADER64.DataDirectory
+    imp_rva = struct.unpack_from("<I", data, ddir_off + 1 * 8)[0]
+    imp_size = struct.unpack_from("<I", data, ddir_off + 1 * 8 + 4)[0]
+
+    sec_table = opt + sopt
+    sections: List[Tuple[str, int, int, int, int]] = []
+    for i in range(nsec):
+        off = sec_table + i * 40
+        name = data[off : off + 8].rstrip(b"\0").decode("ascii", "replace")
+        vsz = struct.unpack_from("<I", data, off + 8)[0]
+        va = struct.unpack_from("<I", data, off + 12)[0]
+        rsz = struct.unpack_from("<I", data, off + 16)[0]
+        roff = struct.unpack_from("<I", data, off + 20)[0]
+        sections.append((name, va, vsz, roff, rsz))
+
+    return {
+        "image_base": image_base,
+        "image_size": image_size,
+        "sections": sections,
+        "import_rva": imp_rva,
+        "import_size": imp_size,
+    }
+
+
+def _rva_to_off(sections, rva: int) -> Optional[int]:
+    for _name, va, vsz, roff, rsz in sections:
+        if va <= rva < va + max(vsz, rsz):
+            return roff + (rva - va)
+    return None
+
+
+def _parse_imports(data: bytes, info: dict) -> List[Tuple[int, str]]:
+    """Return [(iat_slot_va, function_name)] across every imported DLL."""
+    if info["import_rva"] == 0:
+        return []
+    base = info["image_base"]
+    secs = info["sections"]
+    desc = _rva_to_off(secs, info["import_rva"])
+    out: List[Tuple[int, str]] = []
+    while True:
+        ilt_rva = struct.unpack_from("<I", data, desc)[0]
+        name_rva = struct.unpack_from("<I", data, desc + 12)[0]
+        iat_rva = struct.unpack_from("<I", data, desc + 16)[0]
+        if ilt_rva == 0 and iat_rva == 0:
+            break
+        dll_off = _rva_to_off(secs, name_rva)
+        dll = data[dll_off:].split(b"\0", 1)[0].decode("ascii", "replace")
+        thunks_rva = ilt_rva or iat_rva
+        thunks_off = _rva_to_off(secs, thunks_rva)
+        if thunks_off is None:
+            desc += 20
+            continue
+        idx = 0
+        while True:
+            entry = struct.unpack_from("<Q", data, thunks_off + idx * 8)[0]
+            if entry == 0:
+                break
+            iat_slot_va = base + iat_rva + idx * 8
+            if entry & (1 << 63):
+                ordinal = entry & 0xFFFF
+                fname = f"{dll}#{ordinal}"
+            else:
+                hint_off = _rva_to_off(secs, entry & 0x7FFFFFFF)
+                fname = data[hint_off + 2 :].split(b"\0", 1)[0].decode("ascii", "replace")
+            out.append((iat_slot_va, fname))
+            idx += 1
+        desc += 20
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Operand resolution (capstone -> effective address)
+# ---------------------------------------------------------------------------
+
+
+def _compute_ea(uc: Uc, ins, op, reg_xlat: Dict[int, int]) -> Optional[int]:
+    mem = op.mem
+    base_v = 0
+    if mem.base:
+        if mem.base == cs_x86.X86_REG_RIP:
+            base_v = ins.address + ins.size
+        else:
+            uc_id = reg_xlat.get(mem.base)
+            if uc_id is None:
+                return None
+            base_v = uc.reg_read(uc_id)
+    index_v = 0
+    if mem.index:
+        uc_id = reg_xlat.get(mem.index)
+        if uc_id is None:
+            return None
+        index_v = uc.reg_read(uc_id)
+    return (base_v + index_v * mem.scale + mem.disp) & 0xFFFFFFFFFFFFFFFF
+
+
+# ---------------------------------------------------------------------------
+# Main tracer
+# ---------------------------------------------------------------------------
+
+
+SENTINEL_BASE = 0xDEAD_0000  # picked so it sits well outside any mapped region
+STACK_BASE = 0x7FFE_0000_0000
+STACK_SIZE = 0x100_0000
+TEB_BASE = 0x7FFD_0000_0000
+TEB_SIZE = 0x10000
+
+
+def trace(
+    binary: Path,
+    entry: int,
+    *,
+    max_insns: int,
+    max_hits: int,
+    verbose_calls: bool,
+) -> int:
+    data = binary.read_bytes()
+    info = _parse_pe(data)
+    imports = _parse_imports(data, info)
+    base = info["image_base"]
+
+    print(f"[pe] image_base=0x{base:x} image_size=0x{info['image_size']:x}")
+    print(f"[pe] {len(imports)} imports across {len({n.split('#')[0] for _, n in imports})} DLLs")
+    for iat, name in imports[:8]:
+        print(f"     IAT[0x{iat:x}] -> {name}")
+    if len(imports) > 8:
+        print(f"     ... +{len(imports) - 8} more")
+
+    uc = Uc(UC_ARCH_X86, UC_MODE_64)
+    md = capstone.Cs(capstone.CS_ARCH_X86, capstone.CS_MODE_64)
+    md.detail = True
+    reg_xlat = _build_reg_translation(md)
+
+    # Map the full image (page-aligned) and write each section's raw bytes.
+    page = 0x1000
+    img_size = (info["image_size"] + page - 1) & ~(page - 1)
+    uc.mem_map(base, img_size, unicorn.UC_PROT_ALL)
+    for name, va, _vsz, roff, rsz in info["sections"]:
+        if rsz:
+            uc.mem_write(base + va, data[roff : roff + rsz])
+
+    # Stack
+    uc.mem_map(STACK_BASE, STACK_SIZE, unicorn.UC_PROT_READ | unicorn.UC_PROT_WRITE)
+    rsp_top = STACK_BASE + STACK_SIZE - 0x1000
+    # TEB at GS_BASE, with sane StackBase / StackLimit
+    uc.mem_map(TEB_BASE, TEB_SIZE, unicorn.UC_PROT_READ | unicorn.UC_PROT_WRITE)
+    uc.mem_write(TEB_BASE + 0x08, struct.pack("<Q", STACK_BASE + STACK_SIZE))
+    uc.mem_write(TEB_BASE + 0x10, struct.pack("<Q", STACK_BASE))
+    uc.reg_write(ux.UC_X86_REG_MSR, (0xC0000101, TEB_BASE))  # IA32_GS_BASE
+
+    # Patch IAT: every slot points at a unique sentinel in unmapped space.
+    sentinel_to_name: Dict[int, str] = {}
+    for i, (iat_va, fname) in enumerate(imports):
+        sentinel = SENTINEL_BASE + i * 0x10
+        uc.mem_write(iat_va, struct.pack("<Q", sentinel))
+        sentinel_to_name[sentinel] = fname
+
+    # Initial state
+    for r in (
+        ux.UC_X86_REG_RAX, ux.UC_X86_REG_RBX, ux.UC_X86_REG_RCX, ux.UC_X86_REG_RDX,
+        ux.UC_X86_REG_RSI, ux.UC_X86_REG_RDI, ux.UC_X86_REG_RBP,
+        ux.UC_X86_REG_R8, ux.UC_X86_REG_R9, ux.UC_X86_REG_R10, ux.UC_X86_REG_R11,
+        ux.UC_X86_REG_R12, ux.UC_X86_REG_R13, ux.UC_X86_REG_R14, ux.UC_X86_REG_R15,
+    ):
+        uc.reg_write(r, 0)
+    sentinel_ret = 0xC0DE_0000
+    uc.mem_write(rsp_top - 8, struct.pack("<Q", sentinel_ret))
+    uc.reg_write(ux.UC_X86_REG_RSP, rsp_top - 8)
+
+    # State the hooks share via closure
+    state = {
+        "insns": 0,
+        "hits": [],         # [(callsite, mnemonic, kind, target, name)]
+        "last_pc": entry,
+    }
+
+    def code_hook(_uc, addr, size, _ud):
+        state["insns"] += 1
+        state["last_pc"] = addr
+        if state["insns"] > max_insns:
+            uc.emu_stop()
+            return
+        try:
+            buf = bytes(uc.mem_read(addr, size))
+        except Exception:
+            return
+        for ins in md.disasm(buf, addr):
+            mn = ins.mnemonic
+            is_ret = mn in ("ret", "retf", "iret", "iretq", "retq")
+            is_transfer = is_ret or mn in ("call", "jmp")
+            if not is_transfer:
+                break
+            target: Optional[int] = None
+            kind = "?"
+            if is_ret:
+                # The target is [rsp]: the value about to be popped into RIP.
+                rsp_now = uc.reg_read(ux.UC_X86_REG_RSP)
+                try:
+                    target = struct.unpack("<Q", bytes(uc.mem_read(rsp_now, 8)))[0]
+                    kind = f"pop[rsp=0x{rsp_now:x}]"
+                except Exception:
+                    kind = f"pop[rsp=0x{rsp_now:x}]-unread"
+            elif ins.operands:
+                op = ins.operands[0]
+                if op.type == cs_x86.X86_OP_IMM:
+                    target = op.imm
+                    kind = "imm"
+                elif op.type == cs_x86.X86_OP_REG:
+                    uc_id = reg_xlat.get(op.reg)
+                    if uc_id is not None:
+                        target = uc.reg_read(uc_id)
+                        kind = f"reg:{md.reg_name(op.reg)}"
+                elif op.type == cs_x86.X86_OP_MEM:
+                    ea = _compute_ea(uc, ins, op, reg_xlat)
+                    if ea is not None:
+                        try:
+                            target = struct.unpack("<Q", bytes(uc.mem_read(ea, 8)))[0]
+                            kind = f"mem@0x{ea:x}"
+                        except Exception:
+                            kind = f"mem@0x{ea:x}-unread"
+            if target is None:
+                break
+            name = sentinel_to_name.get(target)
+            external = name is not None or not (base <= target < base + info["image_size"])
+            if verbose_calls or external:
+                tag = "[HIT ]" if name else ("[EXT?]" if external else "[xfer]")
+                resolved = name if name else ("<unknown-extern>" if external else "<internal>")
+                print(
+                    f"{tag} insn={state['insns']:>7} @0x{addr:x} "
+                    f"{mn} {ins.op_str} | kind={kind} target=0x{target:x} -> {resolved}"
+                )
+                if name:
+                    state["hits"].append((addr, mn, kind, target, name))
+                    if len(state["hits"]) >= max_hits:
+                        uc.emu_stop()
+            break
+
+    def unmapped_hook(_uc, _access, addr, _size, _value, _ud):
+        # Catches both data accesses and instruction fetches into unmapped space.
+        # Sentinel fetches are interesting; everything else is usually a real
+        # bug in the emulator setup we want to surface.
+        name = sentinel_to_name.get(addr)
+        rsp_now = uc.reg_read(ux.UC_X86_REG_RSP)
+        try:
+            ret_to = struct.unpack("<Q", bytes(uc.mem_read(rsp_now, 8)))[0]
+        except Exception:
+            ret_to = 0
+        if name:
+            print(
+                f"[FETCH-SENTINEL] -> {name}  insn={state['insns']}  "
+                f"last_pc=0x{state['last_pc']:x}  rsp=0x{rsp_now:x}  ret_to=0x{ret_to:x}"
+            )
+        else:
+            print(
+                f"[UNMAPPED] addr=0x{addr:x}  insn={state['insns']}  "
+                f"last_pc=0x{state['last_pc']:x}  rsp=0x{rsp_now:x}  ret_to=0x{ret_to:x}"
+            )
+        return False  # let unicorn raise; we'll handle in the outer try
+
+    uc.hook_add(UC_HOOK_CODE, code_hook)
+    uc.hook_add(UC_HOOK_MEM_UNMAPPED, unmapped_hook)
+
+    print(f"\n[run] starting emulation @ 0x{entry:x}, max_insns={max_insns}\n")
+    try:
+        uc.emu_start(entry, 0, count=max_insns)
+    except unicorn.UcError as exc:
+        rip = uc.reg_read(ux.UC_X86_REG_RIP)
+        print(f"\n[stop] unicorn raised at RIP=0x{rip:x} after {state['insns']} insns: {exc}")
+    else:
+        print(f"\n[stop] emulation ended cleanly after {state['insns']} insns")
+
+    print(f"\n--- summary ---")
+    print(f"instructions executed : {state['insns']}")
+    print(f"sentinel hits         : {len(state['hits'])}")
+    for callsite, mn, kind, target, name in state["hits"]:
+        print(f"  @0x{callsite:x}  {mn:<4}  kind={kind:<24}  -> {name}")
+    return 0 if state["hits"] else 1
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("binary", type=Path)
+    ap.add_argument("entry", help="entry VA, e.g. 0x140001000")
+    ap.add_argument("--max-insns", type=int, default=1_000_000)
+    ap.add_argument("--max-hits", type=int, default=8,
+                    help="stop after this many distinct external-call observations")
+    ap.add_argument("--verbose-calls", action="store_true",
+                    help="log every call/jmp, not just the external ones")
+    args = ap.parse_args()
+    sys.exit(trace(
+        args.binary,
+        int(args.entry, 0),
+        max_insns=args.max_insns,
+        max_hits=args.max_hits,
+        verbose_calls=args.verbose_calls,
+    ))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rewrite/check_themida_equivalence.py
+++ b/scripts/rewrite/check_themida_equivalence.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Themida devirtualization semantic-equivalence check.
+
+Premise: a virtualized function, after devirtualization, must call the same
+external imports as its non-virtualized counterpart. Structural divergence in
+the lifted IR (block count, SSA names, pass-ordering artifacts) is allowed;
+semantic divergence at the import boundary is not.
+
+For each entry in ``themida_samples.json``:
+- lift the virtualized binary
+- extract external call names from the resulting IR
+- compare against the manifest's ``required_imports`` list
+- fail hard on any required import that is absent
+
+Use ``--update`` to regenerate ``required_imports`` from the reference binary.
+Samples whose binaries are not present on disk are skipped, not failed, because
+the binaries live outside the repository (``../testthemida/``) and are not
+available in CI.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+ROOT = Path(__file__).resolve().parents[2]
+LIFTER = ROOT / "build_iced" / "lifter.exe"
+DEFAULT_MANIFEST = Path(__file__).resolve().parent / "themida_samples.json"
+WORKROOT = ROOT.parent / "rewrite-regression-work" / "themida_ir"
+
+# Matches a `call` that targets a named function:
+#   %N = call i64 @GetStdHandle(...)
+#   call void @"VirtualizerSDK64.dll#103"(...)
+#   tail call ptr @foo(...)
+# Captures the callee identifier (unquoted or the contents of the quotes).
+_CALL_RE = re.compile(
+    r'''^\s*(?:%\S+\s*=\s*)?(?:tail\s+|musttail\s+|notail\s+)?'''
+    r'''call\s+\S+\s+@(?:"([^"]+)"|([A-Za-z_][\w.]*))\s*\(''',
+    re.MULTILINE,
+)
+
+
+def _lift(binary: Path, entry: str, workdir: Path) -> Path:
+    if not LIFTER.exists():
+        raise SystemExit(
+            f"Lifter not found: {LIFTER}. Build it with "
+            "'cmd /c scripts\\dev\\build_iced.cmd' first."
+        )
+    if not binary.exists():
+        raise SystemExit(f"Binary not found: {binary}")
+
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    # Clear previous artifacts so a stale file can't mask a new failure.
+    for stale in ("output.ll", "output_no_opts.ll", "output_diagnostics.json"):
+        (workdir / stale).unlink(missing_ok=True)
+
+    result = subprocess.run(
+        [str(LIFTER), str(binary), entry],
+        cwd=workdir,
+        env=os.environ.copy(),
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    ir_path = workdir / "output_no_opts.ll"
+    if not ir_path.exists():
+        tail_stdout = (result.stdout or "")[-600:]
+        tail_stderr = (result.stderr or "")[-600:]
+        raise SystemExit(
+            f"Lifter did not emit output_no_opts.ll for {binary} @ {entry}\n"
+            f"exit_code={result.returncode}\n"
+            f"stdout-tail:\n{tail_stdout}\n"
+            f"stderr-tail:\n{tail_stderr}"
+        )
+    return ir_path
+
+
+def _extract_call_names(ir_text: str) -> Dict[str, int]:
+    """Return a multiset of call-target identifiers found in IR text.
+
+    Intramodule calls to ``@main`` and outlined ``@sub_*`` thunks are excluded
+    — we only care about named external imports that the lifter resolved.
+    """
+    counts: Dict[str, int] = {}
+    for match in _CALL_RE.finditer(ir_text):
+        name = match.group(1) or match.group(2)
+        if not name:
+            continue
+        if name == "main" or name.startswith("sub_") or name.startswith("llvm."):
+            continue
+        counts[name] = counts.get(name, 0) + 1
+    return counts
+
+
+def _filter_imports(imports: Dict[str, int], ignore_patterns: List[str]) -> Dict[str, int]:
+    if not ignore_patterns:
+        return dict(imports)
+    compiled = [re.compile(p) for p in ignore_patterns]
+    return {k: v for k, v in imports.items() if not any(p.search(k) for p in compiled)}
+
+
+def _diff(
+    required: Set[str],
+    actual: Dict[str, int],
+) -> Tuple[List[str], bool]:
+    lines: List[str] = []
+    ok = True
+
+    missing = sorted(required - set(actual))
+    if missing:
+        ok = False
+        for name in missing:
+            lines.append(f"  MISSING required import: @{name}")
+
+    extra = sorted(set(actual) - required)
+    # Extras are informational — a smarter devirtualizer may legitimately
+    # surface additional imports. Never fatal.
+    for name in extra:
+        lines.append(f"  extra import (not required): @{name} x{actual[name]}")
+
+    return lines, ok
+
+
+def _check_sample(sample: dict) -> bool:
+    name = sample["name"]
+    virt_rel = sample["virt_binary"]
+    virt = (ROOT / virt_rel).resolve()
+    entry = sample["entry"]
+    ignore = sample.get("ignore_imports", [])
+    required = set(sample.get("required_imports", []))
+
+    if not virt.exists():
+        print(f"SKIP: {name} — virt binary not present at {virt}")
+        return True
+
+    if not required:
+        print(
+            f"FAIL: {name} — manifest has no required_imports; "
+            f"run `python test.py themida --update` first."
+        )
+        return False
+
+    ir_path = _lift(virt, entry, WORKROOT / name)
+    ir_text = ir_path.read_text(encoding="utf-8", errors="replace")
+    actual = _filter_imports(_extract_call_names(ir_text), ignore)
+
+    lines, ok = _diff(required, actual)
+    summary = (
+        f"{len(actual)} distinct imports, {sum(actual.values())} calls "
+        f"(required {len(required)})"
+    )
+    if ok:
+        print(f"PASS: {name} — {summary}")
+        for line in lines:
+            print(line)
+    else:
+        print(f"FAIL: {name} — {summary}")
+        for line in lines:
+            print(line)
+        req_str = ", ".join(sorted(required)) or "(none)"
+        act_str = ", ".join(f"{k}x{v}" for k, v in sorted(actual.items())) or "(none)"
+        print(f"  required: {req_str}")
+        print(f"  actual:   {act_str}")
+    return ok
+
+
+def _update_sample(sample: dict) -> dict:
+    name = sample["name"]
+    ref_rel = sample.get("reference_binary")
+    entry = sample["entry"]
+    ignore = sample.get("ignore_imports", [])
+
+    if not ref_rel:
+        print(f"SKIP update: {name} — no reference_binary in manifest")
+        return sample
+
+    ref = (ROOT / ref_rel).resolve()
+    if not ref.exists():
+        print(f"SKIP update: {name} — reference binary not present at {ref}")
+        return sample
+
+    ir_path = _lift(ref, entry, WORKROOT / f"{name}_reference")
+    ir_text = ir_path.read_text(encoding="utf-8", errors="replace")
+    imports = _filter_imports(_extract_call_names(ir_text), ignore)
+
+    updated = dict(sample)
+    updated["required_imports"] = sorted(imports.keys())
+    print(
+        f"UPDATED {name}: {len(imports)} required imports from {ref.name} "
+        f"({sum(imports.values())} total calls in reference)"
+    )
+    return updated
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="regenerate required_imports from reference binaries",
+    )
+    parser.add_argument(
+        "filter",
+        nargs="*",
+        help="only process samples whose name contains any of these tokens",
+    )
+    args = parser.parse_args()
+
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    all_samples = manifest["samples"]
+
+    def matches(sample: dict) -> bool:
+        return not args.filter or any(tok in sample["name"] for tok in args.filter)
+
+    if args.update:
+        manifest["samples"] = [
+            _update_sample(s) if matches(s) else s for s in all_samples
+        ]
+        args.manifest.write_text(
+            json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+        )
+        print(f"Wrote {args.manifest}")
+        return
+
+    selected = [s for s in all_samples if matches(s)]
+    if not selected:
+        raise SystemExit("No samples matched filter")
+
+    all_ok = True
+    for s in selected:
+        all_ok &= _check_sample(s)
+    if not all_ok:
+        raise SystemExit("Themida equivalence check FAILED")
+    print("All Themida equivalence checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rewrite/themida_samples.json
+++ b/scripts/rewrite/themida_samples.json
@@ -1,0 +1,19 @@
+{
+  "samples": [
+    {
+      "name": "example2",
+      "reference_binary": "../testthemida/example2.bin",
+      "virt_binary": "../testthemida/example2-virt.bin",
+      "entry": "0x140001000",
+      "ignore_imports": [
+        "^VirtualizerSDK64\\.dll#"
+      ],
+      "required_imports": [
+        "CharUpperA",
+        "GetStdHandle",
+        "ReadConsoleA",
+        "WriteConsoleA"
+      ]
+    }
+  ]
+}

--- a/scripts/rewrite/themida_samples.json
+++ b/scripts/rewrite/themida_samples.json
@@ -1,13 +1,25 @@
 {
+  "_comment": [
+    "Themida preserves the guest binary's own imports (Win32 APIs) in the IAT,",
+    "but rewrites each call site from `call [rip+IAT]` to a VM-staged",
+    "`push target; ret` where `target` was loaded from the IAT by an upstream",
+    "VM handler. The lifter currently does not recognize this transfer pattern",
+    "as an import call, so the guest's externals do not surface in the IR.",
+    "See scripts/dev/trace_external_calls.py for a Unicorn-based tracer that",
+    "shows the real call mechanism at runtime.",
+    "",
+    "Themida strips its own SDK markers (VirtualizerSDK64.dll#103/#503,",
+    "VirtualizerStart/End) from the protected binary's IAT, so those",
+    "appear in the non-virt reference but not in the virt binary. The",
+    "ignore_imports pattern filters them out before update / compare."
+  ],
   "samples": [
     {
       "name": "example2",
       "reference_binary": "../testthemida/example2.bin",
       "virt_binary": "../testthemida/example2-virt.bin",
       "entry": "0x140001000",
-      "ignore_imports": [
-        "^VirtualizerSDK64\\.dll#"
-      ],
+      "ignore_imports": ["^VirtualizerSDK64\\.dll#"],
       "required_imports": [
         "CharUpperA",
         "GetStdHandle",

--- a/test.py
+++ b/test.py
@@ -18,6 +18,7 @@ DEFAULT_VECTORS = ROOT / "lifter" / "test" / "test_vectors" / "oracle_vectors.js
 IR_OUTPUT_DIR = ROOT.parent / "rewrite-regression-work" / "ir_outputs"
 GOLDEN_HASHES_FILE = ROOT / "lifter" / "test" / "test_vectors" / "golden_ir_hashes.json"
 SEMANTIC_SCRIPT = REWRITE_DIR / "check_semantic.py"
+THEMIDA_SCRIPT = REWRITE_DIR / "check_themida_equivalence.py"
 
 # C-compiled samples produce toolchain-dependent IR (different addresses across
 # compiler versions/machines). Exclude them from golden hash determinism checks;
@@ -254,6 +255,15 @@ def run_vmp(filter_tokens: List[str]) -> None:
     _run(args)
 
 
+def run_themida(filter_tokens: List[str], update: bool) -> None:
+    args = [sys.executable, str(THEMIDA_SCRIPT)]
+    if update:
+        args.append("--update")
+    if filter_tokens:
+        args.extend(filter_tokens)
+    _run(args)
+
+
 def run_negative_checks() -> None:
     lifter_path = ROOT / "build_iced" / "lifter.exe"
     if not lifter_path.exists():
@@ -423,6 +433,16 @@ def parse_args() -> argparse.Namespace:
         help="attempt local VMP target lifts (recommended for big control-flow/semantics changes)",
     )
     vmp.add_argument("filter", nargs="*", help="optional VMP target name filter tokens")
+    themida = sub.add_parser(
+        "themida",
+        help="run Themida devirtualization import-equivalence checks",
+    )
+    themida.add_argument(
+        "--update",
+        action="store_true",
+        help="regenerate required_imports from reference binaries",
+    )
+    themida.add_argument("filter", nargs="*", help="optional sample name filter tokens")
     return parser.parse_args()
 
 
@@ -481,6 +501,10 @@ def main() -> None:
 
     if command == "vmp":
         run_vmp(args.filter)
+        return
+
+    if command == "themida":
+        run_themida(args.filter, args.update)
         return
 
     if command == "flags":


### PR DESCRIPTION
Six commits, three workstreams that compose: (1) a red correctness gate for Themida import recovery, (2) a Unicorn-based diagnostic tracer that surfaces the runtime call mechanism, (3) two lifter changes (a recognition path, an experimental generalization knob) that lay groundwork for the eventual fix.

## Commits

- `41b6e8e tests: add Themida devirtualization import-equivalence check`
- `4114bb6 diag: add Unicorn-based external-call tracer; document Themida transform`
- `9fce813 diag: trace_external_calls can dump visited PCs and record sentinel push chain`
- `5bae459 diag: add MERGEN_NO_LOOP_GEN env gate for loop-generalization`
- `9637c85 lifter: recognize ret-to-IAT as named external call in lift_ret`
- `736e7b3 lifter: gate canGeneralize on per-header revisit count`

## What this lands

**`python test.py themida`** — a correctness gate parallel to the existing 2544-instruction coverage benchmark. Lifts the virt binary, greps the IR for required imports, fails hard if any are missing. Currently red on `example2-virt.bin` (0/4 required imports) and that is intentional: the existing "lift completes with 0 errors" benchmark is satisfied while the recovered IR is semantically wrong (zero external calls). This test exposes the gap.

**`scripts/dev/trace_external_calls.py`** — patches every IAT slot with a sentinel address, emulates the binary in Unicorn, logs every transfer (call/jmp/ret) whose target resolves to a sentinel. Optional `--dump-visited` lists every unique PC the emulator executes (diff against the lifter's `MERGEN_DIAG_LIFT_PROGRESS` reach-set to localise where static exploration diverges from runtime).

**`MERGEN_NO_LOOP_GEN=1`** — diagnostic env gate that disables loop-generalization entirely. Used to measure how much of a lift's coverage depends on generalization vs. the underlying concolic engine.

**`MERGEN_GEN_MIN_REVISITS=N`** — experimental revisit-count threshold on the generalization gate (default 0 = pre-existing behaviour). Lets a header execute concretely for the first N visits before abstracting. Caveat documented in the commit message: T values 6, 8, 12 crash the lifter on `example2-virt.bin` due to latent dispatcher state-machinery bugs that surface only when generalization fires mid-iteration; T=4/16/32/64/128 are stable. Default 0 keeps everything inert.

**`lift_ret` import recognition** — when the value being popped resolves (via direct ConstantInt or single-valued computePossibleValues) to a concrete address that is in importMap, emits the named external call and continues at the continuation address. Pattern is correct; on Themida it currently never fires because the VM's arithmetic-decrypt chain folds via computePossibleValues to wrong concrete targets (e.g. 0x140002628 instead of the actual GetStdHandle IAT slot 0x140002490). Lands as ground work — will start surfacing imports as soon as upstream resolution improves.

## What this does NOT land

- A fix that turns the themida gate green. The gate is intentionally red on `example2-virt.bin`. The two lifter changes (lift_ret recognition + the experimental revisit knob) are necessary infrastructure but not sufficient: the upstream resolution gap (computePossibleValues folding the VM decrypt chain to wrong addresses) is the next surface to attack.
- The T>=6 dispatcher crash. That is a pre-existing latent bug that the new revisit-count knob exposes when set non-zero. Default 0 avoids it.

## Verified

- `example2.bin` (non-virt baseline): 61 insns, 0 warnings, 0 errors, 5 register-indirect import resolutions (GetStdHandle x2, WriteConsoleA x3). Matches main.
- `example2-virt.bin` (virt, default env): 56 blocks, 2544 insns, 0 errors. Matches the existing "passing" benchmark.
- `python test.py themida`: red on example2-virt.bin (0/4 required), passes its own schema validation, fails on missing imports as designed.

## Followups (not in this PR)

1. Fix the dispatcher state-machinery crash exposed by T>=6. Required before the revisit-count knob can have a non-zero default.
2. Improve computePossibleValues fidelity through the VM's arithmetic-decrypt chain so the lift_ret recognition actually surfaces imports on Themida targets.
3. Once 1+2 land, the equivalence gate goes from red to green automatically.
