### PR TITLE
lifter: centralise import recognition in PathSolver.resolveTargetBlock

### DIFF
--- a/lifter/analysis/PathSolver.ipp
+++ b/lifter/analysis/PathSolver.ipp
@@ -84,11 +84,42 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(PATH_info)::solvePath(
     bool generalizedBackup;
   };
 
+  auto importBlocks = std::make_shared<std::unordered_map<uint64_t, BasicBlock*>>();
+  auto resolveImportTarget = [&, this, importBlocks](uint64_t target) -> BasicBlock* {
+    auto importIt = importMap.find(target);
+    if (importIt == importMap.end()) return nullptr;
+    auto cached = importBlocks->find(target);
+    if (cached != importBlocks->end()) return cached->second;
+    const std::string& importName = importIt->second;
+    BasicBlock* importBB = BasicBlock::Create(
+        builder->getContext(), "bb_import_" + importName, fnc);
+    BasicBlock* savedBB = builder->GetInsertBlock();
+    auto savedIP = builder->GetInsertPoint();
+    builder->SetInsertPoint(importBB);
+    callFunctionIR(importName, nullptr);
+    builder->CreateUnreachable();
+    builder->SetInsertPoint(savedBB, savedIP);
+    diagnostics.info(
+        DiagCode::CallOutlinedImportThunk,
+        current_address - instruction.length,
+        "Resolved indirect-transfer import: " + importName);
+    (*importBlocks)[target] = importBB;
+    return importBB;
+  };
+
   auto resolveTargetBlock = [&](uint64_t target, const std::string& name)
       -> ResolvedTargetBlock {
     if (auto* reused = getLiftedBackedgeBB(target)) {
       record_generalized_loop_backedge(reused);
       return {reused, true, false};
+    }
+    // Import recognition: if the resolved target is an entry in importMap
+    // (IAT slot VA or its hint/name VA alias), the transfer is actually
+    // a call to a named external function.  Materialise a leaf block with
+    // call @import + unreachable so we do not follow into Kernel32 or
+    // try to lift the on-disk hint/name bytes as code.
+    if (auto* importBB = resolveImportTarget(target)) {
+      return {importBB, /*reusedBackedge=*/false, /*generalizedBackup=*/false};
     }
 
     const bool backwardVisitedTarget =

--- a/lifter/core/LifterClass.hpp
+++ b/lifter/core/LifterClass.hpp
@@ -797,9 +797,13 @@ public:
     // Tunable via MERGEN_GEN_MIN_REVISITS.
     //
     // Default 0 keeps the pre-existing behaviour (threshold never
-    // rejects). Non-zero values currently expose latent state-machinery
-    // bugs in the Themida VM dispatcher path (crashes at T=6/8/12 on
-    // example2-virt.bin) - experiment flag, not a production tuning yet.
+    // rejects). Non-zero values currently regress the rewrite_smoke
+    // VM-loop samples (their IR shape expects generalisation to fire
+    // immediately). Themida-style targets benefit from T=16+ but the
+    // knob is exposed rather than defaulted until a shape-aware
+    // heuristic can distinguish a VM dispatcher from a simple loop.
+    // Values {6, 8, 12} crash on example2-virt.bin - unrelated
+    // dispatcher-state bug; avoid those when sweeping.
     unsigned revisitThreshold = 0;
     if (const char* env = std::getenv("MERGEN_GEN_MIN_REVISITS")) {
       char* end = nullptr;


### PR DESCRIPTION
When solvePath resolves its target to an entry in importMap (IAT slot VA or hint/name-alias VA, added in #184), materialise a leaf block containing `call @<importName>(); unreachable` and return it as the branch target. One hook covers every solvePath caller (lift_jmp, lift_ret) instead of duplicating the check in each caller.

Replaces the previous behaviour of following the resolved target into Kernel32 / .rdata — which triggered OUTSD "not implemented" errors on example2-virt.bin under `MERGEN_NO_LOOP_GEN=1` because the lifter tried to decode hint/name table bytes as code.

**Scope:** fires only when the lifter actually reaches an IAT-backed target. At default env that does not happen on `example2-virt.bin` because loop-generalisation abstracts the VM dispatcher before any ret site is reached. With `MERGEN_GEN_MIN_REVISITS=16` the first IAT gadget is reached and GetStdHandle surfaces as a named call; the test still fails 3/4 because the other imports live further into the dispatcher.

**Why the default isnt raised in this PR:** bumping `MERGEN_GEN_MIN_REVISITS` from 0 to 16 was tried and reverted — it regresses the `rewrite_smoke` VM-loop samples (`dummy_vm_loop`, `bytecode_vm_loop`, `stack_vm_loop`) whose required patterns expect generalisation to fire on the first backedge. A shape-aware discriminator between a VM dispatcher and a simple loop is needed before the knob can safely be non-zero by default.

**Regression checks (all on default env):**
- non-virt `example2.bin`: unchanged — 61 insns, 6 imports, 0 warn/err.
- `python test.py baseline`: passes; determinism check: passes.
- `python test.py themida`: still red 0/4 at default env (unchanged); 1/4 with `MERGEN_GEN_MIN_REVISITS=16` env override.

**Followup:** a shape-aware gate that tells a VM dispatcher from a simple loop, allowing a safe non-zero default for `MERGEN_GEN_MIN_REVISITS`.