### PR TITLE
lifter: guard pop rsp against out-of-range concrete values

### DIFF
--- a/lifter/semantics/Semantics_Bitwise.ipp
+++ b/lifter/semantics/Semantics_Bitwise.ipp
@@ -445,6 +445,32 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_pop() {
 
   SetRegisterValue(Register::RSP, result); // then add rsp 8
 
+  // Guard: `pop rsp` (destination operand IS RSP) with a concrete popped
+  // value outside the tracked pseudo-stack range is a VM stack-switch
+  // gadget whose subsequent [rsp] loads dereference into unmapped
+  // memory and crash the lifter. When we can see this statically, bail
+  // the block with a structured warning and an unreachable terminator
+  // instead of letting the next memory op take us down. Symbolic Rvalue
+  // is already handled by the existing symbolic-load path.
+  if (instruction.types[0] >= OperandType::Register8 &&
+      instruction.types[0] <= OperandType::Register64 &&
+      getBiggestEncoding(instruction.regs[0]) == Register::RSP) {
+    if (auto* rvConst = llvm::dyn_cast<llvm::ConstantInt>(Rvalue)) {
+      uint64_t rv = rvConst->getZExtValue();
+      if (!isTrackedStackAddress(rv)) {
+        diagnostics.warning(
+            DiagCode::UnresolvedIndirectJump,
+            current_address - instruction.length,
+            "pop rsp loaded an out-of-range concrete value; bailing to"
+            " avoid a downstream unmapped-memory crash");
+        builder->CreateUnreachable();
+        run = 0;
+        finished = 1;
+        return;
+      }
+    }
+  }
+
   SetIndexValue(0, Rvalue); // op
                             // mov val, rsp first
                             /* ???


### PR DESCRIPTION
A concrete RSP produced by `pop rsp` that falls outside the tracked pseudo-stack range crashes the lifter on the next `[rsp]` memory op — via an unmapped dereference inside `GetMemoryValue`/`solveLoad`. This shape appears in VM stack-switch gadgets (example: the Themida-virt handler at `0x14017facc..fae3`), and the crash kills deep-exploration sweeps.

When `lift_pop` detects the destination operand is `RSP` and `Rvalue` is a `ConstantInt` outside `isTrackedStackAddress`, emit a structured warning and an `unreachable` terminator for the block instead of writing the bad RSP and letting the next memory op take us down.

**Preserved:**
- Symbolic `Rvalue` is unchanged — existing symbolic-load path already handles it
- `ConstantInt` **inside** the tracked stack range is unchanged — legitimate `pop rsp` on a real stack pointer stays supported

**Verified on `example2-virt.bin @ 0x140001000`:**

| config | before | after |
|---|---|---|
| default | 359 blocks, 0 warn, 0 err | 359 blocks, 0 warn, 0 err (guard inert) |
| `chain + T=32` | **SEGV at block 755 / PC 0x14017fae1** | 755 blocks, 1/4, 2 warn, 0 err, exit 0 |
| `chain + NO_LOOP_GEN` | SEGV | 2972 blocks, 1/4, exit 0 |

**The gadget that triggers it:**
```
0x14017facc  xor r11, [rsp]
0x14017fad0  push r13
0x14017fad2  mov r13, r11
0x14017fad5  xor [rsp+8], r13
0x14017fada  pop r13
0x14017fadc  xor r11, [rsp]
0x14017fae0  pop rsp       ← loads new RSP (out-of-range concrete)
0x14017fae1  push [rsp]    ← before: SEGV    after: block bails with warning
```

`python test.py baseline` remains green (rewrite regression + determinism). Default themida lift unchanged — the guard fires only when exploration reaches the gadget, which at current defaults it does not.