### PR TITLE
lifter: register-indirect import resolution + silent-failure diagnostics

### DIFF
--- a/lifter/core/LiftDiagnostics.hpp
+++ b/lifter/core/LiftDiagnostics.hpp
@@ -47,6 +47,7 @@ enum class DiagCode : uint16_t {
   OptimizationComplete      = 501,
   SignatureSearchComplete   = 502,
   LiftBlockBudgetExceeded   = 503,
+  IncompleteBlockSealed     = 504,
 
 };
 

--- a/lifter/core/LifterClass.hpp
+++ b/lifter/core/LifterClass.hpp
@@ -359,6 +359,15 @@ public:
   // function declarations instead of opaque inttoptr calls.
   std::unordered_map<uint64_t, std::string> importMap;
 
+  // Register-indirect import provenance: maps a register (canonicalized to
+  // its 64-bit encoding via getBiggestEncoding) to the import name last
+  // loaded into it.  Set by lift_mov when the source is `[rip+disp]` with
+  // disp+RIP in importMap.  Cleared on every SetRegisterValue so any other
+  // write invalidates the binding.  Read by lift_call for register-indirect
+  // calls so `mov rsi, [rip+iat]; call rsi` resolves to a named external
+  // call instead of an opaque inttoptr.
+  std::unordered_map<Register, std::string> registerImportSource;
+
   // If targetVA is an import thunk, returns the import name.
   // Otherwise returns empty string.
   std::string resolveImportName(uint64_t targetVA) {
@@ -476,6 +485,12 @@ public:
         this->run = 0;
         this->finished = 1;
         builder->CreateUnreachable();
+        // Surface the bailout as a warning so callers can see that the
+        // lift reached an unmapped address (typically the result of a
+        // queued constant target that turned out not to be real code).
+        diagnostics.warning(
+            DiagCode::UnresolvedIndirectJump, addr,
+            "liftAddress: target address not mapped in image; emitted unreachable");
         return;
       }
       // what about the basicblock?
@@ -895,6 +910,13 @@ public:
         continue;
       llvm::IRBuilder<> fallbackBuilder(&BB);
       fallbackBuilder.CreateRet(llvm::UndefValue::get(fnc->getReturnType()));
+      // Surface the seal as a warning so silent dataflow corruption
+      // (ret undef -> noundef UB -> O2 unreachable) is visible in
+      // output_diagnostics.json instead of having to read the IR.
+      diagnostics.warning(
+          DiagCode::IncompleteBlockSealed, 0,
+          "Basic block '" + BB.getName().str() +
+              "' had no terminator; sealed with ret undef");
     }
   }
 

--- a/lifter/core/LifterStages.hpp
+++ b/lifter/core/LifterStages.hpp
@@ -81,6 +81,19 @@ createConfiguredLifterForRuntime(uint8_t* fileBase, size_t fileSize,
           // name lookup (common with bound imports and some linkers).
           if (iltOff == 0) iltOff = iatOff;
 
+          // Resolve DLL name once per descriptor.  Used as the namespace
+          // prefix when synthesizing a name for ordinal imports that
+          // have no hint/name entry.
+          std::string dllName;
+          if (auto dllNameOff = lifter->file.RvaToFileOffset(imports->rva_name);
+              dllNameOff != 0 && dllNameOff < fileSize) {
+            const char* raw =
+                reinterpret_cast<const char*>(fileBase + dllNameOff);
+            size_t dllMaxLen = fileSize - dllNameOff;
+            if (strnlen(raw, dllMaxLen) < dllMaxLen) dllName = raw;
+          }
+          if (dllName.empty()) dllName = "unknown";
+
           auto* ilt = reinterpret_cast<const uint64_t*>(fileBase + iltOff);
           uint32_t iatRva = imports->rva_first_thunk;
           // Cap iteration to prevent walking off mapped memory when the
@@ -89,8 +102,17 @@ createConfiguredLifterForRuntime(uint8_t* fileBase, size_t fileSize,
 
           for (size_t i = 0; i < maxIltEntries && ilt[i] != 0; ++i) {
             uint64_t iatSlotVA = imageBase + iatRva + i * 8;
-            // Bit 63 set = import by ordinal, no name available.
-            if (ilt[i] & (1ULL << 63)) continue;
+            // Bit 63 set = import by ordinal.  Synthesize "<dll>#<ord>"
+            // so the fast path in lift_call resolves and we emit a named
+            // external declaration instead of falling through to operand
+            // dispatch (which would treat raw on-disk IAT bytes as a
+            // jump target and silently corrupt the lift).
+            if (ilt[i] & (1ULL << 63)) {
+              uint16_t ordinal = static_cast<uint16_t>(ilt[i] & 0xFFFF);
+              lifter->importMap[iatSlotVA] =
+                  dllName + "#" + std::to_string(ordinal);
+              continue;
+            }
             // Bits 30:0 = RVA to hint/name entry {uint16_t hint; char name[]}.
             uint32_t hintNameRva = static_cast<uint32_t>(ilt[i] & 0x7FFFFFFF);
             auto hnOff = lifter->file.RvaToFileOffset(hintNameRva);

--- a/lifter/semantics/OperandUtils.ipp
+++ b/lifter/semantics/OperandUtils.ipp
@@ -1401,6 +1401,10 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::SetRegisterValue(const Register key,
   printvalue(value);
   Register newKey = getBiggestEncoding(key);
   SetRegisterValue_internal(newKey, value);
+  // Any write invalidates a stale import-provenance binding on this
+  // register; a later `call reg` must not emit a named external call
+  // unless a fresh `mov reg, [rip+iat]` re-tagged it.
+  registerImportSource.erase(newKey);
 
 }
 

--- a/lifter/semantics/Semantics_ControlFlow.ipp
+++ b/lifter/semantics/Semantics_ControlFlow.ipp
@@ -49,6 +49,24 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_mov() {
   printvalue(Rvalue);
 
   SetIndexValue(0, Rvalue);
+
+  // Provenance tagging: if this is `mov reg, [rip+disp]` and disp+RIP
+  // resolves to an IAT slot, remember which import the register now holds.
+  // A later `call reg` can then emit a named external call without needing
+  // SSA-level back-tracing through the folded load.
+  if (instruction.types[0] >= OperandType::Register8 &&
+      instruction.types[0] <= OperandType::Register64 &&
+      instruction.types[1] >= OperandType::Memory8 &&
+      instruction.types[1] <= OperandType::Memory64 &&
+      instruction.mem_base == Register::RIP &&
+      instruction.mem_index == Register::None) {
+    uint64_t ea = current_address + instruction.mem_disp;
+    auto it = importMap.find(ea);
+    if (it != importMap.end()) {
+      registerImportSource[getBiggestEncoding(instruction.regs[0])] =
+          it->second;
+    }
+  }
 }
 MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_cmovcc() {
 
@@ -174,6 +192,59 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_call() {
       emittedExternalCall = true;
 
       // Skip the switch/Unflatten path entirely.
+      goto call_done;
+    }
+    // Unresolved RIP-relative call: importMap has no entry for this IAT
+    // slot.  Emit an opaque external call with strict-ABI clobber and
+    // continue at the post-call address.  Falling through to operand
+    // dispatch would treat the raw on-disk IAT bytes as a jump target
+    // and silently corrupt the lift (the post-call block ends up
+    // sealed with ret undef).
+    {
+      auto fx = this->buildUnknownCallFx();
+      fx.target = CallTargetClass::UnknownIndirect;
+      auto* eaValue = builder->getInt64(ea);
+      auto* targetPtr = builder->CreateIntToPtr(
+          eaValue, PointerType::get(context, 0));
+      auto* callResult = builder->CreateCall(
+          parseArgsType(nullptr, context), targetPtr, parseArgs(nullptr));
+      applyPostCallEffects(callResult, fx);
+      abi::printCallEffectsDiag(fx, current_address - instruction.length);
+      diagnostics.warning(
+          DiagCode::CallIndirectUnresolved,
+          current_address - instruction.length,
+          "Unresolved RIP-relative IAT call at EA=0x" +
+              std::to_string(ea) + " (no importMap entry)");
+      emittedExternalCall = true;
+      goto call_done;
+    }
+  }
+
+  // Provenance-based fast path for register-indirect calls.  If this
+  // register was last loaded from an IAT slot, emit the named external
+  // call directly — this covers the common MSVC pattern:
+  //   mov rsi, [rip+iat]
+  //   call rsi
+  //   ... args setup ...
+  //   call rsi
+  // where the concolic engine has folded the load to a ConstantInt
+  // matching the on-disk IAT value, losing SSA provenance.
+  if (instruction.types[0] >= OperandType::Register8 &&
+      instruction.types[0] <= OperandType::Register64) {
+    Register reg = getBiggestEncoding(instruction.regs[0]);
+    auto it = registerImportSource.find(reg);
+    if (it != registerImportSource.end()) {
+      const auto& importName = it->second;
+      callFunctionIR(importName, nullptr);
+      debugging::doIfDebug([&]() {
+        std::cout << "[call-abi] resolved import via register provenance: "
+                  << importName << "\n" << std::flush;
+      });
+      diagnostics.info(
+          DiagCode::CallOutlinedImportThunk,
+          current_address - instruction.length,
+          "Resolved register-indirect import: " + importName);
+      emittedExternalCall = true;
       goto call_done;
     }
   }


### PR DESCRIPTION
Recovered WIP from a prior session. See commit body for details and provenance note. Verified to produce the expected lift output on example2.bin (61 insns, 6 imports, 0 warnings, 0 errors).