### PR TITLE
lifter: add Win32 console-I/O signatures and preserve call-arg GEPs

### DIFF
--- a/lifter/analysis/CustomPasses.hpp
+++ b/lifter/analysis/CustomPasses.hpp
@@ -161,6 +161,23 @@ public:
           auto* GEP = llvm::dyn_cast<llvm::GetElementPtrInst>(&I);
           if (!GEP) continue;
           if (GEP->getPointerOperand() != memory) continue;
+          // Skip GEPs that escape via a call argument: migrating them to the
+          // stack alloca and then having a call use the resulting pointer
+          // blocks mem2reg/SROA, leaving hundreds of dead stack stores in
+          // the post-opt IR. Leave such GEPs through %memory - it is
+          // already a function argument, so escaping it costs nothing.
+          // Other non-load/store uses (ptrtoint, GEP-of-GEP, etc.) still
+          // get migrated; rewrite_smoke samples rely on that.
+          {
+            bool escapesViaCall = false;
+            for (auto* U : GEP->users()) {
+              if (llvm::isa<llvm::CallBase>(U)) {
+                escapesViaCall = true;
+                break;
+              }
+            }
+            if (escapesViaCall) continue;
+          }
           auto* OffOp = GEP->getOperand(GEP->getNumOperands() - 1);
 
           if (auto* CI = dyn_cast<ConstantInt>(OffOp)) {

--- a/lifter/core/FunctionSignatures.hpp
+++ b/lifter/core/FunctionSignatures.hpp
@@ -298,7 +298,22 @@ public:
       funcArgInfo(Register::R9, I64, 1),
   };
 
-  static inline constexpr std::array<SignatureSpec, 33> kNamedFunctionSpecs = {{
+  // GetStdHandle(DWORD nStdHandle) -> HANDLE
+  // WriteConsoleA / ReadConsoleA  (HANDLE, ptr buf, count, ptr out)
+  static inline constexpr std::array<funcArgInfo, 4> kConsoleIOArgs = {
+      funcArgInfo(Register::RCX, I64, 0),
+      funcArgInfo(Register::RDX, I64, 1),
+      funcArgInfo(Register::R8,  I32, 0),
+      funcArgInfo(Register::R9,  I64, 1),
+  };
+  static inline constexpr std::array<funcArgInfo, 1> kCharUpperArgs = {
+      funcArgInfo(Register::RCX, I64, 1),
+  };
+  static inline constexpr std::array<funcArgInfo, 1> kGetStdHandleArgs = {
+      funcArgInfo(Register::RCX, I32, 0),
+  };
+
+  static inline constexpr std::array<SignatureSpec, 37> kNamedFunctionSpecs = {{
       {"MessageBoxW", nullptr, 0, kMessageBoxArgs.data(), kMessageBoxArgs.size()},
       {"MessageBoxA", nullptr, 0, kMessageBoxArgs.data(), kMessageBoxArgs.size()},
       {"GetTickCount64", nullptr, 0, nullptr, 0},
@@ -332,6 +347,10 @@ public:
       {"RegOpenKeyExW", nullptr, 0, kRegOpenKeyExWArgs.data(), kRegOpenKeyExWArgs.size()},
       {"RegQueryValueExW", nullptr, 0, kRegQueryValueExWArgs.data(), kRegQueryValueExWArgs.size()},
       {"RegCloseKey", nullptr, 0, kCloseHandleArgs.data(), kCloseHandleArgs.size()},
+      {"GetStdHandle", nullptr, 0, kGetStdHandleArgs.data(), kGetStdHandleArgs.size()},
+      {"WriteConsoleA", nullptr, 0, kConsoleIOArgs.data(), kConsoleIOArgs.size()},
+      {"ReadConsoleA",  nullptr, 0, kConsoleIOArgs.data(), kConsoleIOArgs.size()},
+      {"CharUpperA",    nullptr, 0, kCharUpperArgs.data(), kCharUpperArgs.size()},
   }};
 
   static std::unordered_map<std::string, functioninfo>& getNamedFunctionsByName() {


### PR DESCRIPTION
Register proper prototypes for `GetStdHandle`, `WriteConsoleA`, `ReadConsoleA`, and `CharUpperA` in `funcsignatures`. The infrastructure for typed-pointer imports was already in place (`parseArgs` uses `getPointer()` when `arg.argtype.isPtr`), but these four imports lacked signatures and fell through to the unknown-call path that passes 16 GPRs + a raw `%memory` pointer, each arg typed `i64`.

Also extend `PromotePseudoStackPass` with a **narrow** escape filter: stack-range `%memory` GEPs whose users include a `CallBase` are no longer migrated onto the `%stackmemory` alloca. Migrating them would let a call argument use the alloca pointer, which blocks `mem2reg`/SROA on the alloca and leaves hundreds of dead stack stores in the post-opt IR. Leaving those specific GEPs through `%memory` costs nothing (memory is already a function argument). Other non-load/store uses (`ptrtoint`, GEP-of-GEP, stored-as-value) still migrate, so `rewrite_smoke` samples that depend on full alloca promotion keep working.

## Before vs after (example2-virt.bin @ 0x140001000)

Before:
```llvm
%2 = tail call i64 @WriteConsoleA(i64 %1, i64 5368717648, i64 16,
                                  i64 1375568, ptr %memory)
declare i64 @WriteConsoleA(i64, i64, i64, i64, ptr)
```

After:
```llvm
%2 = tail call i64 @WriteConsoleA(
    i64 %1, ptr nonnull inttoptr (i64 5368717648 to ptr),
    i32 16, ptr nonnull inttoptr (i64 1375568 to ptr))
declare i64 @WriteConsoleA(i64, ptr, i32, ptr) local_unnamed_addr
```

All 4 imports now carry their real Win32 prototype:
- `@GetStdHandle(i32)`
- `@WriteConsoleA(i64, ptr, i32, ptr)`
- `@ReadConsoleA (i64, ptr, i32, ptr)`
- `@CharUpperA (ptr)`

## Impact

| metric | before | after |
|---|---|---|
| wall clock (median) | 1.25s | **1.07s** (-14%) |
| post-opt lines | 247 | 257 (+10, signature overhead) |
| themida imports | 4/4 | 4/4 |
| themida warn/err | 1/0 | 1/0 |

Non-virt `example2.bin` output gets dramatically more readable — the full program flow (GetStdHandle×2 → WriteConsoleA prompt → ReadConsoleA → CharUpperA → WriteConsoleA×2) is visible in ~20 typed tail calls. Still 0 warn, 0 err.

## Verified

- `python test.py baseline` green
- `python test.py quick` green (33/33 semantic + microtests)
- `python test.py themida` green: `PASS: example2 - 4 distinct imports, 5 calls (required 4)`