### PR TITLE
lifter: make maxBasicBlockBudget tunable via MERGEN_MAX_BLOCK_BUDGET

### DIFF
--- a/lifter/core/LifterStages.hpp
+++ b/lifter/core/LifterStages.hpp
@@ -26,6 +26,13 @@ createConfiguredLifterForRuntime(uint8_t* fileBase, size_t fileSize,
     lifter->liftProgressDiagEnabled =
         value == "1" || value == "true" || value == "TRUE";
   }
+  if (const char* env = std::getenv("MERGEN_MAX_BLOCK_BUDGET")) {
+    char* end = nullptr;
+    unsigned long parsed = std::strtoul(env, &end, 10);
+    if (end != env && *end == '\0') {
+      lifter->maxBasicBlockBudget = static_cast<uint32_t>(parsed);
+    }
+  }
   // Memory policy configured later in prepareLifterStageContext
   // when RuntimeImageContext (with PE stack reserve) is available.
 


### PR DESCRIPTION
The per-function basic-block budget is a compile-time constant (`4096`). Deep-exploration crashes — e.g. the chain + `T>=32` SEGV at ~1891 blocks tracked as a known blocker for Themida-virt import recovery — need a reliable way to cap the lift at a specific block count to bisect the crash site.

Expose an integer env var that overrides the default:

| value | behaviour |
|---|---|
| `MERGEN_MAX_BLOCK_BUDGET=0` | disables the cap entirely |
| `MERGEN_MAX_BLOCK_BUDGET=<N>` | caps the function at N basic blocks, terminating cleanly with the existing `LiftBlockBudgetExceeded` error once `fnc->size()` reaches N |
| unset | current default (4096) |

**Verified:**
- `MERGEN_MAX_BLOCK_BUDGET=100` stops at 99 blocks and emits `LiftBlockBudgetExceeded`
- `MERGEN_MAX_BLOCK_BUDGET=0` leaves behaviour unchanged (359 blocks on `example2-virt @ 0x140001000`)
- Default lift (no env) leaves behaviour unchanged
- `python test.py baseline` still green (all rewrite regression checks + determinism)

Pure diagnostic knob. No behaviour change for existing runs.