### PR TITLE
lifter: track chained import ret-sites to suppress redundant warnings

### DIFF
--- a/lifter/core/LifterClass.hpp
+++ b/lifter/core/LifterClass.hpp
@@ -1186,6 +1186,11 @@ public:
   std::set<uint64_t> generalizedLoopAddresses;
   std::set<uint64_t> pendingLoopGeneralizationAddresses;
   std::set<uint64_t> stackBypassGeneralizedLoopAddresses;
+  // PCs where the ret-to-IAT chain (lift_ret) has successfully recognised
+  // a concrete import call. Used to suppress the UnresolvedRetChain
+  // warning for downstream symbolic re-entries of the same PC - the
+  // concrete semantics are already captured by the earlier chain site.
+  std::set<uint64_t> chainedImportRetSites;
   llvm::DenseMap<uint64_t, llvm::BasicBlock*> addrToBB;
 
   // creates an edge to created bb

--- a/lifter/semantics/Semantics_ControlFlow.ipp
+++ b/lifter/semantics/Semantics_ControlFlow.ipp
@@ -539,6 +539,7 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_ret() { // fix
         if (!visitedAddresses.contains(contVA)) {
           addUnvisitedAddr(BBInfo(contVA, contBB));
         }
+        chainedImportRetSites.insert(current_address - instruction.length);
         destination = contVA;
         // Stop the outer per-instruction lift loop for this block: the
         // chain has emitted the block's terminator (br to contBB). Any
@@ -556,12 +557,17 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_ret() { // fix
   ScopedPathSolveContext pathSolveContext(this, PathSolveContext::Ret);
   auto pathResult = solvePath(function, destination, realval);
   if (pathResult == PATH_unsolved) {
-    ++liftStats.blocks_unreachable;
     uint64_t diagAddr = current_address - instruction.length;
-    std::cout << "[diag] lift_ret: unresolved ROP chain at 0x"
-              << std::hex << diagAddr << std::dec << "\n" << std::flush;
-    diagnostics.warning(DiagCode::UnresolvedRetChain, diagAddr,
-                        "Unresolved ROP chain (ret to symbolic address)");
+    // Suppress the warning when this PC has already been recognised as a
+    // concrete VM-staged import ret-site by an earlier chain fire; the
+    // symbolic re-entry here carries no new information.
+    if (chainedImportRetSites.find(diagAddr) == chainedImportRetSites.end()) {
+      ++liftStats.blocks_unreachable;
+      std::cout << "[diag] lift_ret: unresolved ROP chain at 0x"
+                << std::hex << diagAddr << std::dec << "\n" << std::flush;
+      diagnostics.warning(DiagCode::UnresolvedRetChain, diagAddr,
+                          "Unresolved ROP chain (ret to symbolic address)");
+    }
   }
 
   // If the callee returned to our speculative call's return address,


### PR DESCRIPTION
The ret-to-IAT chain in `lift_ret` recognises concrete VM-staged import calls on first visit. Later symbolic re-entries of the same PC fall through to `solvePath`, which returns `PATH_unsolved` when the popped `realval` is now a phi of multiple concrete values from different dispatch paths, and emits an `UnresolvedRetChain` warning.

The warning is factually correct — that specific revisit couldn't resolve symbolically — but semantically redundant: the concrete import semantics are already captured at the chain site, so the re-entry carries no new information.

Track chained import-ret-site PCs in a new `std::set` member, insert on successful chain fire, and skip the warning emission when the `PATH_unsolved` site is in the set.

**Impact on `example2-virt.bin @ 0x140001000`:**

| | before | after |
|---|---|---|
| warn count | 1 | 1 |
| warn site | `0x14017fa77` (GetStdHandle chain re-entry) | `0x14000110d` (top-level entry ret) |

The warn count is coincidentally unchanged; what moved is *which* PC triggered the single diagnostic emission. The new site is a genuine top-level return that the lifter cannot resolve (the entry function has no caller in this lift context).

**Verified:**
- `python test.py baseline` green
- `python test.py quick` green
- `python test.py themida` green
- Non-virt `example2.bin` unchanged (0 warn, 0 err)