### PR TITLE
lifter: add MERGEN_BLOCK_TRACE_FILE breadcrumb env var

### DIFF
--- a/lifter/core/LifterClass.hpp
+++ b/lifter/core/LifterClass.hpp
@@ -1059,6 +1059,17 @@ public:
         generalizedLoopAddresses.insert(out.block_address);
       }
       visitedAddresses.insert(out.block_address);
+      // Per-block VA breadcrumb to pin crashes when a debugger is not
+      // available. Emitted only when MERGEN_BLOCK_TRACE_FILE is set.
+      if (const char* trace = std::getenv("MERGEN_BLOCK_TRACE_FILE")) {
+        FILE* f = std::fopen(trace, "a");
+        if (f) {
+          std::fprintf(f, "%zu 0x%llx\n", fnc->size(),
+              (unsigned long long)out.block_address);
+          std::fflush(f);
+          std::fclose(f);
+        }
+      }
       blockInfo = out;
       return true;
     }


### PR DESCRIPTION
Emit one line per block pulled off the lift worklist to a file, with per-block flush. Useful for pinning deep-exploration crashes when a debugger is unavailable or cannot attach to the release-built lifter on this host.

**Format per line** (space-separated):
```
<fnc->size()-at-pop> <0x-prefixed-block-VA>
```

Emitted only when `MERGEN_BLOCK_TRACE_FILE=<path>` is set. File is opened in append mode and flushed + closed on every block, so the last line always survives a crash.

Used during iteration on the Themida-virt import-recovery work to pin a `chain+T=32` SEGV to block **755**, VA `0x14017facc`. The bytes there include a `pop rsp` (`5c`), a classic symbolic-memory hazard — useful diagnostic lead for future crash-fix work.

**Verified:**
- `python test.py baseline` green (rewrite regression + determinism)
- Default themida lift unchanged (359 blocks, 1/4 imports)

Pure diagnostic knob. No behaviour change when the env var is unset.