### PR TITLE
lifter: shape-aware gen threshold: 16 on IndirectJump, 0 elsewhere

### DIFF
--- a/lifter/core/LifterClass.hpp
+++ b/lifter/core/LifterClass.hpp
@@ -796,15 +796,29 @@ public:
     // dispatchers (which re-enter the header many times) still generalize.
     // Tunable via MERGEN_GEN_MIN_REVISITS.
     //
-    // Default 0 keeps the pre-existing behaviour (threshold never
-    // rejects). Non-zero values currently regress the rewrite_smoke
-    // VM-loop samples (their IR shape expects generalisation to fire
-    // immediately). Themida-style targets benefit from T=16+ but the
-    // knob is exposed rather than defaulted until a shape-aware
-    // heuristic can distinguish a VM dispatcher from a simple loop.
+    // Shape-aware default: when the current path-solve context is
+    // IndirectJump (or a resolved-target widening from one), the header
+    // is most likely a VM dispatcher that re-enters with different
+    // opcodes on every iteration. Holding off generalisation until the
+    // header has been revisited enough times lets concrete exploration
+    // cover more handlers before the state is abstracted to phis.
+    // Simple guest loops reached through ConditionalBranch/DirectJump
+    // keep threshold 0 so their first backedge immediately generalises
+    // (which is what rewrite_smoke VM-loop samples rely on).
+    //
     // Values {6, 8, 12} crash on example2-virt.bin - unrelated
-    // dispatcher-state bug; avoid those when sweeping.
-    unsigned revisitThreshold = 0;
+    // dispatcher-state bug; avoid those when sweeping manually via
+    // MERGEN_GEN_MIN_REVISITS.
+    // Only IndirectJump context indicates a dispatcher (jmp reg / jmp [mem])
+    // whose targets come from indirect computation. DirectJump and
+    // ConditionalBranch paths belong to simple guest loops and keep
+    // threshold 0 so their first backedge immediately generalises. This
+    // preserves the rewrite_smoke VM-loop sample patterns while still
+    // holding off generalisation on Themida-style dispatchers long enough
+    // for concrete exploration to cover the IAT-gadget ret sites.
+    const bool dispatcherShape =
+        currentPathSolveContext == PathSolveContext::IndirectJump;
+    unsigned revisitThreshold = dispatcherShape ? 16u : 0u;
     if (const char* env = std::getenv("MERGEN_GEN_MIN_REVISITS")) {
       char* end = nullptr;
       unsigned long parsed = std::strtoul(env, &end, 10);


### PR DESCRIPTION
First import to surface on `example2-virt.bin` under **default environment** without any env override. `python test.py themida` goes from 0/4 → **1/4** (GetStdHandle).

**What changed.** The revisit threshold on `canGeneralizeStructuredLoopHeader` now keys on the path-solve context:

| context | threshold | rationale |
|---|---|---|
| `IndirectJump` (jmp reg / jmp [mem]) | 16 | likely a VM dispatcher; hold generalisation off long enough for concrete exploration to reach IAT-gadget ret sites |
| `DirectJump` / `ConditionalBranch` | 0 | simple guest loops; generalise on first backedge so rewrite_smoke VM-loop patterns stay intact |

Replaces the earlier `targetResolvedConcretely` signal that fired on every solvePath-resolved target — too broad, regressed the VM-loop samples.

**Measurement on `example2-virt.bin @ 0x140001000`:**

|  | before | after |
|---|---|---|
| imports | 0/4 | **1/4 (GetStdHandle)** |
| instructions_lifted | 2544 | 11441 |
| blocks_attempted | 56 | 359 |
| warnings | 0 | 0 |
| errors | 0 | 0 |

**Regression checks:**
- non-virt `example2.bin`: 61 insns, 6 imports, 0 warn/err (unchanged).
- `python test.py baseline`: passes including `dummy_vm_loop` / `bytecode_vm_loop` / `stack_vm_loop` (required `phi i32`/`add i32`/`sub i32`/`mul i33` patterns all present).
- Determinism check: passes.

`MERGEN_GEN_MIN_REVISITS` env still overrides per-header for researchers. Values {6, 8, 12} still crash the virt sample — unrelated dispatcher-state bug, same as before.

**Followup:** other 3 required imports (CharUpperA, ReadConsoleA, WriteConsoleA) still blocked. Their ret sites live behind the same downstream-exploration ceiling; the chaining attempt (#187 tombstone) showed a crash at ~1891 blocks deep. Next step is localising that crash under a debugger.