### PR TITLE
lifter: alias hint/name VAs in importMap; stop lift_ret at import call

### DIFF
--- a/lifter/core/LifterStages.hpp
+++ b/lifter/core/LifterStages.hpp
@@ -126,6 +126,19 @@ createConfiguredLifterForRuntime(uint8_t* fileBase, size_t fileSize,
             size_t maxLen = fileSize - (hnOff + 2);
             if (strnlen(funcName, maxLen) == maxLen) continue;
             lifter->importMap[iatSlotVA] = funcName;
+            // Alias the hint/name entry's runtime VA to the same name.
+            // The Win32 loader replaces each IAT slot at startup with the
+            // resolved function pointer, but the lifter's static memory
+            // model returns the on-disk QWORD - which for name imports is
+            // the RVA of the hint/name entry.  Without this alias, when an
+            // obfuscated dispatcher loads the IAT slot and uses the value
+            // as a call/ret target, lift_call/lift_ret would see the hint/
+            // name address (e.g. 0x140002628 for GetStdHandle) and fail to
+            // recognise it as an import.  Including the alias lets the
+            // existing import-recognition paths fire on the lifter's
+            // pre-load value just as they do on the runtime value.
+            uint64_t hintNameVA = imageBase + hintNameRva;
+            lifter->importMap[hintNameVA] = funcName;
           }
         }
       }

--- a/lifter/semantics/Semantics_ControlFlow.ipp
+++ b/lifter/semantics/Semantics_ControlFlow.ipp
@@ -538,17 +538,19 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_ret() { // fix
             DiagCode::CallOutlinedImportThunk,
             current_address - instruction.length,
             "Resolved ret-to-IAT import: " + importName);
-        // Simulate the external callee's own ret by popping one more
-        // qword (the continuation address pre-staged by the caller).
-        // The new [rsp] now holds that continuation; feed it to solvePath
-        // so the lifter continues at the VM's post-call handler instead
-        // of the IAT pointer we just consumed.
-        auto* continuationValue = GetMemoryValue(getSPaddress(), 64);
-        rsp_result = createAddFolder(
-            rsp_result,
-            llvm::ConstantInt::get(rsp_result->getType(), ptrSize));
-        SetRegisterValue(Register::RSP, rsp_result);
-        realval = continuationValue;
+        // The continuation address that the caller pre-staged on the stack
+        // (e.g. Themida's VM pushes the next-handler address below the IAT
+        // pointer) is not generally resolvable from the lifter's static
+        // memory model: the stored slot holds runtime-specific data we
+        // cannot reconstruct statically.  Terminate this path here - the
+        // named external call is in the IR, which is what the devirtual-
+        // isation correctness gate needs.  If we need transitive control
+        // flow later, route it through a dedicated 'imported-call-con-
+        // tinuation' analysis that has enough state to resolve it.
+        builder->CreateUnreachable();
+        run = 0;
+        finished = 1;
+        return;
       }
     }
   }


### PR DESCRIPTION
First measurable progress on the Themida equivalence gate: 1 import (GetStdHandle) now surfaces on example2-virt.bin when reachability is unblocked (MERGEN_NO_LOOP_GEN=1). The gate itself is still red under default env (0/4) because default loop-generalization caps exploration before the ret site; this PR covers the **recognition** half of the fix.

**Two fixes.**

1. LifterStages.hpp: alias the hint/name entry runtime VA of every name import to the same import name in importMap. The Windows loader replaces each IAT slot with the resolved function pointer at startup, but the lifters static memory model returns the on-disk QWORD (the hint/name RVA, e.g. 0x140002628 for GetStdHandle on example2-virt). Aliasing lets the existing import-recognition paths fire on the pre-load value too.

2. lift_ret: stop lifting after a ret-to-IAT match. Previous code popped another qword (simulating externals ret) and continued at the continuation. On Themida the continuation is not generally static-resolvable, and the lifter crashed trying to lift bogus memory. Named import is in IR regardless.

**Measurement (example2-virt.bin @ 0x140001000 with MERGEN_NO_LOOP_GEN=1):**
- before: 0 imports, 1 error (OUTSD from wandering into .rdata)
- after:  1 import (GetStdHandle) at 0x14017fa77, 0 errors, 0 warnings

Non-virt example2.bin unchanged: 61 insns, 6 imports, 0 warn/err. python test.py baseline passes. Determinism check passes.

**Why gate still red:** python test.py themida uses default env. Default loop-generalization abstracts the VM dispatch before the ret sites fire. Pairs with #182s MERGEN_GEN_MIN_REVISITS knob once the T=6/8/12 dispatcher-state crash gets fixed.

**Followups:** (a) fix T>=6 dispatcher crash; (b) reach the CharUpperA/ReadConsoleA/WriteConsoleA ret sites via improved dispatcher exploration.