### PR TITLE
lifter: stop the lift loop after the ret-to-IAT chain emits its terminator

### DIFF
--- a/lifter/semantics/Semantics_ControlFlow.ipp
+++ b/lifter/semantics/Semantics_ControlFlow.ipp
@@ -540,6 +540,14 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_ret() { // fix
           addUnvisitedAddr(BBInfo(contVA, contBB));
         }
         destination = contVA;
+        // Stop the outer per-instruction lift loop for this block: the
+        // chain has emitted the block's terminator (br to contBB). Any
+        // further instruction lift here would emit a SECOND terminator,
+        // leaving the block malformed - the second br silently orphans
+        // everything the chain's first br reached, so the new import's
+        // call ends up in a dead BB that O2 then DCEs.
+        run = 0;
+        finished = 1;
         return;
       }
     }


### PR DESCRIPTION
The ret-to-IAT chain in `lift_ret` (landed in #195) emits a `br` to the continuation block and returns. But `lift_ret` returning does **not** stop the outer per-instruction lift loop in `liftBasicBlockFromAddress` — that loop only stops when `run=0` or `finished=1`. On return the loop advances `current_address` by the `ret`'s length and lifts the next byte, which emits a **second** terminator in the same BB.

Two terminators in one BB is accepted by `IRBuilder` but makes the block malformed. LLVM treats only the first `br` as the live terminator. All blocks the first `br` reaches still exist, but predecessor-tracking silently treats the **second** `br`'s target as the live successor, so the chain's continuation block (and everything downstream of it) ends up orphaned with zero predecessors.

Visible consequence: `CharUpperA`'s call was in `bb_solved_const8212` whose source block had two consecutive `br`s. The chain's `br` to the `bb_after_import_CharUpperA` BB was the second terminator, so the first `br` went to some other block and `CharUpperA`'s continuation became unreachable. After O2 it got DCE'd entirely along with its `declare`.

**Fix:** set `run=0` and `finished=1` after `CreateBr` in the chain path. The outer loop exits cleanly, the block keeps its single `br` to `contBB`, and the continuation path stays connected to the CFG.

**Impact on `example2-virt.bin @ 0x140001000`:**

| metric | before | after |
|---|---|---|
| pre-opt imports | 4/4 | 4/4 |
| **post-opt imports (after O2 DCE)** | **1/4** | **4/4** |
| blocks_attempted | 2365 | 2823 |
| themida_warnings | 7 | 1 |
| themida_errors | 2 | 1 |

Baseline + quick + themida remain green. The malformed-block pattern was the source of most of the junk-switch warnings too: those paths were only reached via the second `br`'s stray successor; with the fix the lifter no longer explores them.