### PR TITLE
docs: explain why ret-to-IAT chaining is not wired up

### DIFF
--- a/lifter/semantics/Semantics_ControlFlow.ipp
+++ b/lifter/semantics/Semantics_ControlFlow.ipp
@@ -503,13 +503,20 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_ret() { // fix
   }
 
   SetRegisterValue(Register::RSP, rsp_result);
-
   // Ret-to-IAT import recognition is centralised in the PathSolver
   // resolveTargetBlock hook: it catches any solvePath resolution whose
   // target lands in importMap (IAT VA or hint/name alias), creates a
   // leaf block with 'call @import(); unreachable', and does not queue
-  // the import VA for further lifting.  This covers ret-to-IAT as well
-  // as any other indirect transfer that ends up at an imported target.
+  // the import VA for further lifting.
+  //
+  // A chained-continuation variant (pop the pre-staged continuation and
+  // feed it to solvePath so exploration continues to the next VM handler)
+  // was tried here, including a mapped-address safety guard on the first
+  // chain step. Chaining reliably crashes the lifter on T>=32 runs of
+  // example2-virt.bin after exploring past the first import call. The
+  // crash is downstream of the chain itself (in one of the additional
+  // blocks that chaining unlocks), so the guard does not catch it. Needs
+  // a deeper root-cause investigation before chaining is safe to land.
   
   ScopedPathSolveContext pathSolveContext(this, PathSolveContext::Ret);
   auto pathResult = solvePath(function, destination, realval);


### PR DESCRIPTION
Expands the comment block beside the PathSolver-centralised import hook in `lift_ret` so the next session does not re-attempt the chained-continuation variant from scratch.

Attempted: after recognising a ret-to-IAT, emit `callFunctionIR` and feed the VMs pre-staged continuation (`[rsp+8]` before the original ret) to solvePath so exploration follows into the next handler. Added a mapped-address safety guard on the first chain step.

Result on `example2-virt.bin @ 0x140001000`:

| env | before chaining | with chaining |
|---|---|---|
| default | 0/4, 2544 insns | 0/4, 2544 insns |
| T=16 | 1/4 GetStdHandle, 389 blocks, 0 warn/err | 1/4 GetStdHandle, 429 blocks, 0 warn/err |
| T=32 | 1/4 GetStdHandle, 421 blocks, 0 warn/err | **crash 0xc0000005** |
| NO_LOOP_GEN | 1/4 GetStdHandle, 2638 blocks, 0 warn/err | **crash 0xc0000005** |

Diagnosis: continuations resolve cleanly (GetStdHandles continuation is `0x1401c888e`, a valid .vlizer VM handler entry; other rets give RVAs that normalize to valid .vlizer addresses too). The crash is downstream of the chain — in one of the extra blocks chaining unlocks — so the first-step guard doesnt catch it.

Comment-only change; no code behaviour change.

Non-virt `example2.bin`: unchanged. `python test.py baseline`: passes. Determinism check: passes.