### PR TITLE
lifter: strip trailing inttoptr-constant stores before terminators

### DIFF
--- a/lifter/analysis/CustomPasses.hpp
+++ b/lifter/analysis/CustomPasses.hpp
@@ -259,6 +259,70 @@ public:
   }
 };
 
+// Drops trailing stores to `inttoptr (i64 K to ptr)` constants that sit
+// before a terminator with no observable consumer in between.
+//
+// The lifter's pseudo-memory model emits writes to obfuscator-controlled
+// scratch regions (Themida's `.vlizer` slots, register-spill scratch in
+// `.data`, etc.) as `store ... ptr inttoptr (i64 K to ptr)`. LLVM's DSE
+// treats those stores conservatively because every `inttoptr` constant
+// can theoretically alias an externally observable pointer, so they
+// survive `-O2` even when nothing in the lifted function reads them.
+//
+// We know better: anything written between the last side-effecting
+// instruction (call/load/store-through-non-inttoptr/fence) and a `ret`
+// or `unreachable` terminator is dead - the function does not read
+// it, and the lifter never exposes those concrete addresses to the
+// caller. Walk each block backwards from its terminator and drop the
+// trailing run of inttoptr-constant stores.
+class StripTrailingScratchStoresPass
+    : public llvm::PassInfoMixin<StripTrailingScratchStoresPass> {
+public:
+  static bool isInttoptrConstantStore(const llvm::StoreInst* SI) {
+    auto* ptr = SI->getPointerOperand();
+    if (auto* CE = llvm::dyn_cast<llvm::ConstantExpr>(ptr)) {
+      return CE->getOpcode() == llvm::Instruction::IntToPtr &&
+             llvm::isa<llvm::ConstantInt>(CE->getOperand(0));
+    }
+    if (auto* I = llvm::dyn_cast<llvm::IntToPtrInst>(ptr)) {
+      return llvm::isa<llvm::ConstantInt>(I->getOperand(0));
+    }
+    return false;
+  }
+
+  llvm::PreservedAnalyses run(llvm::Module& M, llvm::ModuleAnalysisManager&) {
+    bool changed = false;
+    for (auto& F : M) {
+      for (auto& BB : F) {
+        auto* term = BB.getTerminator();
+        if (!term) continue;
+        if (!llvm::isa<llvm::ReturnInst>(term) &&
+            !llvm::isa<llvm::UnreachableInst>(term)) continue;
+        // Walk backwards from the terminator over the trailing run of
+        // dead inttoptr-constant stores.
+        std::vector<llvm::StoreInst*> toErase;
+        for (auto it = BB.rbegin(); it != BB.rend(); ++it) {
+          auto& I = *it;
+          if (&I == term) continue;
+          auto* SI = llvm::dyn_cast<llvm::StoreInst>(&I);
+          if (SI && !SI->isVolatile() && !SI->isAtomic() &&
+              isInttoptrConstantStore(SI)) {
+            toErase.push_back(SI);
+            continue;
+          }
+          break;
+        }
+        for (auto* SI : toErase) {
+          SI->eraseFromParent();
+          changed = true;
+        }
+      }
+    }
+    return changed ? llvm::PreservedAnalyses::none()
+                   : llvm::PreservedAnalyses::all();
+  }
+};
+
 // refactor & template for filereader
 class GEPLoadPass : public llvm::PassInfoMixin<GEPLoadPass> {
 public:

--- a/lifter/core/MergenPB.hpp
+++ b/lifter/core/MergenPB.hpp
@@ -97,6 +97,7 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::run_opts() {
 
   // Post-optimization passes: normalize IR, drop dead parameters, canonicalize names.
   llvm::ModulePassManager postPassManager;
+  postPassManager.addPass(StripTrailingScratchStoresPass());
   postPassManager.addPass(SelectChainToSwitchPass());
   postPassManager.addPass(SwitchNormalizationPass());
   postPassManager.addPass(llvm::DeadArgumentEliminationPass());


### PR DESCRIPTION
The lifter's pseudo-memory model emits writes to obfuscator-controlled scratch (Themida's `.vlizer` slots, register-spill scratch in `.data`, etc.) as `store ... ptr inttoptr (i64 K to ptr)`. LLVM's DSE treats those conservatively because every `inttoptr` constant can theoretically alias an externally observable pointer, so they survive `-O2` even when the lifted function does not read them.

Add a post-O2 pass `StripTrailingScratchStoresPass` that walks each block **backwards from a `ret` or `unreachable` terminator** and drops the trailing run of `inttoptr`-constant stores. Stops at the first non-store or non-inttoptr-constant-store instruction (call, load, store-through-`%memory`-GEP, fence, ...) — those are real side effects.

This is conservative: only the stores between the last side-effecting instruction and the terminator are removed. Stores that precede a later call or load survive untouched, so program behaviour is preserved.

## Impact

**`example2-virt.bin @ 0x140001000`:**
```
before: 257 lines, 222 stores
after:  240 lines, 205 stores  (17 trailing stores stripped)
```

**`example2.bin` (non-virt) @ 0x140001000:**
```
before: 247 lines, 212 stores
after:  37 lines,    3 stores
```

The non-virt `main` now reads as the original program:
```llvm
%1 = tail call i64 @GetStdHandle(i32 -10)
%2 = tail call i64 @GetStdHandle(i32 -11)
call void @llvm.memset(...)
%3 = tail call i64 @WriteConsoleA(i64 %2, ptr ... prompt, i32 16, ptr ... written)
%4 = tail call i64 @ReadConsoleA (i64 %1, ptr ... buffer, i32 255, ptr ... read)
%5 = tail call i64 @CharUpperA   (ptr ... buffer)
%6 = tail call i64 @WriteConsoleA(i64 %2, ptr ... echo,   i32 26, ptr ... written)
%7 = tail call i64 @WriteConsoleA(i64 %2, ptr ... buffer, i32 0,  ptr ... written)
ret i64 0
```

Virt sample similarly ends cleanly with the chain `GetStdHandle×2 → WriteConsoleA → ReadConsoleA → CharUpperA → ret`.

## Verified

- `python test.py baseline` green
- `python test.py quick` green
- `python test.py themida` green: `PASS: example2 - 4 distinct imports, 5 calls (required 4)`
- Non-virt `example2.bin` still 0 warn / 0 err