### PR TITLE
docs: Control-Flow Recognition section and punpcklqdq clarification

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,6 +55,39 @@ Pass order matters: GEPLoadPass must run before PromotePseudoMemory, otherwise c
 - **CLI**: `--outline <addrs>` accepts comma-separated hex addresses, parsed in `Utils.cpp`, stored in `ParseResult::outlineAddresses`.
 - **PE export auto-outline**: export addresses are automatically added to the outline set in `createConfiguredLifterForRuntime`. Forwarded exports are filtered out by checking if the RVA falls within the export directory range.
 
+## Control-Flow Recognition
+
+The lift loop recognizes several `ret`/`jmp` shapes beyond a plain return or branch and emits structured IR for them instead of falling through to `solvePath`.
+
+### Real return vs ROP/continuation return
+
+`lift_ret` (`Semantics_ControlFlow.ipp`) classifies the return on entry:
+
+- If RSP folds to the constant `STACKP_VALUE`, this is a return from the outermost (entry) frame. Emit a clean `ret rax` via `emitResolvedFunctionReturn` and stop the lift loop.
+- Otherwise the return is treated as a ROP/continuation return: pop the return target, advance RSP by `ptrSize` (plus the immediate for `ret imm16`), and try to resolve the popped target via `solvePath`. If that fails, the `UnresolvedRetChain` diagnostic is recorded and the block is degraded to a `ret rax` to keep the IR well-formed.
+
+### Ret-to-IAT chain (Themida-virt)
+
+Themida-virt and similar protectors rewrite each `call [rip+IAT]` site as a VM-staged `push target; ret`, where `target` was loaded from the IAT by an upstream VM handler. The original code's semantics consume two stack slots: `ret` pops the IAT slot into RIP (calling the import), then the import's own `ret` pops the continuation address.
+
+When the popped target is a constant in `importMap`, `lift_ret` collapses both pops into one structural emission:
+
+1. Read the next stack slot (`[RSP+ptrSize]`); if it is also a constant, treat it as the continuation VA `contVA`.
+2. Advance RSP by another `ptrSize` so it reflects both pops (the import's return + the original ret). Emitted as `ret-chain-cont-rsp-...` in the IR.
+3. Emit `call @<import>` with an empty `volatileRegs` set so the lifter does not clobber caller-saved GPRs across the external call -- VM dispatchers preserve their own caller-saved state across import calls in the real binary.
+4. Emit `br contBB`, queue `contVA` for lifting if not already visited, record the site in `chainedImportRetSites` so the unresolved-ret diagnostic is suppressed for this address, and stop the per-instruction lift loop for the current block.
+
+Without the RSP advance in step 2, the continuation block sees RSP off by one slot (entry RSP + 8 instead of + 16). For `example2` the post-O2 IR shows only SSA-renumbering churn across the fix because no `[rsp+N]` read in the continuation flows to a visible computation, but the invariant still holds and is gated by the `ret_to_iat_chain_advances_rsp_by_two_slots` microtest.
+
+### Direct vs indirect jumps
+
+`lift_jmp` discriminates on `instruction.types[0]`: `Immediate8`/`Immediate16`/`Immediate32`/`Immediate64` are direct (RIP-relative) jumps, everything else is indirect. For direct jumps the immediate is sign-extended and added to RIP to form the absolute target. Both forms then go through `solvePath`; if the path solver cannot resolve the target, the `UnresolvedIndirectJump` diagnostic is recorded (no inline `std::cout` print -- the diagnostics framework persists it to `output_diagnostics.json`).
+
+### Operand-type quirks
+
+Iced classifies operand types by the bytes the instruction actually accesses, not by physical register/memory width. SSE handlers that gate on `Register128`/`Memory128` only must also accept `Register64`/`Memory64` for instructions whose semantics read fewer bytes than the encoding nominally allows. PUNPCKLQDQ is the canonical example: the encoding is `xmm/m128` but only the low 64 bits of the source are read, so Iced reports `Register64`/`Memory64`. The `sse_memory_form_handlers_do_not_fall_through_to_not_implemented` microtest gates this for `pand`/`por`/`pxor` to catch future Iced reclassifications before they silently reach a `not_implemented; ret` lowering.
+
+
 ## Memory Subsystem
 
 ### FileReader

--- a/docs/REWRITE_BASELINE.md
+++ b/docs/REWRITE_BASELINE.md
@@ -138,7 +138,7 @@ Current active quick-gate semantic coverage is **33 samples / 177 cases** on CI 
 Notable current state:
 - `dummy_vm_loop`, `bytecode_vm_loop`, and `stack_vm_loop` are active VM-shaped control-flow samples.
 - `calc_sum_to_n`, `calc_fib`, and `calc_sum_array` are active again under the current safe path.
-- `calc_cout` is active again after SSE2 `PUNPCKLQDQ` support landed; the manifest currently has zero `ci_skip` entries.
+- `calc_cout` is active under the current safe path. The SSE2 `PUNPCKLQDQ` handler had been present for a while but was silently rejecting real encodings: Iced classifies the source operand by the bytes the instruction actually accesses (low 64 bits), not by physical XMM width, so the handler's `Register128`/`Memory128`-only accept set fell through to `not_implemented` for every site. Fixed in #205 by widening the accept set to also include `Register64`/`Memory64`; the body already truncates to i64 internally so the rewrite is semantically identical. Pre-existing oracle vectors `punpcklqdq_xmm0_xmm1_basic` and `punpcklqdq_xmm0_xmm1_zero_upper_from_zero_source` now pass and gate future regressions; the manifest currently has zero `ci_skip` entries.
 
 ## Call-boundary ABI framework
 


### PR DESCRIPTION
## Summary

Doc-only follow-up to #205 closing two gaps that came up in the post-merge audit:

- **`ARCHITECTURE.md`** gained a **Control-Flow Recognition** section. The `ret-to-IAT chain` pattern (Themida-virt mitigation built out across #195/#196/#205) was completely undocumented despite being a non-trivial structural rewrite. Same section also documents the `lift_ret` real-return vs ROP-return split, `lift_jmp` direct/indirect dispatch, and the Iced operand-type quirk that motivates widening SSE accept sets. New text is descriptive of current behavior, not aspirational.

- **`docs/REWRITE_BASELINE.md`** clarifies the `calc_cout`/`PUNPCKLQDQ` line. It previously said the sample was active "after SSE2 PUNPCKLQDQ support landed", but that was misleading: the handler had been present for a while and silently fell through to `not_implemented` for every site because Iced classifies the source operand by bytes-actually-accessed (low 64), not by physical XMM width. The line now describes the actual fix in #205 and references the pre-existing oracle vectors that gate future regressions.

## Verification

`docs/`-only — no build or test impact. Sanity-checked the rendered Markdown via `read` to confirm structure, and grep'd for `\u2014`-style escape leaks (none).

## Why a separate PR

#205 had already merged when the user asked the doc-update question. Splitting the doc work into its own PR keeps the original PR's diff focused on code/tests and gives the doc text a clean review surface.
