### PR TITLE
lifter: handle INT1 and INT3 like UD2 (call @exception; ret)

### DIFF
--- a/lifter/semantics/Semantics.ipp
+++ b/lifter/semantics/Semantics.ipp
@@ -56,6 +56,8 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::liftInstructionSemantics() {
 #include "x86_64_opcodes.x"
 #undef OPCODE
 #undef OPCODE_CASE
+  case Mnemonic::INT1:
+  case Mnemonic::INT3:
   case Mnemonic::UD2: {
     Function* externFunc = cast<Function>(
         fnc->getParent()


### PR DESCRIPTION
Both `0xF1` (INT1, ICEBP debug trap) and `0xCC` (INT3, debugger break) previously fell through to the `Instruction not implemented` default and emitted a `DiagCode::InstructionNotImplemented` error. Both raise `#DB`/`#BP` exceptions at runtime — functionally equivalent to `UD2`, which already lowers to `call @exception; ret`.

Group them with `UD2` by adding two fall-through case labels. Same lowering: emit `call @exception()`, `ret`, and stop the block.

**On `example2-virt.bin @ 0x140001000`:**

| metric | before | after |
|---|---|---|
| imports | 4/4 | 4/4 |
| warnings | 1 | 1 |
| **errors** | **1** (INT1 at 0x1401928ef) | **0** |

Baseline + quick + themida remain green. Non-virt `example2.bin` unchanged.