### PR TITLE
lifter: add MERGEN_INSTR_TRACE_FILE per-instruction breadcrumb

### DIFF
--- a/lifter/core/LifterClass.hpp
+++ b/lifter/core/LifterClass.hpp
@@ -480,6 +480,17 @@ public:
     {
       auto decodeSample = profiler.sample("lift_decode");
       this->current_address = addr;
+      // Per-instruction VA breadcrumb: complements MERGEN_BLOCK_TRACE_FILE
+      // by pinning the exact instruction PC when a crash occurs within a
+      // block. Set MERGEN_INSTR_TRACE_FILE to enable.
+      if (const char* trace = std::getenv("MERGEN_INSTR_TRACE_FILE")) {
+        FILE* f = std::fopen(trace, "a");
+        if (f) {
+          std::fprintf(f, "0x%llx\n", (unsigned long long)addr);
+          std::fflush(f);
+          std::fclose(f);
+        }
+      }
       auto offset = file.address_to_mapped_address(addr);
       if (offset == 0) {
         this->run = 0;


### PR DESCRIPTION
Companion to `MERGEN_BLOCK_TRACE_FILE` from #192. Writes one line per instruction lifted to the target file, with per-instruction flush. Pins exactly which instruction VA precedes a crash when debuggers are unavailable.

**Format:**
```
0x<instruction-VA>
```

**Used to localise** the `chain+T=32` Themida crash from *"block 755"* (block-level trace) down to the **exact instruction PC `0x14017fae1`** — the `push [rsp]` immediately after `pop rsp` in the VM's stack-switch gadget at `0x14017facc..0x14017fae3`:

```
0x14017facc  4c 33 1c 24           xor r11, [rsp]
0x14017fad0  41 55                 push r13
0x14017fad2  4d 89 dd              mov r13, r11
0x14017fad5  4c 31 6c 24 08        xor [rsp+8], r13
0x14017fada  41 5d                 pop r13
0x14017fadc  4c 33 1c 24           xor r11, [rsp]
0x14017fae0  5c                    pop rsp        ← loads new RSP from memory
0x14017fae1  ff 34 24              push [rsp]     ← CRASH (reads via new RSP)
```

Concrete bug class now identified: the lifter's `GetMemoryValue` path does not tolerate an out-of-range concrete RSP produced by `pop rsp`. Fixing that is a separate follow-up.

**Verified:**
- `python test.py baseline` green (rewrite regression + determinism)
- Default themida lift unchanged (359 blocks, 1/4 imports)

Pure diagnostic knob. No behaviour change when the env var is unset.