### PR TITLE
lifter: lower IndirectJump shape-aware threshold from 128 to 80

### DIFF
--- a/lifter/core/LifterClass.hpp
+++ b/lifter/core/LifterClass.hpp
@@ -829,7 +829,7 @@ public:
     // for concrete exploration to cover the IAT-gadget ret sites.
     const bool dispatcherShape =
         currentPathSolveContext == PathSolveContext::IndirectJump;
-    unsigned revisitThreshold = dispatcherShape ? 128u : 0u;
+    unsigned revisitThreshold = dispatcherShape ? 80u : 0u;
     if (const char* env = std::getenv("MERGEN_GEN_MIN_REVISITS")) {
       char* end = nullptr;
       unsigned long parsed = std::strtoul(env, &end, 10);


### PR DESCRIPTION
PR #195 set the IndirectJump shape-aware revisit threshold to 128 to unlock all 4 imports on `example2-virt.bin`. Sweeping the threshold post-chain shows **80 is sufficient**: 4/4 imports surface at T=80 already, matching T=128's metric while doing significantly less work.

| T | blocks | imports |
|---|---|---|
| 32 | 797 | 1/4 |
| 48 | 1234 | 2/4 |
| 64 | 1615 | 3/4 |
| **80** | **1986** | **4/4** ← new default |
| 96 | 2374 | 4/4 |
| 128 | 3077 | 4/4 (old default) |

## Impact on `example2-virt.bin @ 0x140001000`

| metric | T=128 | **T=80** |
|---|---|---|
| wall clock (median) | 2.21s | **1.25s** (−43%) |
| pre-opt IR lines | 50,856 | **38,260** (−25%) |
| post-opt IR lines | 305 | **247** (−19%) |
| post-opt stores | 268 | **212** (−21%) |
| imports pre/post | 4/4 | **4/4** |

`DirectJump` and `ConditionalBranch` still use threshold 0, so `rewrite_smoke` VM-loop samples still generalise on their first backedge — no regression.

## Verified

- `python test.py baseline` green (rewrite regression + determinism)
- `python test.py quick` green (semantic regression + microtests)
- `python test.py themida` green: `PASS: example2 - 4 distinct imports, 5 calls (required 4)`
- Non-virt `example2.bin` unchanged