### PR TITLE
lifter: cleanup follow-ups to the PathSolver import hook

### DIFF
--- a/lifter/analysis/PathSolver.ipp
+++ b/lifter/analysis/PathSolver.ipp
@@ -119,7 +119,11 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(PATH_info)::solvePath(
     // call @import + unreachable so we do not follow into Kernel32 or
     // try to lift the on-disk hint/name bytes as code.
     if (auto* importBB = resolveImportTarget(target)) {
-      return {importBB, /*reusedBackedge=*/false, /*generalizedBackup=*/false};
+      // Mark as reusedBackedge so solvePath skips queuing the target for
+      // further lifting - the import block is a terminal leaf, attempting
+      // to lift at its 'address' (an IAT slot or hint/name VA) would try
+      // to decode on-disk data as code.
+      return {importBB, /*reusedBackedge=*/true, /*generalizedBackup=*/false};
     }
 
     const bool backwardVisitedTarget =

--- a/lifter/semantics/Semantics_ControlFlow.ipp
+++ b/lifter/semantics/Semantics_ControlFlow.ipp
@@ -504,56 +504,12 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_ret() { // fix
 
   SetRegisterValue(Register::RSP, rsp_result);
 
-  // Ret-to-IAT import recognition.  If the value being popped resolves to
-  // a concrete IAT slot, this ret is actually a 'push target; ret'
-  // indirect-call gadget (VMP/Themida dispatcher idiom, or plain thunk).
-  // Emit the named external call, then simulate the external's own ret by
-  // popping the continuation address off the stack so control flow resumes
-  // at the VM's post-call handler instead of lifting IAT bytes as code.
-  //
-  // Try two routes to a concrete target: direct ConstantInt (the popped
-  // value was a SSA-folded load of an IAT slot) and computePossibleValues
-  // returning a single concrete value (obfuscation chains that fold to one
-  // address on this path).
-  {
-    uint64_t retTargetAddr = 0;
-    bool retTargetResolved = false;
-    if (auto* constInt = llvm::dyn_cast<llvm::ConstantInt>(realval)) {
-      retTargetAddr = constInt->getZExtValue();
-      retTargetResolved = true;
-    } else {
-      auto pvset = computePossibleValues(realval);
-      if (pvset.size() == 1) {
-        retTargetAddr = pvset.begin()->getZExtValue();
-        retTargetResolved = true;
-      }
-    }
-    if (retTargetResolved) {
-      retTargetAddr = normalizeRuntimeTargetAddress(retTargetAddr);
-      auto importIt = importMap.find(retTargetAddr);
-      if (importIt != importMap.end()) {
-        const auto& importName = importIt->second;
-        callFunctionIR(importName, nullptr);
-        diagnostics.info(
-            DiagCode::CallOutlinedImportThunk,
-            current_address - instruction.length,
-            "Resolved ret-to-IAT import: " + importName);
-        // The continuation address that the caller pre-staged on the stack
-        // (e.g. Themida's VM pushes the next-handler address below the IAT
-        // pointer) is not generally resolvable from the lifter's static
-        // memory model: the stored slot holds runtime-specific data we
-        // cannot reconstruct statically.  Terminate this path here - the
-        // named external call is in the IR, which is what the devirtual-
-        // isation correctness gate needs.  If we need transitive control
-        // flow later, route it through a dedicated 'imported-call-con-
-        // tinuation' analysis that has enough state to resolve it.
-        builder->CreateUnreachable();
-        run = 0;
-        finished = 1;
-        return;
-      }
-    }
-  }
+  // Ret-to-IAT import recognition is centralised in the PathSolver
+  // resolveTargetBlock hook: it catches any solvePath resolution whose
+  // target lands in importMap (IAT VA or hint/name alias), creates a
+  // leaf block with 'call @import(); unreachable', and does not queue
+  // the import VA for further lifting.  This covers ret-to-IAT as well
+  // as any other indirect transfer that ends up at an imported target.
   
   ScopedPathSolveContext pathSolveContext(this, PathSolveContext::Ret);
   auto pathResult = solvePath(function, destination, realval);


### PR DESCRIPTION
Two small cleanups on top of #185.

1. **PathSolver.resolveTargetBlock returns `reusedBackedge=true`** for the synthetic import block. solvePath uses that flag to skip queuing the target for further lifting, which is what we want: the import blocks "address" is an IAT slot VA or a hint/name VA, and decoding the bytes at those addresses repeats the OUTSD "not implemented" error the hook exists to avoid.
2. **Delete the ret-to-IAT pre-check in `lift_ret`** (added in #184). The PathSolver hook already catches every target the pre-check would have (and more, via solvePath’s `getConstraintVal` route). Removing it deletes ~50 lines of duplicated logic and leaves the hook as the single source of truth.

**Functionally neutral on every measured configuration:**

| | before | after |
|---|---|---|
| virt default env | 0/4 | 0/4 |
| virt MERGEN_GEN_MIN_REVISITS=16 | 1/4 GetStdHandle | 1/4 GetStdHandle |
| virt MERGEN_NO_LOOP_GEN=1 | 1/4 GetStdHandle | 1/4 GetStdHandle |
| non-virt example2.bin | 6 imports, 0 warn/err | 6 imports, 0 warn/err |

`python test.py baseline` passes; determinism check passes.