### PR TITLE
Loop generalization, BSR/BSF intrinsics, and stack alloca split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,4 +73,4 @@ scripts/rewrite/tmp_*.json
 *.vtil
 
 # test binaries and research (sources live in testcases/)
-/simple/
+/simple/themida_trace.txt

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ scripts/rewrite/tmp_*.json
 
 # test binaries and research (sources live in testcases/)
 /simple/themida_trace.txt
+simple/
+themida_trace.txt

--- a/lifter/analysis/CustomPasses.hpp
+++ b/lifter/analysis/CustomPasses.hpp
@@ -116,17 +116,23 @@ public:
 
     for (auto& F : M) {
       llvm::Value* memory = mem;
-      llvm::Value* stackMemory = nullptr;
-      // --- Pass 1: scan all stack GEPs to find the actual offset range ---
-      // The stack spans both below and above STACKP_VALUE:
-      //   below = locals/saved regs (frame grows downward)
-      //   above = return address, shadow space, stack-passed arguments
-      // We use explicit stack bounds [stackLower, stackUpper] derived from the
-      // PE header's stack reserve, NOT isConcrete() — because PE image sections
-      // are also concrete and would be misclassified as stack.
-      uint64_t min_offset = UINT64_MAX;
-      uint64_t max_offset = 0;
-      bool found_any = false;
+
+      // Two-alloca split:
+      //   - Main alloca:  scratch slots that don't escape via calls (SROA-friendly).
+      //   - Escape alloca: slots whose pointer flows into a CallBase (won't SROA,
+      //     but isolated so dead stores in the main alloca still get DSE'd).
+      //
+      // The split is by CONSTANT OFFSET: any constant offset touched by ANY
+      // GEP with a CallBase user is marked "escaped". All GEPs (constant or
+      // non-constant) at escaped offsets go to the escape alloca; everything
+      // else goes to the main alloca. This preserves pointer identity within
+      // each escaped slot (init store, call arg, post-call read all alias).
+      //
+      // Non-constant-offset GEPs always go to the main alloca because we can't
+      // cheaply determine whether their KnownBits range overlaps an escaped slot.
+      // In practice, lifters emit non-constant offsets for buffer regions and
+      // constant offsets for scalar API slots, so this partitioning works.
+
       auto getMaxAccessBytes = [&](llvm::GetElementPtrInst* GEP) -> uint64_t {
         uint64_t maxBytes = 1;
         for (auto* User : GEP->users()) {
@@ -149,106 +155,128 @@ public:
         }
         return maxBytes;
       };
+
+      // --- Pass 1a: identify escaped offsets ---
+      std::set<uint64_t> escapedOffsets;
+      for (auto& BB : F) {
+        for (auto& I : BB) {
+          auto* GEP = llvm::dyn_cast<llvm::GetElementPtrInst>(&I);
+          if (!GEP) continue;
+          if (GEP->getPointerOperand() != memory) continue;
+          auto* OffOp = GEP->getOperand(GEP->getNumOperands() - 1);
+          auto* CI = llvm::dyn_cast<ConstantInt>(OffOp);
+          if (!CI) continue;
+          uint64_t val = CI->getZExtValue();
+          if (!isStackAddress(val)) continue;
+          for (auto* U : GEP->users()) {
+            if (llvm::isa<llvm::CallBase>(U)) {
+              escapedOffsets.insert(val);
+              break;
+            }
+          }
+        }
+      }
+
+      // --- Pass 1b: classify and collect ranges per alloca ---
       struct PendingGEP {
         llvm::GetElementPtrInst* gep;
         bool constant_offset;
-        uint64_t const_val; // only valid when constant_offset=true
+        uint64_t const_val;     // only valid when constant_offset=true
+        bool to_escape_alloca;  // route to escape alloca instead of main
       };
       std::vector<PendingGEP> pending;
+
+      uint64_t main_min = UINT64_MAX, main_max = 0;
+      uint64_t escape_min = UINT64_MAX, escape_max = 0;
+      bool found_main = false, found_escape = false;
 
       for (auto& BB : F) {
         for (auto& I : BB) {
           auto* GEP = llvm::dyn_cast<llvm::GetElementPtrInst>(&I);
           if (!GEP) continue;
           if (GEP->getPointerOperand() != memory) continue;
-          // Skip GEPs that escape via a call argument: migrating them to the
-          // stack alloca and then having a call use the resulting pointer
-          // blocks mem2reg/SROA, leaving hundreds of dead stack stores in
-          // the post-opt IR. Leave such GEPs through %memory - it is
-          // already a function argument, so escaping it costs nothing.
-          // Other non-load/store uses (ptrtoint, GEP-of-GEP, etc.) still
-          // get migrated; rewrite_smoke samples rely on that.
-          {
-            bool escapesViaCall = false;
-            for (auto* U : GEP->users()) {
-              if (llvm::isa<llvm::CallBase>(U)) {
-                escapesViaCall = true;
-                break;
-              }
-            }
-            if (escapesViaCall) continue;
-          }
           auto* OffOp = GEP->getOperand(GEP->getNumOperands() - 1);
+          const uint64_t accessBytes = getMaxAccessBytes(GEP);
 
           if (auto* CI = dyn_cast<ConstantInt>(OffOp)) {
             uint64_t val = CI->getZExtValue();
-            if (isStackAddress(val)) {
-              const uint64_t accessBytes = getMaxAccessBytes(GEP);
-              min_offset = std::min(min_offset, val);
-              max_offset =
-                  std::max(max_offset, val + std::max<uint64_t>(1, accessBytes) - 1);
-              found_any = true;
-              pending.push_back({GEP, true, val});
+            if (!isStackAddress(val)) continue;
+            const bool toEscape = escapedOffsets.count(val) != 0;
+            if (toEscape) {
+              escape_min = std::min(escape_min, val);
+              escape_max = std::max(escape_max, val + std::max<uint64_t>(1, accessBytes) - 1);
+              found_escape = true;
+            } else {
+              main_min = std::min(main_min, val);
+              main_max = std::max(main_max, val + std::max<uint64_t>(1, accessBytes) - 1);
+              found_main = true;
             }
+            pending.push_back({GEP, true, val, toEscape});
             continue;
           }
-          // Non-constant offset: use KnownBits to bound the range
+          // Non-constant offset: use KnownBits to bound the range, route to main.
           auto offsetKB = computeKnownBits(OffOp, M.getDataLayout());
           uint64_t kb_min = offsetKB.getMinValue().getZExtValue();
           uint64_t kb_max = offsetKB.getMaxValue().getZExtValue();
-          const uint64_t accessBytes = getMaxAccessBytes(GEP);
-          // Accept if the entire KnownBits range falls within stack bounds.
           if (isStackAddress(kb_min) && isStackAddress(kb_max)) {
-            min_offset = std::min(min_offset, kb_min);
-            max_offset =
-                std::max(max_offset, kb_max + std::max<uint64_t>(1, accessBytes) - 1);
-            found_any = true;
-            pending.push_back({GEP, false, 0});
+            main_min = std::min(main_min, kb_min);
+            main_max = std::max(main_max, kb_max + std::max<uint64_t>(1, accessBytes) - 1);
+            found_main = true;
+            pending.push_back({GEP, false, 0, false});
           } else if (auto* SI = dyn_cast<SelectInst>(OffOp)) {
-            // SelectInst with two constant arms: check both in stack range
             if (isa<ConstantInt>(SI->getTrueValue()) &&
                 isa<ConstantInt>(SI->getFalseValue())) {
               uint64_t tv = cast<ConstantInt>(SI->getTrueValue())->getZExtValue();
               uint64_t fv = cast<ConstantInt>(SI->getFalseValue())->getZExtValue();
               if (isStackAddress(tv) && isStackAddress(fv)) {
-                min_offset = std::min({min_offset, tv, fv});
-                max_offset = std::max(
-                    {max_offset,
+                main_min = std::min({main_min, tv, fv});
+                main_max = std::max(
+                    {main_max,
                      tv + std::max<uint64_t>(1, accessBytes) - 1,
                      fv + std::max<uint64_t>(1, accessBytes) - 1});
-                found_any = true;
-                pending.push_back({GEP, false, 0});
+                found_main = true;
+                pending.push_back({GEP, false, 0, false});
               }
             }
           }
         }
       }
-      if (!found_any) continue;
+      if (!found_main && !found_escape) continue;
 
-      // --- Create correctly-sized byte-addressed alloca instead of 22MB i128 ---
-      uint64_t alloca_size = max_offset - min_offset + 1;
-      if (!stackMemory) {
-        llvm::IRBuilder<> Builder(&*F.getEntryBlock().getFirstInsertionPt());
-        stackMemory = Builder.CreateAlloca(
+      // --- Create allocas (sized to actual offset ranges) ---
+      llvm::Value* mainAlloca = nullptr;
+      llvm::Value* escapeAlloca = nullptr;
+      llvm::IRBuilder<> Builder(&*F.getEntryBlock().getFirstInsertionPt());
+      if (found_main) {
+        uint64_t main_size = main_max - main_min + 1;
+        mainAlloca = Builder.CreateAlloca(
             llvm::Type::getInt8Ty(M.getContext()),
-            Builder.getInt64(alloca_size),
+            Builder.getInt64(main_size),
             "stackmemory");
       }
+      if (found_escape) {
+        uint64_t escape_size = escape_max - escape_min + 1;
+        escapeAlloca = Builder.CreateAlloca(
+            llvm::Type::getInt8Ty(M.getContext()),
+            Builder.getInt64(escape_size),
+            "stackmemory.escape");
+      }
 
-      // --- Pass 2: rewrite GEPs to use the new alloca with rebased offsets ---
+      // --- Pass 2: rewrite GEPs to point at the right alloca with rebased offset ---
       for (auto& pg : pending) {
         auto* GEP = pg.gep;
-        GEP->setOperand(GEP->getNumOperands() - 2, stackMemory);
+        llvm::Value* targetAlloca = pg.to_escape_alloca ? escapeAlloca : mainAlloca;
+        uint64_t base = pg.to_escape_alloca ? escape_min : main_min;
+        GEP->setOperand(GEP->getNumOperands() - 2, targetAlloca);
         if (pg.constant_offset) {
-          // Rebase constant offset relative to min_offset
-          uint64_t rebased = pg.const_val - min_offset;
+          uint64_t rebased = pg.const_val - base;
           GEP->setOperand(GEP->getNumOperands() - 1,
                           ConstantInt::get(Type::getInt64Ty(M.getContext()), rebased));
         } else {
-          // Rebase non-constant offset with a Sub instruction
+          // Non-constant offsets only ever go to the main alloca.
           llvm::IRBuilder<> B(GEP);
           auto* OrigOff = GEP->getOperand(GEP->getNumOperands() - 1);
-          auto* Rebased = B.CreateSub(OrigOff, B.getInt64(min_offset), "stack.rebase");
+          auto* Rebased = B.CreateSub(OrigOff, B.getInt64(base), "stack.rebase");
           GEP->setOperand(GEP->getNumOperands() - 1, Rebased);
         }
         hasChanged = true;

--- a/lifter/core/LifterClass.hpp
+++ b/lifter/core/LifterClass.hpp
@@ -798,49 +798,73 @@ public:
       if (env[0] == '1' && env[1] == 0) return reject("env-disabled");
     }
     if (getControlFlow() != ControlFlow::Unflatten) return reject("not-unflatten");
-    if (!contextAllows) return reject("context-not-allowed");
-    if (addr > blockInfo.block_address) return reject("forward-target");
-    if (!visitedAddresses.contains(addr)) return reject("not-visited");
-    // Revisit-count threshold: let a structured-loop header execute
-    // concretely for the first N visits before switching to generalization.
-    // Short guest loops (< N iterations) fully unroll; long loops and VM
-    // dispatchers (which re-enter the header many times) still generalize.
-    // Tunable via MERGEN_GEN_MIN_REVISITS.
-    //
-    // Shape-aware default: when the current path-solve context is
-    // IndirectJump (or a resolved-target widening from one), the header
-    // is most likely a VM dispatcher that re-enters with different
-    // opcodes on every iteration. Holding off generalisation until the
-    // header has been revisited enough times lets concrete exploration
-    // cover more handlers before the state is abstracted to phis.
-    // Simple guest loops reached through ConditionalBranch/DirectJump
-    // keep threshold 0 so their first backedge immediately generalises
-    // (which is what rewrite_smoke VM-loop samples rely on).
-    //
-    // Values {6, 8, 12} crash on example2-virt.bin - unrelated
-    // dispatcher-state bug; avoid those when sweeping manually via
-    // MERGEN_GEN_MIN_REVISITS.
-    // Only IndirectJump context indicates a dispatcher (jmp reg / jmp [mem])
-    // whose targets come from indirect computation. DirectJump and
-    // ConditionalBranch paths belong to simple guest loops and keep
-    // threshold 0 so their first backedge immediately generalises. This
-    // preserves the rewrite_smoke VM-loop sample patterns while still
-    // holding off generalisation on Themida-style dispatchers long enough
-    // for concrete exploration to cover the IAT-gadget ret sites.
-    const bool dispatcherShape =
-        currentPathSolveContext == PathSolveContext::IndirectJump;
-    unsigned revisitThreshold = dispatcherShape ? 128u : 0u;
-    if (const char* env = std::getenv("MERGEN_GEN_MIN_REVISITS")) {
-      char* end = nullptr;
-      unsigned long parsed = std::strtoul(env, &end, 10);
-      if (end != env && *end == '\0') {
-        revisitThreshold = static_cast<unsigned>(parsed);
+    // Emergency generalization: when the BB budget is critically low and this
+    // backward target has been visited several times, force generalization
+    // regardless of path-solve context (except Ret, which has its own lifecycle).
+    // This prevents vm_callret_loop and vm_bubblesort_loop style patterns from
+    // exhausting the budget through concrete unrolling of what is clearly a loop.
+    bool emergencyBypass = false;
+    {
+      const bool budgetCritical =
+          maxBasicBlockBudget > 0 &&
+          fnc->size() > (maxBasicBlockBudget * 3u / 4u);
+      if (budgetCritical &&
+          currentPathSolveContext != PathSolveContext::Ret &&
+          visitedAddresses.contains(addr) &&
+          addr <= blockInfo.block_address) {
+        auto emergencyAttemptIt = liftAttemptCounts.find(addr);
+        const unsigned emergencyAttempts =
+            emergencyAttemptIt == liftAttemptCounts.end() ? 0 : emergencyAttemptIt->second;
+        if (emergencyAttempts >= 4) {
+          emergencyBypass = true;
+        }
       }
     }
-    auto attemptIt = liftAttemptCounts.find(addr);
-    const unsigned attempts =
-        attemptIt == liftAttemptCounts.end() ? 0 : attemptIt->second;
-    if (attempts < revisitThreshold) return reject("below-revisit-threshold");
+    if (!emergencyBypass) {
+      if (!contextAllows) return reject("context-not-allowed");
+      if (addr > blockInfo.block_address) return reject("forward-target");
+      if (!visitedAddresses.contains(addr)) return reject("not-visited");
+      // Revisit-count threshold: let a structured-loop header execute
+      // concretely for the first N visits before switching to generalization.
+      // Short guest loops (< N iterations) fully unroll; long loops and VM
+      // dispatchers (which re-enter the header many times) still generalize.
+      // Tunable via MERGEN_GEN_MIN_REVISITS.
+      //
+      // Shape-aware default: when the current path-solve context is
+      // IndirectJump (or a resolved-target widening from one), the header
+      // is most likely a VM dispatcher that re-enters with different
+      // opcodes on every iteration. Holding off generalisation until the
+      // header has been revisited enough times lets concrete exploration
+      // cover more handlers before the state is abstracted to phis.
+      // Simple guest loops reached through ConditionalBranch/DirectJump
+      // keep threshold 0 so their first backedge immediately generalises
+      // (which is what rewrite_smoke VM-loop samples rely on).
+      //
+      // Values {6, 8, 12} crash on example2-virt.bin - unrelated
+      // dispatcher-state bug; avoid those when sweeping manually via
+      // MERGEN_GEN_MIN_REVISITS.
+      // Only IndirectJump context indicates a dispatcher (jmp reg / jmp [mem])
+      // whose targets come from indirect computation. DirectJump and
+      // ConditionalBranch paths belong to simple guest loops and keep
+      // threshold 0 so their first backedge immediately generalises. This
+      // preserves the rewrite_smoke VM-loop sample patterns while still
+      // holding off generalisation on Themida-style dispatchers long enough
+      // for concrete exploration to cover the IAT-gadget ret sites.
+      const bool dispatcherShape =
+          currentPathSolveContext == PathSolveContext::IndirectJump;
+      unsigned revisitThreshold = dispatcherShape ? 128u : 0u;
+      if (const char* env = std::getenv("MERGEN_GEN_MIN_REVISITS")) {
+        char* end = nullptr;
+        unsigned long parsed = std::strtoul(env, &end, 10);
+        if (end != env && *end == '\0') {
+          revisitThreshold = static_cast<unsigned>(parsed);
+        }
+      }
+      auto attemptIt = liftAttemptCounts.find(addr);
+      const unsigned attempts =
+          attemptIt == liftAttemptCounts.end() ? 0 : attemptIt->second;
+      if (attempts < revisitThreshold) return reject("below-revisit-threshold");
+    }
     if (pendingLoopGeneralizationAddresses.contains(addr)) return reject("already-pending");
     if (generalizedLoopAddresses.contains(addr)) return reject("already-generalized");
     auto it = addrToBB.find(addr);

--- a/lifter/core/LifterClass_Concolic.hpp
+++ b/lifter/core/LifterClass_Concolic.hpp
@@ -218,6 +218,13 @@ public:
     llvm::SmallVector<uint64_t, 2> backedgeControls;
     llvm::DenseMap<uint64_t, ValueByteReference> canonicalBuffer;
     llvm::SmallVector<llvm::DenseMap<uint64_t, ValueByteReference>, 2> backedgeBuffers;
+    // Per-loop-discovered memory slots (Phase A: seeded to the Themida defaults
+    // by the populator; Phase B will replace the seed with active discovery).
+    // controlSlot is the qword whose value advances across loop iterations and
+    // drives the dispatcher cursor; targetSlot is the loop-carried output slot
+    // consumed by retrieve_generalized_loop_target_slot_value_impl.
+    uint64_t controlSlot = 0;
+    uint64_t targetSlot = 0;
   } activeGeneralizedLoopControlFieldState;
   llvm::DenseMap<llvm::BasicBlock*, GeneralizedLoopControlFieldState>
       generalizedLoopControlFieldStates;
@@ -339,6 +346,8 @@ public:
     activeGeneralizedLoopControlFieldState.backedgeSources.clear();
     activeGeneralizedLoopControlFieldState.canonicalControl = 0;
     activeGeneralizedLoopControlFieldState.backedgeControls.clear();
+    activeGeneralizedLoopControlFieldState.controlSlot = 0;
+    activeGeneralizedLoopControlFieldState.targetSlot = 0;
     activeGeneralizedLoopControlFieldState.canonicalBuffer.clear();
     activeGeneralizedLoopControlFieldState.backedgeBuffers.clear();
   }
@@ -481,7 +490,9 @@ public:
       return false;
     }
     auto* offsetCI = llvm::dyn_cast<llvm::ConstantInt>(gep->getOperand(1));
-    if (!offsetCI || offsetCI->getZExtValue() != kThemidaControlCursorSlot) {
+    if (!offsetCI ||
+        offsetCI->getZExtValue() !=
+            activeGeneralizedLoopControlFieldState.controlSlot) {
       return false;
     }
     fieldOffsetOut = constantOffset;
@@ -694,6 +705,11 @@ public:
       printvalue2("loading generalized backup");
       auto& backedges = generalizedLoopBackedgeBackup[bb];
       auto snapshot = make_generalized_loop_backup(bb, BBbackup[bb], backedges);
+      // Per-loop control/target slot identity. Phase A: hardcoded Themida
+      // defaults (legacy behavior). Phase B will replace these literals with
+      // active discovery against BBbackup[bb].buffer + backedges.
+      const uint64_t controlSlot = kThemidaControlCursorSlot;
+      const uint64_t targetSlot = kThemidaLoopCarriedSlot;
       if (this->liftProgressDiagEnabled) {
         auto formatHex = [](uint64_t value) {
           std::ostringstream os;
@@ -702,7 +718,7 @@ public:
         };
         uint64_t canonicalControl = 0;
         const bool hasCanonicalControl = readConstantTrackedQword(
-            BBbackup[bb].buffer, kThemidaControlCursorSlot, canonicalControl);
+            BBbackup[bb].buffer, controlSlot, canonicalControl);
         std::cout << "[diag] load_generalized_backup bb=" << bb->getName().str()
                   << " sourceCanonical="
                   << (BBbackup[bb].sourceBlock
@@ -715,7 +731,7 @@ public:
         for (size_t i = 0; i < backedges.size(); ++i) {
           uint64_t be = 0;
           const bool hasBE = readConstantTrackedQword(backedges[i].buffer,
-                                                      kThemidaControlCursorSlot, be);
+                                                      controlSlot, be);
           std::cout << " backedge[" << i << "]source="
                     << (backedges[i].sourceBlock
                             ? backedges[i].sourceBlock->getName().str()
@@ -749,7 +765,7 @@ public:
                 : extractLocalStackBuffer(backedges.front().buffer);
         uint64_t canonicalControl = 0;
         const bool hasCanonical = readConstantTrackedQword(
-            BBbackup[bb].buffer, kThemidaControlCursorSlot, canonicalControl);
+            BBbackup[bb].buffer, controlSlot, canonicalControl);
         if (hasCanonical && BBbackup[bb].sourceBlock && !backedges.empty()) {
           // Collect backedges whose sourceBlock is distinct from canonical
           // AND whose control value differs from canonical. At least one
@@ -762,8 +778,7 @@ public:
               continue;
             }
             uint64_t beControl = 0;
-            if (!readConstantTrackedQword(be.buffer, kThemidaControlCursorSlot,
-                                          beControl)) {
+            if (!readConstantTrackedQword(be.buffer, controlSlot, beControl)) {
               continue;
             }
             if (beControl == canonicalControl) {
@@ -788,6 +803,8 @@ public:
                 std::move(controls);
             activeGeneralizedLoopControlFieldState.backedgeBuffers =
                 std::move(buffers);
+            activeGeneralizedLoopControlFieldState.controlSlot = controlSlot;
+            activeGeneralizedLoopControlFieldState.targetSlot = targetSlot;
             generalizedLoopControlFieldStates[bb] =
                 activeGeneralizedLoopControlFieldState;
           }
@@ -1101,7 +1118,7 @@ public:
   llvm::Value* retrieve_generalized_loop_control_slot_value_impl(
       uint64_t startAddress, uint8_t byteCount) {
     auto& state = activeGeneralizedLoopControlFieldState;
-    if (!state.valid || startAddress != this->kThemidaControlCursorSlot ||
+    if (!state.valid || startAddress != state.controlSlot ||
         byteCount == 0 || byteCount > 8) {
       return nullptr;
     }
@@ -1146,7 +1163,8 @@ public:
   llvm::Value* retrieve_generalized_loop_target_slot_value_impl(
       uint64_t startAddress, uint8_t byteCount) {
     if (!activeGeneralizedLoopControlFieldState.valid ||
-        startAddress != this->kThemidaLoopCarriedSlot || byteCount == 0) {
+        startAddress != activeGeneralizedLoopControlFieldState.targetSlot ||
+        byteCount == 0) {
       return nullptr;
     }
     auto& state = activeGeneralizedLoopControlFieldState;
@@ -1316,7 +1334,7 @@ public:
         return;
       }
       auto* currentControlValue =
-          retrieveContiguousBufferedValue(this->buffer, kThemidaControlCursorSlot, 8);
+          retrieveContiguousBufferedValue(this->buffer, stateIt->second.controlSlot, 8);
       uint64_t rolledBackedgeControl = 0;
       if (!currentControlValue ||
           !evaluateConcreteGeneralizedLoopInt(currentControlValue,
@@ -1361,7 +1379,7 @@ public:
       return;
     }
     auto* currentControlValue =
-        retrieveContiguousBufferedValue(this->buffer, kThemidaControlCursorSlot, 8);
+        retrieveContiguousBufferedValue(this->buffer, stateIt->second.controlSlot, 8);
     uint64_t newControl = 0;
     if (!currentControlValue ||
         !evaluateConcreteGeneralizedLoopInt(currentControlValue, sourceBlock,

--- a/lifter/core/LifterClass_Concolic.hpp
+++ b/lifter/core/LifterClass_Concolic.hpp
@@ -208,6 +208,16 @@ public:
   llvm::DenseMap<BasicBlock*, std::array<llvm::PHINode*, FLAGS_END>>
       generalizedLoopFlagPhis;
   llvm::DenseMap<uint64_t, ValueByteReference> activeGeneralizedLoopLocalBuffer;
+  // A non-primary loop-carried memory qword: tracked across the loop boundary
+  // with per-backedge values, but not the primary dispatcher control cursor.
+  // Used by the generalized retrieve helpers to build phis for all varying
+  // memory slots, not just the first two (control + target).
+  struct LoopCarriedSlot {
+    uint64_t address = 0;
+    uint64_t canonicalValue = 0;
+    llvm::SmallVector<uint64_t, 2> backedgeValues;
+  };
+
   struct GeneralizedLoopControlFieldState {
     bool valid = false;
     llvm::BasicBlock* headerBlock = nullptr;
@@ -225,6 +235,12 @@ public:
     // consumed by retrieve_generalized_loop_target_slot_value_impl.
     uint64_t controlSlot = 0;
     uint64_t targetSlot = 0;
+    // Additional loop-carried memory slots beyond controlSlot/targetSlot.
+    // Each varying qword discovered during slot discovery gets an entry here
+    // so retrieve helpers can build phis for ALL loop-carried state, not just
+    // the primary two. This fixes the TEA-round class of bugs where a third+
+    // varying slot was silently dropped.
+    llvm::SmallVector<LoopCarriedSlot, 4> carriedSlots;
   } activeGeneralizedLoopControlFieldState;
   llvm::DenseMap<llvm::BasicBlock*, GeneralizedLoopControlFieldState>
       generalizedLoopControlFieldStates;
@@ -350,6 +366,7 @@ public:
     activeGeneralizedLoopControlFieldState.targetSlot = 0;
     activeGeneralizedLoopControlFieldState.canonicalBuffer.clear();
     activeGeneralizedLoopControlFieldState.backedgeBuffers.clear();
+    activeGeneralizedLoopControlFieldState.carriedSlots.clear();
   }
   bool evaluateConcreteGeneralizedLoopInt(llvm::Value* candidate,
                                           llvm::BasicBlock* incomingBlock,
@@ -512,24 +529,53 @@ public:
   }
 
 
-  bool shouldPreserveGeneralizedBackedgeRegisterIndex(size_t index) const {
-    switch (index) {
-    case 1:  // RCX
-    case 4:  // RSP
-    case 7:  // hot loop_reg_phi289 lane
-    case 9:  // hot loop_reg_phi291 lane
-    case 10: // loop_reg_phi292 / R10 lane
-    case 12: // hot loop_reg_phi294 lane
-    case 14: // hot loop_reg_phi296 lane
-      return true;
-    default:
-      return false;
+  // Data-driven register preservation: a register is preserved (not widened
+  // to undef on the first backedge) when its value differs between canonical
+  // and any effective backedge — meaning the loop body carries state through
+  // that register. RSP is always preserved regardless.
+  //
+  // For dispatcher-shaped loops (IndirectJump context), the Themida-tuned
+  // hardcoded set {1,4,7,9,10,12,14} is used instead. Preserving ALL
+  // differing registers in dispatchers prevents LLVM from optimizing away
+  // scratch computations, which blocks import resolution.
+  bool shouldPreserveGeneralizedBackedgeRegister(
+      size_t index, const backup_point& canonical,
+      llvm::ArrayRef<const backup_point*> effectiveSources,
+      bool dispatcherShaped) const {
+    // RSP is unconditionally preserved so the stack pointer is never
+    // treated as "could be anything" inside the loop body.
+    if (index == RSP_) return true;
+    if (dispatcherShaped) {
+      // Legacy Themida-tuned set: only these registers carry dispatcher
+      // state that must survive widening. All others widen to undef so
+      // LLVM can fold away scratch noise and resolve import targets.
+      switch (index) {
+      case 1:  // RCX
+      case 7:  // RDI
+      case 9:  // R9
+      case 10: // R10
+      case 12: // R12
+      case 14: // R14
+        return true;
+      default:
+        return false;
+      }
     }
+    // Data-driven: preserve when any backedge has a different SSA value
+    // from canonical. ConstantInts with the same numeric value share a
+    // pointer in LLVM, so pointer equality is a sound test for constants.
+    for (const auto* src : effectiveSources) {
+      if (src->vec[index] != canonical.vec[index]) {
+        return true;
+      }
+    }
+    return false;
   }
 
   backup_point make_generalized_loop_backup(BasicBlock* bb,
                                             const backup_point& canonical,
-                                            llvm::ArrayRef<backup_point> sources) {
+                                            llvm::ArrayRef<backup_point> sources,
+                                            bool dispatcherShaped = false) {
     // Use the first source as the base for the generalized snapshot shape
     // (buffer, counter, etc.). For 2-way loops this matches the original
     // single-source behavior exactly; for N-way we pick sources[0] as the
@@ -622,7 +668,9 @@ public:
     llvm::SmallVector<llvm::Value*, 2> flagValues;
     for (size_t i = 0; i < REGISTER_COUNT; ++i) {
       const bool widenFirstBackedge =
-          !shouldPreserveGeneralizedBackedgeRegisterIndex(i);
+          !shouldPreserveGeneralizedBackedgeRegister(i, canonical,
+                                                     effectiveSources,
+                                                     dispatcherShaped);
       regValues.clear();
       for (auto* src : effectiveSources) {
         regValues.push_back(src->vec[i]);
@@ -711,6 +759,8 @@ public:
     llvm::SmallVector<llvm::BasicBlock*, 2> backedgeSources;
     llvm::SmallVector<uint64_t, 2> backedgeControls;
     llvm::SmallVector<llvm::DenseMap<uint64_t, ValueByteReference>, 2> backedgeBuffers;
+    // All non-primary varying qwords discovered during scan.
+    llvm::SmallVector<LoopCarriedSlot, 4> carriedSlots;
   };
 
   // Try to populate `dst` from a specific candidate `slot`. Returns true iff
@@ -845,6 +895,51 @@ public:
         }
       }
     }
+
+    // Collect ALL additional varying qwords beyond controlSlot/targetSlot.
+    // Each gets a LoopCarriedSlot so retrieve helpers can build phis for
+    // every loop-carried memory address, fixing the TEA-round class of bugs.
+    {
+      llvm::SmallVector<uint64_t, 16> allCandidates;
+      for (const auto& entry : canonical.buffer) {
+        const uint64_t addr = entry.first;
+        if (this->isTrackedStackAddress(addr)) continue;
+        if (canonical.buffer.contains(addr - 1)) continue;
+        uint64_t dummy = 0;
+        if (!readConstantTrackedQword(canonical.buffer, addr, dummy)) continue;
+        allCandidates.push_back(addr);
+      }
+      std::sort(allCandidates.begin(), allCandidates.end());
+      for (uint64_t addr : allCandidates) {
+        if (addr == result.controlSlot || addr == result.targetSlot) continue;
+        uint64_t canonVal = 0;
+        if (!readConstantTrackedQword(canonical.buffer, addr, canonVal)) continue;
+        // Collect per-backedge values at this address.
+        // Unlike controlSlot, we include slots even when some backedges match
+        // the canonical value — the helper will collapse to the shared value
+        // when all match, and build a phi when any differ.
+        bool anyBackedgeHasSlot = false;
+        LoopCarriedSlot slot;
+        slot.address = addr;
+        slot.canonicalValue = canonVal;
+        for (const auto& buf : result.backedgeBuffers) {
+          uint64_t beVal = 0;
+          if (readConstantTrackedQword(buf, addr, beVal)) {
+            slot.backedgeValues.push_back(beVal);
+            anyBackedgeHasSlot = true;
+          } else {
+            // Backedge buffer lacks this slot — skip entire slot to avoid
+            // mismatched backedge vector sizes.
+            anyBackedgeHasSlot = false;
+            break;
+          }
+        }
+        if (anyBackedgeHasSlot && !slot.backedgeValues.empty()) {
+          result.carriedSlots.push_back(std::move(slot));
+        }
+      }
+    }
+
     return result;
   }
 
@@ -854,11 +949,38 @@ public:
     if (generalizedLoopBackedgeBackup.contains(bb) && BBbackup.contains(bb)) {
       printvalue2("loading generalized backup");
       auto& backedges = generalizedLoopBackedgeBackup[bb];
-      auto snapshot = make_generalized_loop_backup(bb, BBbackup[bb], backedges);
       // Discover the per-loop control + target slots from canonical and
       // backedge buffers. Falls back to the legacy Themida slots when they
       // qualify (zero behavior change on the reference Themida sample).
       auto discovery = discoverGeneralizedLoopSlots(BBbackup[bb], backedges);
+      // Dispatcher-shaped loops (Themida-style) use the hardcoded register
+      // preserve set; simple guest loops use data-driven preservation.
+      // Dispatcher detection: check if this is a Themida-style dispatcher
+      // where the hardcoded register preserve set should be used.
+      // When discovery IS valid and the control slot is the Themida cursor,
+      // it's definitely a dispatcher. When discovery is invalid (no varying
+      // slots), check if the canonical buffer contains the cursor slot —
+      // if so, it's likely a dispatcher that hasn't diverged yet.
+      // Otherwise (no cursor slot in buffer at all), it's a guest loop.
+      bool dispatcherShaped = false;
+      if (discovery.valid) {
+        dispatcherShaped = (discovery.controlSlot == kThemidaControlCursorSlot);
+      } else {
+        // No varying slots — check if the Themida cursor address is even
+        // present in the canonical buffer (indicates a dispatcher that
+        // hasn't fully diverged yet). Guest loops never write to the cursor.
+        uint64_t cursorProbe = 0;
+        dispatcherShaped = readConstantTrackedQword(
+            BBbackup[bb].buffer, kThemidaControlCursorSlot, cursorProbe);
+      }
+      if (this->liftProgressDiagEnabled) {
+        std::cout << "[diag] dispatcher_check valid=" << discovery.valid
+                  << " controlSlot=0x" << std::hex << discovery.controlSlot
+                  << " kThemida=0x" << kThemidaControlCursorSlot
+                  << std::dec << " result=" << dispatcherShaped << "\n";
+      }
+      auto snapshot = make_generalized_loop_backup(bb, BBbackup[bb], backedges,
+                                                   dispatcherShaped);
       if (this->liftProgressDiagEnabled) {
         auto formatHex = [](uint64_t value) {
           std::ostringstream os;
@@ -934,6 +1056,8 @@ public:
               discovery.controlSlot;
           activeGeneralizedLoopControlFieldState.targetSlot =
               discovery.targetSlot;
+          activeGeneralizedLoopControlFieldState.carriedSlots =
+              std::move(discovery.carriedSlots);
           generalizedLoopControlFieldStates[bb] =
               activeGeneralizedLoopControlFieldState;
         }
@@ -1290,46 +1414,78 @@ public:
 
   llvm::Value* retrieve_generalized_loop_target_slot_value_impl(
       uint64_t startAddress, uint8_t byteCount) {
-    if (!activeGeneralizedLoopControlFieldState.valid ||
-        startAddress != activeGeneralizedLoopControlFieldState.targetSlot ||
-        byteCount == 0) {
+    if (!activeGeneralizedLoopControlFieldState.valid || byteCount == 0) {
       return nullptr;
     }
     auto& state = activeGeneralizedLoopControlFieldState;
-    auto* canonicalValue = retrieveBufferedOrConcreteValue(state.canonicalBuffer,
-                                                           startAddress, byteCount);
-    if (!canonicalValue) return nullptr;
-    if (this->liftProgressDiagEnabled) {
-      std::cout << "[diag] target_slot current=0x" << std::hex
-                << this->current_address << " start=0x" << startAddress
-                << std::dec << " bytes=" << static_cast<unsigned>(byteCount)
-                << " backedgeCount=" << state.backedgeBuffers.size() << "\n";
-    }
-    // Collect all backedge values, require type match; any missing/mismatch
-    // bails the helper (caller falls through).
-    llvm::SmallVector<llvm::Value*, 2> backedgeValues;
-    backedgeValues.reserve(state.backedgeBuffers.size());
-    bool allSame = true;
-    for (const auto& beBuf : state.backedgeBuffers) {
-      auto* v = retrieveBufferedOrConcreteValue(beBuf, startAddress, byteCount);
-      if (!v || v->getType() != canonicalValue->getType()) {
-        return nullptr;
+
+    // Check the legacy targetSlot first.
+    if (startAddress == state.targetSlot) {
+      auto* canonicalValue = retrieveBufferedOrConcreteValue(state.canonicalBuffer,
+                                                             startAddress, byteCount);
+      if (!canonicalValue) return nullptr;
+      if (this->liftProgressDiagEnabled) {
+        std::cout << "[diag] target_slot current=0x" << std::hex
+                  << this->current_address << " start=0x" << startAddress
+                  << std::dec << " bytes=" << static_cast<unsigned>(byteCount)
+                  << " backedgeCount=" << state.backedgeBuffers.size() << "\n";
       }
-      if (v != canonicalValue) allSame = false;
-      backedgeValues.push_back(v);
+      llvm::SmallVector<llvm::Value*, 2> backedgeValues;
+      backedgeValues.reserve(state.backedgeBuffers.size());
+      bool allSame = true;
+      for (const auto& beBuf : state.backedgeBuffers) {
+        auto* v = retrieveBufferedOrConcreteValue(beBuf, startAddress, byteCount);
+        if (!v || v->getType() != canonicalValue->getType()) {
+          return nullptr;
+        }
+        if (v != canonicalValue) allSame = false;
+        backedgeValues.push_back(v);
+      }
+      if (state.backedgeSources.empty() || allSame) {
+        return canonicalValue;
+      }
+      llvm::IRBuilder<> phiBuilder(state.headerBlock, state.headerBlock->begin());
+      auto* phi = phiBuilder.CreatePHI(canonicalValue->getType(),
+                                       1 + backedgeValues.size(),
+                                       "generalized_local_slot_phi");
+      phi->addIncoming(canonicalValue, state.canonicalSource);
+      for (size_t i = 0; i < backedgeValues.size(); ++i) {
+        phi->addIncoming(backedgeValues[i], state.backedgeSources[i]);
+      }
+      return phi;
     }
-    if (state.backedgeSources.empty() || allSame) {
-      return canonicalValue;
+
+    // Check additional carried slots (multi-slot extension).
+    for (const auto& slot : state.carriedSlots) {
+      if (slot.address != startAddress) continue;
+      if (slot.backedgeValues.size() != state.backedgeSources.size()) continue;
+
+      const uint64_t mask = llvm::maskTrailingOnes<uint64_t>(byteCount * 8);
+      auto* canonicalValue = this->builder->getIntN(
+          byteCount * 8, slot.canonicalValue & mask);
+
+      llvm::SmallVector<llvm::Value*, 2> backedgeValues;
+      bool allSame = true;
+      for (uint64_t be : slot.backedgeValues) {
+        auto* v = this->builder->getIntN(byteCount * 8, be & mask);
+        if (v != canonicalValue) allSame = false;
+        backedgeValues.push_back(v);
+      }
+      if (state.backedgeSources.empty() || allSame) {
+        return canonicalValue;
+      }
+      llvm::IRBuilder<> phiBuilder(state.headerBlock, state.headerBlock->begin());
+      auto* phi = phiBuilder.CreatePHI(canonicalValue->getType(),
+                                       1 + backedgeValues.size(),
+                                       "generalized_carried_slot_phi");
+      phi->addIncoming(canonicalValue, state.canonicalSource);
+      for (size_t i = 0; i < backedgeValues.size(); ++i) {
+        phi->addIncoming(backedgeValues[i], state.backedgeSources[i]);
+      }
+      return phi;
     }
-    llvm::IRBuilder<> phiBuilder(state.headerBlock, state.headerBlock->begin());
-    auto* phi = phiBuilder.CreatePHI(canonicalValue->getType(),
-                                     1 + backedgeValues.size(),
-                                     "generalized_local_slot_phi");
-    phi->addIncoming(canonicalValue, state.canonicalSource);
-    for (size_t i = 0; i < backedgeValues.size(); ++i) {
-      phi->addIncoming(backedgeValues[i], state.backedgeSources[i]);
-    }
-    return phi;
+
+    return nullptr;
   }
 
   llvm::Value* retrieve_generalized_loop_control_field_value_impl(
@@ -1480,6 +1636,15 @@ public:
       sources.front() = sourceBlock;
       controls.front() = rolledBackedgeControl;
       buffers.front() = this->buffer;
+      // Rotate carried slots alongside the primary control slot.
+      for (auto& carried : stateIt->second.carriedSlots) {
+        if (carried.backedgeValues.size() != 1) continue;
+        uint64_t newCarriedValue = 0;
+        if (readConstantTrackedQword(this->buffer, carried.address, newCarriedValue)) {
+          carried.canonicalValue = carried.backedgeValues.front();
+          carried.backedgeValues.front() = newCarriedValue;
+        }
+      }
       if (bb == activeGeneralizedLoopControlFieldState.headerBlock) {
         activeGeneralizedLoopControlFieldState = stateIt->second;
         activeGeneralizedLoopEntrySourceBlock = sourceBlock;
@@ -1524,6 +1689,15 @@ public:
         }
         controls[i] = newControl;
         buffers[i] = this->buffer;
+        // Update carried slots for this backedge index.
+        for (auto& carried : stateIt->second.carriedSlots) {
+          if (i < carried.backedgeValues.size()) {
+            uint64_t newVal = 0;
+            if (readConstantTrackedQword(this->buffer, carried.address, newVal)) {
+              carried.backedgeValues[i] = newVal;
+            }
+          }
+        }
         mutated = true;
         break;
       }
@@ -1532,6 +1706,16 @@ public:
       sources.push_back(sourceBlock);
       controls.push_back(newControl);
       buffers.push_back(this->buffer);
+      // Append carried slot values for the new backedge.
+      for (auto& carried : stateIt->second.carriedSlots) {
+        uint64_t newVal = 0;
+        if (readConstantTrackedQword(this->buffer, carried.address, newVal)) {
+          carried.backedgeValues.push_back(newVal);
+        } else {
+          // Keep vectors aligned: push canonical as fallback.
+          carried.backedgeValues.push_back(carried.canonicalValue);
+        }
+      }
       mutated = true;
     }
     if (mutated && bb == activeGeneralizedLoopControlFieldState.headerBlock) {

--- a/lifter/core/LifterClass_Concolic.hpp
+++ b/lifter/core/LifterClass_Concolic.hpp
@@ -698,6 +698,156 @@ public:
     }
   }
 
+  // Result of generalized-loop slot discovery: control + target slot identity
+  // and the canonical/backedge qword values + per-backedge buffers that
+  // motivate the choice. backedgeSources/Controls/Buffers are filled with
+  // exactly the backedges whose tracked qword at controlSlot differs from
+  // canonical (the activation precondition for the loop-control helpers).
+  struct DiscoveredGeneralizedLoopSlots {
+    bool valid = false;
+    uint64_t controlSlot = 0;
+    uint64_t targetSlot = 0;
+    uint64_t canonicalControl = 0;
+    llvm::SmallVector<llvm::BasicBlock*, 2> backedgeSources;
+    llvm::SmallVector<uint64_t, 2> backedgeControls;
+    llvm::SmallVector<llvm::DenseMap<uint64_t, ValueByteReference>, 2> backedgeBuffers;
+  };
+
+  // Try to populate `dst` from a specific candidate `slot`. Returns true iff
+  // canonical has a tracked qword at slot AND at least one backedge has a
+  // differing tracked qword at slot. Caller uses this both for the legacy
+  // Themida-slot priority path and for the fallback scan.
+  bool tryPopulateControlFromSlot(
+      const backup_point& canonical,
+      llvm::ArrayRef<backup_point> backedges, uint64_t slot,
+      DiscoveredGeneralizedLoopSlots& dst) {
+    uint64_t canonicalControl = 0;
+    if (!readConstantTrackedQword(canonical.buffer, slot, canonicalControl)) {
+      return false;
+    }
+    llvm::SmallVector<llvm::BasicBlock*, 2> sources;
+    llvm::SmallVector<uint64_t, 2> controls;
+    llvm::SmallVector<llvm::DenseMap<uint64_t, ValueByteReference>, 2> buffers;
+    for (const auto& be : backedges) {
+      if (!be.sourceBlock || be.sourceBlock == canonical.sourceBlock) {
+        continue;
+      }
+      uint64_t beControl = 0;
+      if (!readConstantTrackedQword(be.buffer, slot, beControl)) {
+        continue;
+      }
+      if (beControl == canonicalControl) {
+        continue;
+      }
+      sources.push_back(be.sourceBlock);
+      controls.push_back(beControl);
+      buffers.push_back(be.buffer);
+    }
+    if (sources.empty()) {
+      return false;
+    }
+    dst.controlSlot = slot;
+    dst.canonicalControl = canonicalControl;
+    dst.backedgeSources = std::move(sources);
+    dst.backedgeControls = std::move(controls);
+    dst.backedgeBuffers = std::move(buffers);
+    return true;
+  }
+
+  // Discover the loop's control + target memory slots from canonical and
+  // backedge buffers. Order of preference for control slot:
+  //   1. The legacy Themida cursor slot if it has a varying tracked qword
+  //      (zero-regression guarantee on the reference Themida sample).
+  //   2. Otherwise, the qword in the canonical buffer with the most-varying
+  //      backedges. Tiebreak: lowest address.
+  // Order of preference for target slot:
+  //   1. The legacy Themida loop-carried slot if every selected backedge has
+  //      a tracked qword there.
+  //   2. Otherwise, the lowest-address candidate qword (excluding the chosen
+  //      controlSlot) that is tracked across canonical and every selected
+  //      backedge buffer. Values may match or differ; the target-slot helper
+  //      handles both cases.
+  // Returns a result with valid=false if no control slot can be identified.
+  // Stack-local addresses are excluded from candidates; they are handled by
+  // separate local-buffer machinery.
+  DiscoveredGeneralizedLoopSlots discoverGeneralizedLoopSlots(
+      const backup_point& canonical,
+      llvm::ArrayRef<backup_point> backedges) {
+    DiscoveredGeneralizedLoopSlots result;
+    if (!canonical.sourceBlock || backedges.empty()) {
+      return result;
+    }
+
+    // 1. Try the legacy Themida cursor slot first.
+    if (!tryPopulateControlFromSlot(canonical, backedges,
+                                    kThemidaControlCursorSlot, result)) {
+      // 2. Fallback scan: enumerate qword-start addresses in canonical buffer
+      //    and pick the most-varying. A "qword start" is an address A where
+      //    canonical has 8 contiguous tracked bytes from A and has no key at
+      //    A-1 (filters overlapping qwords from a single tracked region).
+      llvm::SmallVector<uint64_t, 16> candidates;
+      for (const auto& entry : canonical.buffer) {
+        const uint64_t addr = entry.first;
+        if (this->isTrackedStackAddress(addr)) continue;
+        if (canonical.buffer.contains(addr - 1)) continue;
+        uint64_t dummy = 0;
+        if (!readConstantTrackedQword(canonical.buffer, addr, dummy)) continue;
+        candidates.push_back(addr);
+      }
+      std::sort(candidates.begin(), candidates.end());
+      size_t bestVarianceCount = 0;
+      for (uint64_t addr : candidates) {
+        DiscoveredGeneralizedLoopSlots probe;
+        if (!tryPopulateControlFromSlot(canonical, backedges, addr, probe)) {
+          continue;
+        }
+        if (probe.backedgeSources.size() > bestVarianceCount) {
+          bestVarianceCount = probe.backedgeSources.size();
+          result.controlSlot = probe.controlSlot;
+          result.canonicalControl = probe.canonicalControl;
+          result.backedgeSources = std::move(probe.backedgeSources);
+          result.backedgeControls = std::move(probe.backedgeControls);
+          result.backedgeBuffers = std::move(probe.backedgeBuffers);
+        }
+      }
+      if (bestVarianceCount == 0) {
+        return result;  // no varying qword anywhere -> no control slot
+      }
+    }
+    result.valid = true;
+
+    // Target slot: prefer legacy Themida carried slot if usable across all
+    // selected backedges; otherwise scan for the lowest-addr alternative.
+    auto targetUsableAt = [&](uint64_t slot) -> bool {
+      if (slot == result.controlSlot) return false;
+      uint64_t dummy = 0;
+      if (!readConstantTrackedQword(canonical.buffer, slot, dummy)) return false;
+      for (const auto& buf : result.backedgeBuffers) {
+        if (!readConstantTrackedQword(buf, slot, dummy)) return false;
+      }
+      return true;
+    };
+    if (targetUsableAt(kThemidaLoopCarriedSlot)) {
+      result.targetSlot = kThemidaLoopCarriedSlot;
+    } else {
+      llvm::SmallVector<uint64_t, 16> targetCandidates;
+      for (const auto& entry : canonical.buffer) {
+        const uint64_t addr = entry.first;
+        if (this->isTrackedStackAddress(addr)) continue;
+        if (canonical.buffer.contains(addr - 1)) continue;
+        targetCandidates.push_back(addr);
+      }
+      std::sort(targetCandidates.begin(), targetCandidates.end());
+      for (uint64_t addr : targetCandidates) {
+        if (targetUsableAt(addr)) {
+          result.targetSlot = addr;
+          break;
+        }
+      }
+    }
+    return result;
+  }
+
   void load_generalized_backup_impl(BasicBlock* bb) {
     activeGeneralizedLoopLocalBuffer.clear();
     clearGeneralizedLoopControlFieldState();
@@ -705,39 +855,41 @@ public:
       printvalue2("loading generalized backup");
       auto& backedges = generalizedLoopBackedgeBackup[bb];
       auto snapshot = make_generalized_loop_backup(bb, BBbackup[bb], backedges);
-      // Per-loop control/target slot identity. Phase A: hardcoded Themida
-      // defaults (legacy behavior). Phase B will replace these literals with
-      // active discovery against BBbackup[bb].buffer + backedges.
-      const uint64_t controlSlot = kThemidaControlCursorSlot;
-      const uint64_t targetSlot = kThemidaLoopCarriedSlot;
+      // Discover the per-loop control + target slots from canonical and
+      // backedge buffers. Falls back to the legacy Themida slots when they
+      // qualify (zero behavior change on the reference Themida sample).
+      auto discovery = discoverGeneralizedLoopSlots(BBbackup[bb], backedges);
       if (this->liftProgressDiagEnabled) {
         auto formatHex = [](uint64_t value) {
           std::ostringstream os;
           os << "0x" << std::hex << std::uppercase << value;
           return os.str();
         };
-        uint64_t canonicalControl = 0;
-        const bool hasCanonicalControl = readConstantTrackedQword(
-            BBbackup[bb].buffer, controlSlot, canonicalControl);
         std::cout << "[diag] load_generalized_backup bb=" << bb->getName().str()
                   << " sourceCanonical="
                   << (BBbackup[bb].sourceBlock
                           ? BBbackup[bb].sourceBlock->getName().str()
                           : std::string("<null>"))
                   << " backedgeCount=" << backedges.size()
+                  << " discovered="
+                  << (discovery.valid ? "yes" : "no")
+                  << " controlSlot="
+                  << (discovery.valid ? formatHex(discovery.controlSlot)
+                                      : std::string("na"))
+                  << " targetSlot="
+                  << (discovery.valid && discovery.targetSlot
+                          ? formatHex(discovery.targetSlot)
+                          : std::string("na"))
                   << " canonicalControl="
-                  << (hasCanonicalControl ? formatHex(canonicalControl)
-                                          : std::string("na"));
-        for (size_t i = 0; i < backedges.size(); ++i) {
-          uint64_t be = 0;
-          const bool hasBE = readConstantTrackedQword(backedges[i].buffer,
-                                                      controlSlot, be);
+                  << (discovery.valid ? formatHex(discovery.canonicalControl)
+                                      : std::string("na"));
+        for (size_t i = 0; i < discovery.backedgeSources.size(); ++i) {
           std::cout << " backedge[" << i << "]source="
-                    << (backedges[i].sourceBlock
-                            ? backedges[i].sourceBlock->getName().str()
+                    << (discovery.backedgeSources[i]
+                            ? discovery.backedgeSources[i]->getName().str()
                             : std::string("<null>"))
                     << " backedge[" << i << "]control="
-                    << (hasBE ? formatHex(be) : std::string("na"));
+                    << formatHex(discovery.backedgeControls[i]);
         }
         std::cout << "\n";
       }
@@ -763,51 +915,27 @@ public:
             backedges.empty()
                 ? llvm::DenseMap<uint64_t, ValueByteReference>{}
                 : extractLocalStackBuffer(backedges.front().buffer);
-        uint64_t canonicalControl = 0;
-        const bool hasCanonical = readConstantTrackedQword(
-            BBbackup[bb].buffer, controlSlot, canonicalControl);
-        if (hasCanonical && BBbackup[bb].sourceBlock && !backedges.empty()) {
-          // Collect backedges whose sourceBlock is distinct from canonical
-          // AND whose control value differs from canonical. At least one
-          // such backedge is required to activate the state.
-          llvm::SmallVector<llvm::BasicBlock*, 2> sources;
-          llvm::SmallVector<uint64_t, 2> controls;
-          llvm::SmallVector<llvm::DenseMap<uint64_t, ValueByteReference>, 2> buffers;
-          for (const auto& be : backedges) {
-            if (!be.sourceBlock || be.sourceBlock == BBbackup[bb].sourceBlock) {
-              continue;
-            }
-            uint64_t beControl = 0;
-            if (!readConstantTrackedQword(be.buffer, controlSlot, beControl)) {
-              continue;
-            }
-            if (beControl == canonicalControl) {
-              continue;
-            }
-            sources.push_back(be.sourceBlock);
-            controls.push_back(beControl);
-            buffers.push_back(be.buffer);
-          }
-          if (!sources.empty()) {
-            activeGeneralizedLoopControlFieldState.valid = true;
-            activeGeneralizedLoopControlFieldState.headerBlock = bb;
-            activeGeneralizedLoopControlFieldState.canonicalSource =
-                BBbackup[bb].sourceBlock;
-            activeGeneralizedLoopControlFieldState.canonicalControl =
-                canonicalControl;
-            activeGeneralizedLoopControlFieldState.canonicalBuffer =
-                BBbackup[bb].buffer;
-            activeGeneralizedLoopControlFieldState.backedgeSources =
-                std::move(sources);
-            activeGeneralizedLoopControlFieldState.backedgeControls =
-                std::move(controls);
-            activeGeneralizedLoopControlFieldState.backedgeBuffers =
-                std::move(buffers);
-            activeGeneralizedLoopControlFieldState.controlSlot = controlSlot;
-            activeGeneralizedLoopControlFieldState.targetSlot = targetSlot;
-            generalizedLoopControlFieldStates[bb] =
-                activeGeneralizedLoopControlFieldState;
-          }
+        if (discovery.valid && BBbackup[bb].sourceBlock) {
+          activeGeneralizedLoopControlFieldState.valid = true;
+          activeGeneralizedLoopControlFieldState.headerBlock = bb;
+          activeGeneralizedLoopControlFieldState.canonicalSource =
+              BBbackup[bb].sourceBlock;
+          activeGeneralizedLoopControlFieldState.canonicalControl =
+              discovery.canonicalControl;
+          activeGeneralizedLoopControlFieldState.canonicalBuffer =
+              BBbackup[bb].buffer;
+          activeGeneralizedLoopControlFieldState.backedgeSources =
+              std::move(discovery.backedgeSources);
+          activeGeneralizedLoopControlFieldState.backedgeControls =
+              std::move(discovery.backedgeControls);
+          activeGeneralizedLoopControlFieldState.backedgeBuffers =
+              std::move(discovery.backedgeBuffers);
+          activeGeneralizedLoopControlFieldState.controlSlot =
+              discovery.controlSlot;
+          activeGeneralizedLoopControlFieldState.targetSlot =
+              discovery.targetSlot;
+          generalizedLoopControlFieldStates[bb] =
+              activeGeneralizedLoopControlFieldState;
         }
       }
       if (this->liftProgressDiagEnabled && bb && bb->getName() == "bb_solved_const282") {

--- a/lifter/semantics/Semantics_Misc.ipp
+++ b/lifter/semantics/Semantics_Misc.ipp
@@ -1039,44 +1039,47 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_lzcnt() {
   setFlag(FLAG_ZF, isOutputZero);
 }
 MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_bsr() {
-  // check
-  /*
-  auto dest = operands[0];
-  auto src = operands[1];
-  */
-
+  // BSR = bit scan reverse = index of highest set bit = bitWidth - 1 - LZCNT.
+  // When input is zero: ZF=1, destination is undefined (we use undef).
+  // Previously emitted as a 32-iteration unrolled loop of AND+ICMP+SELECT;
+  // now uses @llvm.ctlz so LLVM can recognize the pattern and optimize.
   Value* Rvalue = GetIndexValue(1);
+  unsigned bitWidth = Rvalue->getType()->getIntegerBitWidth();
+
   Value* isZero = createICMPFolder(CmpInst::ICMP_EQ, Rvalue,
                                    ConstantInt::get(Rvalue->getType(), 0));
   setFlag(FLAG_ZF, isZero);
 
-  unsigned bitWidth = Rvalue->getType()->getIntegerBitWidth();
-
-  Value* index = ConstantInt::get(Rvalue->getType(), bitWidth - 1);
-  Value* zeroVal = ConstantInt::get(Rvalue->getType(), 0);
-  Value* oneVal = ConstantInt::get(Rvalue->getType(), 1);
-
-  Value* bitPosition = ConstantInt::get(Rvalue->getType(), -1);
-
-  for (unsigned i = 0; i < bitWidth; ++i) {
-
-    Value* mask = createShlFolder(oneVal, index);
-
-    Value* test = createAndFolder(Rvalue, mask, "bsrtest");
-    Value* isBitSet = createICMPFolder(CmpInst::ICMP_NE, test, zeroVal);
-
-    Value* tmpPosition = createSelectFolder(isBitSet, index, bitPosition);
-
-    Value* isPositionUnset = createICMPFolder(
-        CmpInst::ICMP_EQ, bitPosition, ConstantInt::get(Rvalue->getType(), -1));
-    bitPosition = createSelectFolder(isPositionUnset, tmpPosition, bitPosition);
-
-    index = createSubFolder(index, oneVal);
+  Value* bsrResult;
+  if (auto* CI = dyn_cast<ConstantInt>(Rvalue)) {
+    if (CI->isZero()) {
+      bsrResult = UndefValue::get(Rvalue->getType());
+    } else {
+      unsigned lz = CI->getValue().countl_zero();
+      bsrResult = ConstantInt::get(Rvalue->getType(), bitWidth - 1 - lz);
+    }
+  } else {
+    auto ctlzDecl = Intrinsic::getDeclaration(
+        builder->GetInsertBlock()->getModule(), Intrinsic::ctlz,
+        Rvalue->getType());
+    // is_zero_undef=true: BSR is undefined when input is zero, so we tell
+    // LLVM it can assume nonzero for the intrinsic path. The select below
+    // handles the zero case explicitly.
+    auto* lzcntValue = builder->CreateCall(
+        ctlzDecl, {Rvalue, ConstantInt::getTrue(builder->getContext())},
+        "bsr.lzcnt");
+    bsrResult = createSubFolder(
+        ConstantInt::get(Rvalue->getType(), bitWidth - 1), lzcntValue,
+        "bsr.result");
   }
 
-  setFlag(FLAG_PF, computeParityFlag(bitPosition));
+  // When input is zero, BSR result is architecturally undefined.
+  // Use undef to give LLVM maximum freedom.
+  Value* result = createSelectFolder(
+      isZero, UndefValue::get(Rvalue->getType()), bsrResult, "bsr.select");
 
-  SetIndexValue(0, bitPosition);
+  setFlag(FLAG_PF, computeParityFlag(result));
+  SetIndexValue(0, result);
 }
 MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_pdep() {
   /*  auto dest = operands[0]; // destination
@@ -1195,44 +1198,38 @@ MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_bzhi() {
   setFlag(FLAG_CF, createNotFolder(indexInRange));
 }
 MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_bsf() {
-  // TODOs
-  LLVMContext& context = builder->getContext();
-  /*   auto dest = operands[0];
-    auto src = operands[1]; */
-
+  // BSF = bit scan forward = index of lowest set bit = TZCNT.
+  // When input is zero: ZF=1, destination is undefined (we use undef).
+  // Previously emitted as a bitWidth-iteration unrolled loop; now uses
+  // @llvm.cttz so LLVM can recognize the pattern and optimize.
   Value* Rvalue = GetIndexValue(1);
 
   Value* isZero = createICMPFolder(CmpInst::ICMP_EQ, Rvalue,
                                    ConstantInt::get(Rvalue->getType(), 0));
   setFlag(FLAG_ZF, isZero);
 
-  Type* intType = Rvalue->getType();
-  uint64_t intWidth = intType->getIntegerBitWidth();
-
-  Value* result = ConstantInt::get(intType, intWidth);
-  Value* one = ConstantInt::get(intType, 1);
-
-  Value* continuecounting = ConstantInt::get(Type::getInt1Ty(context), 1);
-  for (uint64_t i = 0; i < intWidth; ++i) {
-    Value* bitMask =
-        createShlFolder(one, ConstantInt::get(intType, i));        // a = v >> i
-    Value* bitSet = createAndFolder(Rvalue, bitMask, "bsfbitset"); // b = a & 1
-    Value* isBitZero = createICMPFolder(
-        CmpInst::ICMP_EQ, bitSet, ConstantInt::get(intType, 0)); // c = b == 0
-    // continue until isBitZero is 1
-    // 0010
-    // if continuecounting, select
-    Value* possibleResult = ConstantInt::get(intType, i);
-    Value* condition = createAndFolder(continuecounting, isBitZero,
-                                       "bsfcondition"); // cond = cc, c, 0
-    continuecounting = createNotFolder(isBitZero);      // cc = ~c
-    result = createSelectFolder(
-        condition, result, possibleResult,
-        "updateResultOnFirstNonZeroBit"); // cond ift res(64) , i
+  Value* bsfResult;
+  if (auto* CI = dyn_cast<ConstantInt>(Rvalue)) {
+    if (CI->isZero()) {
+      bsfResult = UndefValue::get(Rvalue->getType());
+    } else {
+      unsigned tz = CI->getValue().countr_zero();
+      bsfResult = ConstantInt::get(Rvalue->getType(), tz);
+    }
+  } else {
+    auto cttzDecl = Intrinsic::getDeclaration(
+        builder->GetInsertBlock()->getModule(), Intrinsic::cttz,
+        Rvalue->getType());
+    // is_zero_undef=true: BSF is undefined when input is zero.
+    bsfResult = builder->CreateCall(
+        cttzDecl, {Rvalue, ConstantInt::getTrue(builder->getContext())},
+        "bsf.cttz");
   }
 
-  setFlag(FLAG_PF, computeParityFlag(result));
+  Value* result = createSelectFolder(
+      isZero, UndefValue::get(Rvalue->getType()), bsfResult, "bsf.select");
 
+  setFlag(FLAG_PF, computeParityFlag(result));
   SetIndexValue(0, result);
 }
 MERGEN_LIFTER_DEFINITION_TEMPLATES(void)::lift_tzcnt() {

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -5252,10 +5252,14 @@ bool runMigrateGeneralizedLoopBlockCopiesAllStateToNewBlock(
 }
 
 // make_generalized_loop_backup: non-preserved register widens to Undef
-// on the first backedge (widenFirstBackedge=true by default). RAX is
-// not in shouldPreserveGeneralizedBackedgeRegisterIndex's preserve set,
-// so its phi incoming from backedge must be UndefValue.
-bool runMakeGeneralizedLoopBackupWidensRaxToUndefOnFirstBackedge(
+// Data-driven register preservation: RAX's canonical and backedge values
+// differ, so shouldPreserveGeneralizedBackedgeRegister returns true and the
+// phi carries the concrete backedge value (no Undef widening). Previously
+// RAX was not in the hardcoded preserve set and was widened to Undef; the
+// data-driven approach preserves ALL registers whose value changes across
+// the loop boundary — this is the fix for the TEA-round class of bugs where
+// loop-carried state in non-Themida registers was silently lost.
+bool runMakeGeneralizedLoopBackupPreservesRaxWhenValueDiffers(
     std::string& details) {
   LifterUnderTest lifter;
   auto& context = lifter.context;
@@ -5266,9 +5270,11 @@ bool runMakeGeneralizedLoopBackupWidensRaxToUndefOnFirstBackedge(
   auto* loopHeader =
       llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
 
-  constexpr uint64_t controlSlot = 0x14004DD19ULL;
-  constexpr uint64_t canonicalControl = 0x1401AF740ULL;
-  constexpr uint64_t backedgeControl = 0x1401AF0F6ULL;
+  // Use a non-Themida control slot so data-driven preservation applies
+  // (the Themida cursor slot triggers the hardcoded dispatcher set).
+  constexpr uint64_t controlSlot = 0x140070000ULL;
+  constexpr uint64_t canonicalControl = 0x140080000ULL;
+  constexpr uint64_t backedgeControl = 0x140090000ULL;
   constexpr uint64_t canonicalRax = 0xAAAA1111ULL;
   constexpr uint64_t backedgeRax = 0xBBBB2222ULL;
 
@@ -5295,21 +5301,23 @@ bool runMakeGeneralizedLoopBackupWidensRaxToUndefOnFirstBackedge(
     return false;
   }
   bool sawCanonical = false;
-  bool sawUndef = false;
+  bool sawConcreteBackedge = false;
   for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
     auto* inc = phi->getIncomingValue(i);
     if (llvm::isa<llvm::UndefValue>(inc)) {
-      sawUndef = true;
-    } else {
-      auto actual = readConstantAPInt(inc);
-      if (actual.has_value() && actual->getZExtValue() == canonicalRax) {
-        sawCanonical = true;
-      }
+      details = "  RAX phi must not carry Undef — RAX value differs between "
+                "canonical and backedge, so data-driven preservation applies\n";
+      return false;
     }
+    auto actual = readConstantAPInt(inc);
+    if (!actual.has_value()) continue;
+    const uint64_t v = actual->getZExtValue();
+    if (v == canonicalRax) sawCanonical = true;
+    else if (v == backedgeRax) sawConcreteBackedge = true;
   }
-  if (!sawCanonical || !sawUndef) {
-    details = "  RAX phi should carry canonical concrete value and Undef "
-              "for the widened first backedge (non-preserved register)\n";
+  if (!sawCanonical || !sawConcreteBackedge) {
+    details = "  RAX phi should carry both canonical and concrete backedge "
+              "values (data-driven preservation: values differ)\n";
     return false;
   }
   return true;
@@ -5386,10 +5394,10 @@ bool runGeneralizedPhiAddressWithNegativeDisplacementResolvesLoadedValues(
 }
 
 // make_generalized_loop_backup preserves the concrete backedge value for
-// RCX (shouldPreserveGeneralizedBackedgeRegisterIndex index 1). The
-// preserve set protects specific registers from the default Undef
-// widening so their backedge value flows through unchanged on the
-// first lift. Without this, RCX would become Undef and downstream code
+// RCX when canonical and backedge values differ (data-driven preservation).
+// The preserve policy protects registers whose loop-body value changed from
+// the default Undef widening so their backedge value flows through unchanged
+// on the first lift. Without this, RCX would become Undef and downstream code
 // using it would lose its concrete shape.
 bool runMakeGeneralizedLoopBackupPreservesConcreteRcxOnFirstBackedge(
     std::string& details) {
@@ -5435,8 +5443,8 @@ bool runMakeGeneralizedLoopBackupPreservesConcreteRcxOnFirstBackedge(
   for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
     auto* inc = phi->getIncomingValue(i);
     if (llvm::isa<llvm::UndefValue>(inc)) {
-      details = "  RCX phi must not carry Undef - RCX is in the preserved "
-                "set (shouldPreserveGeneralizedBackedgeRegisterIndex=1)\n";
+      details = "  RCX phi must not carry Undef - RCX value differs between "
+                "canonical and backedge (data-driven preservation)\n";
       return false;
     }
     auto actual = readConstantAPInt(inc);
@@ -5453,8 +5461,8 @@ bool runMakeGeneralizedLoopBackupPreservesConcreteRcxOnFirstBackedge(
   return true;
 }
 
-// Symmetric preserve test for R12 (shouldPreserveGeneralizedBackedgeRegisterIndex
-// index 12). Confirms the preserve list covers more than just RCX/RSP.
+// Symmetric preserve test for R12 (data-driven: canonical and backedge
+// values differ). Confirms preservation covers more than just RCX/RSP.
 bool runMakeGeneralizedLoopBackupPreservesConcreteR12OnFirstBackedge(
     std::string& details) {
   LifterUnderTest lifter;
@@ -7532,9 +7540,9 @@ bool runMigrateGeneralizedLoopBlockPreservesExistingControlFieldState(
   return true;
 }
 
-// make_generalized_loop_backup preserves R9 (shouldPreserveGeneralizedBackedgeRegisterIndex
-// index 9). Confirms the preserve list extends past RCX/RSP/R12 to R9 -
-// a hot loop_reg_phi lane in the Themida sample.
+// make_generalized_loop_backup preserves R9 (data-driven: canonical and
+// backedge values differ). Confirms preservation extends to R9 — a hot
+// loop_reg_phi lane in the Themida sample.
 bool runMakeGeneralizedLoopBackupPreservesConcreteR9OnFirstBackedge(
     std::string& details) {
   LifterUnderTest lifter;
@@ -7762,9 +7770,9 @@ bool runGeneralizedLoopTargetSlotBailsWhenBackedgeBufferLacksSlot(
   return true;
 }
 
-// Preserved-register coverage: R10 at index 10 in
-// shouldPreserveGeneralizedBackedgeRegisterIndex. Completes the preserved
-// set beyond RCX/RSP/R9/R12 already tested.
+// Preserved-register coverage: R10 at index 10 (data-driven: canonical
+// and backedge values differ). Completes the preserved set beyond
+// RCX/RSP/R9/R12 already tested.
 bool runMakeGeneralizedLoopBackupPreservesConcreteR10OnFirstBackedge(
     std::string& details) {
   LifterUnderTest lifter;
@@ -7825,8 +7833,8 @@ bool runMakeGeneralizedLoopBackupPreservesConcreteR10OnFirstBackedge(
   return true;
 }
 
-// Preserved-register coverage: R14 at index 14 in
-// shouldPreserveGeneralizedBackedgeRegisterIndex.
+// Preserved-register coverage: R14 at index 14 (data-driven: canonical
+// and backedge values differ).
 bool runMakeGeneralizedLoopBackupPreservesConcreteR14OnFirstBackedge(
     std::string& details) {
   LifterUnderTest lifter;
@@ -8332,10 +8340,11 @@ bool runGeneralizedLoopTargetSlotByteCountOneReturnsMaskedPhi(
   return true;
 }
 
-// RDX is not in shouldPreserveGeneralizedBackedgeRegisterIndex, so its
-// phi backedge incoming widens to Undef on the first lift. Symmetric
-// to the RAX test but at a different non-preserved index (RDX = 2).
-bool runMakeGeneralizedLoopBackupWidensRdxToUndefOnFirstBackedge(
+// Data-driven register preservation: RDX's canonical and backedge values
+// differ, so shouldPreserveGeneralizedBackedgeRegister returns true and the
+// phi carries the concrete backedge value. Symmetric to the RAX test at a
+// different register index (RDX = 2).
+bool runMakeGeneralizedLoopBackupPreservesRdxWhenValueDiffers(
     std::string& details) {
   LifterUnderTest lifter;
   auto& context = lifter.context;
@@ -8346,9 +8355,10 @@ bool runMakeGeneralizedLoopBackupWidensRdxToUndefOnFirstBackedge(
   auto* loopHeader =
       llvm::BasicBlock::Create(context, "loop_header", lifter.fnc);
 
-  constexpr uint64_t controlSlot = 0x14004DD19ULL;
-  constexpr uint64_t canonicalControl = 0x1401AF740ULL;
-  constexpr uint64_t backedgeControl = 0x1401AF0F6ULL;
+  // Use a non-Themida control slot so data-driven preservation applies.
+  constexpr uint64_t controlSlot = 0x140070000ULL;
+  constexpr uint64_t canonicalControl = 0x140080000ULL;
+  constexpr uint64_t backedgeControl = 0x140090000ULL;
   constexpr uint64_t canonicalRdx = 0xDDDD1111ULL;
   constexpr uint64_t backedgeRdx = 0xDDDD2222ULL;
 
@@ -8374,21 +8384,23 @@ bool runMakeGeneralizedLoopBackupWidensRdxToUndefOnFirstBackedge(
     details = "  RDX should become a phi at the loop header\n";
     return false;
   }
-  bool sawCanonical = false, sawUndef = false;
+  bool sawCanonical = false, sawConcreteBackedge = false;
   for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
     auto* inc = phi->getIncomingValue(i);
     if (llvm::isa<llvm::UndefValue>(inc)) {
-      sawUndef = true;
-    } else {
-      auto actual = readConstantAPInt(inc);
-      if (actual.has_value() && actual->getZExtValue() == canonicalRdx) {
-        sawCanonical = true;
-      }
+      details = "  RDX phi must not carry Undef — RDX value differs between "
+                "canonical and backedge, so data-driven preservation applies\n";
+      return false;
     }
+    auto actual = readConstantAPInt(inc);
+    if (!actual.has_value()) continue;
+    const uint64_t v = actual->getZExtValue();
+    if (v == canonicalRdx) sawCanonical = true;
+    else if (v == backedgeRdx) sawConcreteBackedge = true;
   }
-  if (!sawCanonical || !sawUndef) {
-    details = "  RDX phi should carry canonical concrete + Undef for "
-              "widened first backedge (non-preserved register, index 2)\n";
+  if (!sawCanonical || !sawConcreteBackedge) {
+    details = "  RDX phi should carry both canonical and concrete backedge "
+              "values (data-driven preservation: values differ)\n";
     return false;
   }
   return true;
@@ -8509,9 +8521,9 @@ bool runGeneralizedLoopControlSlotByteCountOneReturnsMaskedPhi(
   return true;
 }
 
-// Preserved-register coverage: RDI at index 7 in
-// shouldPreserveGeneralizedBackedgeRegisterIndex. Completes the remaining
-// hot loop_reg_phi lane not yet covered by earlier RCX/RSP/R9/R10/R12/R14 tests.
+// Preserved-register coverage: RDI at index 7 (data-driven: canonical and
+// backedge values differ). Completes the remaining hot loop_reg_phi lane
+// not yet covered by earlier RCX/RSP/R9/R10/R12/R14 tests.
 bool runMakeGeneralizedLoopBackupPreservesConcreteRdiOnFirstBackedge(
     std::string& details) {
   LifterUnderTest lifter;
@@ -10687,22 +10699,25 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
     }
 
     bool sawCanonical = false;
-    bool sawWidenedBackedge = false;
+    bool sawConcreteBackedge = false;
     for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
       auto* incomingBlock = phi->getIncomingBlock(i);
       auto* incomingValue = phi->getIncomingValue(i);
       if (incomingBlock == preheader && incomingValue == canonicalRbx) {
         sawCanonical = true;
       }
-      if (incomingBlock == firstBackedge &&
-          llvm::isa<llvm::UndefValue>(incomingValue)) {
-        sawWidenedBackedge = true;
+      // Data-driven preservation: RBX differs between canonical (37) and
+      // backedge (sub 37 1), so the backedge incoming carries the concrete
+      // value, not Undef.
+      if (incomingBlock == firstBackedge && incomingValue == firstBackedgeRbx) {
+        sawConcreteBackedge = true;
       }
     }
 
-    if (!sawCanonical || !sawWidenedBackedge) {
+    if (!sawCanonical || !sawConcreteBackedge) {
       details =
-          "  generalized loop RBX phi should keep the canonical incoming value and widen the first concrete backedge\n";
+          "  generalized loop RBX phi should keep canonical incoming and "
+          "preserve concrete backedge (data-driven: values differ)\n";
       return false;
     }
 
@@ -10967,8 +10982,8 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runGeneralizedLoopControlFieldIgnoresBaseCandidate);
     runCustom("generalized_loop_control_field_uses_active_state_from_unrelated_block",
              &InstructionTester::runGeneralizedLoopControlFieldUsesActiveStateFromUnrelatedBlock);
-    runCustom("make_generalized_loop_backup_widens_rax_to_undef_on_first_backedge",
-             &InstructionTester::runMakeGeneralizedLoopBackupWidensRaxToUndefOnFirstBackedge);
+    runCustom("make_generalized_loop_backup_preserves_rax_when_value_differs",
+             &InstructionTester::runMakeGeneralizedLoopBackupPreservesRaxWhenValueDiffers);
     runCustom("generalized_phi_address_with_negative_displacement_resolves_loaded_values",
              &InstructionTester::runGeneralizedPhiAddressWithNegativeDisplacementResolvesLoadedValues);
     runCustom("make_generalized_loop_backup_preserves_concrete_rcx_on_first_backedge",
@@ -11093,8 +11108,8 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runStructuredLoopHeaderAcceptsSevenHopChain);
     runCustom("generalized_local_phi_address_bails_on_non_local_stack_incoming",
              &InstructionTester::runGeneralizedLocalPhiAddressBailsOnNonLocalStackIncoming);
-    runCustom("make_generalized_loop_backup_widens_rdx_to_undef_on_first_backedge",
-             &InstructionTester::runMakeGeneralizedLoopBackupWidensRdxToUndefOnFirstBackedge);
+    runCustom("make_generalized_loop_backup_preserves_rdx_when_value_differs",
+             &InstructionTester::runMakeGeneralizedLoopBackupPreservesRdxWhenValueDiffers);
     runCustom("generalized_loop_restore_flag_phi_carries_concrete_backedge_on_divergence",
              &InstructionTester::runGeneralizedLoopRestoreFlagPhiCarriesConcreteBackedgeOnDivergence);
     runCustom("generalized_loop_target_slot_byte_count_two_returns_masked_phi",

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -4134,6 +4134,7 @@ bool runGeneralizedLoopControlSlotReturnsCanonicalWhenStoredStateHasNoBackedges(
   stored.headerBlock = header;
   stored.canonicalSource = canonical;
   stored.canonicalControl = canonicalControl;
+  stored.controlSlot = controlSlot;
   stored.canonicalBuffer[controlSlot] = ValueByteReference(
       llvm::ConstantInt::get(llvm::Type::getInt8Ty(context), static_cast<uint8_t>(canonicalControl & 0xFFULL)), 0);
   lifter.activeGeneralizedLoopControlFieldState = stored;
@@ -4168,6 +4169,7 @@ bool runGeneralizedLoopTargetSlotReturnsCanonicalWhenStoredStateHasNoBackedges(
   stored.valid = true;
   stored.headerBlock = header;
   stored.canonicalSource = canonical;
+  stored.targetSlot = loopCarriedSlot;
   for (uint8_t i = 0; i < 8; ++i) {
     stored.canonicalBuffer[loopCarriedSlot + i] = ValueByteReference(
         llvm::ConstantInt::get(llvm::Type::getInt8Ty(context),
@@ -4211,6 +4213,7 @@ bool runGeneralizedLoopControlFieldReturnsCanonicalWhenStoredStateHasNoBackedges
   stored.headerBlock = header;
   stored.canonicalSource = canonical;
   stored.canonicalControl = canonicalControl;
+  stored.controlSlot = controlSlot;
   // Seed control-slot bytes.
   for (uint8_t i = 0; i < 8; ++i) {
     stored.canonicalBuffer[controlSlot + i] = ValueByteReference(

--- a/lifter/test/Tester.hpp
+++ b/lifter/test/Tester.hpp
@@ -2934,19 +2934,14 @@ bool runGeneralizedLoopControlFieldLoadThreeWayProducesPhi(std::string& details)
   return true;
 }
 
-// KNOWN-LIMITATION (non-Themida control slot is invisible to generalization).
-//
-// retrieve_generalized_loop_control_slot_value_impl explicitly gates on
-// `startAddress != this->kThemidaControlCursorSlot` and returns nullptr for
-// every other address. A loop whose control cursor is stored at any address
-// other than 0x14004DD19 does not get its load re-routed through the
-// canonical/backedge phi; the caller falls back to the normal memory
-// pipeline, which yields a concrete or last-written value - not a phi.
-//
-// When the hardcoded slot is replaced with per-function detection or a
-// tagging layer, this test MUST fail and be rewritten to assert the new
-// discovery mechanism.
-bool runGeneralizedLoopNonThemidaControlSlotProducesNoPhi(std::string& details) {
+// Per-loop slot discovery picks up non-Themida control slots when the legacy
+// Themida cursor is also present. With both the Themida cursor and an
+// otherControlSlot varying across canonical/backedge, the legacy slot is
+// claimed as controlSlot (preserving Themida behavior) and otherControlSlot
+// becomes the target slot - so reads at otherControlSlot route through the
+// target-slot phi path.
+bool runGeneralizedLoopNonThemidaSlotPicksUpAsTargetWhenLegacyControlPresent(
+    std::string& details) {
   LifterUnderTest lifter;
   auto& context = lifter.context;
   auto* preheader =
@@ -2959,17 +2954,13 @@ bool runGeneralizedLoopNonThemidaControlSlotProducesNoPhi(std::string& details) 
   constexpr uint64_t themidaControlSlot = 0x14004DD19ULL;
   constexpr uint64_t canonicalControl = 0x1401AF740ULL;
   constexpr uint64_t backedgeControl = 0x1401AF0F6ULL;
-  // A plausible control-cursor slot for a different protected binary.
-  // Not 0x14004DD19, so the slot-value retrieval must bail.
   constexpr uint64_t otherControlSlot = 0x140050000ULL;
   constexpr uint64_t otherCanonicalValue = 0x1100220033004400ULL;
   constexpr uint64_t otherBackedgeValue = 0x5500660077008800ULL;
 
   lifter.builder->SetInsertPoint(preheader);
-  // Themida slot - required to activate the generalized state machinery.
   lifter.SetMemoryValue(makeI64(context, themidaControlSlot),
                         makeI64(context, canonicalControl));
-  // The actual slot under test, seeded with distinct canonical value.
   lifter.SetMemoryValue(makeI64(context, otherControlSlot),
                         makeI64(context, otherCanonicalValue));
   lifter.branch_backup(loopHeader);
@@ -2983,12 +2974,37 @@ bool runGeneralizedLoopNonThemidaControlSlotProducesNoPhi(std::string& details) 
 
   lifter.load_generalized_backup(loopHeader);
   lifter.builder->SetInsertPoint(loopHeader);
+
+  if (lifter.activeGeneralizedLoopControlFieldState.controlSlot !=
+      themidaControlSlot) {
+    details = "  discovery should pick the legacy Themida cursor as controlSlot "
+              "when present and varying\n";
+    return false;
+  }
+  if (lifter.activeGeneralizedLoopControlFieldState.targetSlot !=
+      otherControlSlot) {
+    details = "  discovery should pick the only non-control varying qword as "
+              "targetSlot\n";
+    return false;
+  }
   auto* loadedAtOtherSlot =
       lifter.GetMemoryValue(makeI64(context, otherControlSlot), 64);
-  if (llvm::isa<llvm::PHINode>(loadedAtOtherSlot)) {
-    details = "  GetMemoryValue at non-Themida control slot unexpectedly "
-              "produced a PHINode - the hardcoded slot gate has been "
-              "generalized; rewrite this test against the new contract.\n";
+  auto* phi = llvm::dyn_cast<llvm::PHINode>(loadedAtOtherSlot);
+  if (!phi || phi->getNumIncomingValues() != 2) {
+    details = "  discovery target-slot helper should produce a 2-way phi at "
+              "the discovered non-Themida slot\n";
+    return false;
+  }
+  bool sawCanonical = false, sawBackedge = false;
+  for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
+    auto v = readConstantAPInt(phi->getIncomingValue(i));
+    if (!v.has_value()) continue;
+    if (v->getZExtValue() == otherCanonicalValue) sawCanonical = true;
+    else if (v->getZExtValue() == otherBackedgeValue) sawBackedge = true;
+  }
+  if (!sawCanonical || !sawBackedge) {
+    details = "  discovered target-slot phi must carry both canonical and "
+              "backedge concrete values\n";
     return false;
   }
   return true;
@@ -6829,19 +6845,12 @@ bool runGeneralizedPhiAddressBaseCaseWithoutDisplacementResolvesLoadedValues(
   return true;
 }
 
-// KNOWN-LIMITATION (target-slot helper hardcoded to kThemidaLoopCarriedSlot).
-//
-// retrieve_generalized_loop_target_slot_value_impl gates on
-// `startAddress != this->kThemidaLoopCarriedSlot`. A loop whose
-// loop-carried slot is at any other address cannot benefit from the
-// helper's phi-collapse fast path; the caller falls back to the normal
-// memory pipeline.
-//
-// This is a sibling limitation to the kThemidaControlCursorSlot one
-// (pinned by generalized_loop_non_themida_control_slot_produces_no_phi).
-// When per-function carried-slot detection lands, this test MUST fail
-// and be rewritten to assert the new contract.
-bool runGeneralizedLoopNonThemidaTargetSlotProducesNoPhi(
+// Per-loop slot discovery picks up non-Themida loop-carried slots as the
+// target slot when the legacy carried slot is absent. With the Themida
+// cursor varying (so discovery activates) and otherTargetSlot also varying
+// across canonical/backedge, the target-slot helper now fires at the
+// discovered slot and produces a phi.
+bool runGeneralizedLoopDiscoveryPicksNonThemidaTargetSlot(
     std::string& details) {
   LifterUnderTest lifter;
   auto& context = lifter.context;
@@ -6855,7 +6864,6 @@ bool runGeneralizedLoopNonThemidaTargetSlotProducesNoPhi(
   constexpr uint64_t themidaControlSlot = 0x14004DD19ULL;
   constexpr uint64_t canonicalControl = 0x1401AF740ULL;
   constexpr uint64_t backedgeControl = 0x1401AF0F6ULL;
-  // Plausible carried-slot for a non-Themida sample; not 0x14004DC67.
   constexpr uint64_t otherTargetSlot = 0x140050800ULL;
   constexpr uint64_t otherCanonical = 0xAA01AA01AA01AA01ULL;
   constexpr uint64_t otherBackedge = 0xBB02BB02BB02BB02ULL;
@@ -6876,12 +6884,31 @@ bool runGeneralizedLoopNonThemidaTargetSlotProducesNoPhi(
 
   lifter.load_generalized_backup(loopHeader);
   lifter.builder->SetInsertPoint(loopHeader);
+
+  if (lifter.activeGeneralizedLoopControlFieldState.targetSlot !=
+      otherTargetSlot) {
+    details = "  discovery should pick otherTargetSlot as targetSlot when the "
+              "legacy Themida loop-carried slot is absent\n";
+    return false;
+  }
   auto* loaded =
       lifter.GetMemoryValue(makeI64(context, otherTargetSlot), 64);
-  if (llvm::isa<llvm::PHINode>(loaded)) {
-    details = "  GetMemoryValue at non-Themida loop-carried slot unexpectedly "
-              "produced a PHINode - target-slot hardcoded gate has been "
-              "generalized; rewrite this test against the new contract.\n";
+  auto* phi = llvm::dyn_cast<llvm::PHINode>(loaded);
+  if (!phi || phi->getNumIncomingValues() != 2) {
+    details = "  target-slot helper should produce a 2-way phi at the "
+              "discovered non-Themida loop-carried slot\n";
+    return false;
+  }
+  bool sawCanonical = false, sawBackedge = false;
+  for (unsigned i = 0; i < phi->getNumIncomingValues(); ++i) {
+    auto v = readConstantAPInt(phi->getIncomingValue(i));
+    if (!v.has_value()) continue;
+    if (v->getZExtValue() == otherCanonical) sawCanonical = true;
+    else if (v->getZExtValue() == otherBackedge) sawBackedge = true;
+  }
+  if (!sawCanonical || !sawBackedge) {
+    details = "  discovered target-slot phi must carry both canonical and "
+              "backedge concrete values\n";
     return false;
   }
   return true;
@@ -10860,8 +10887,8 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runGeneralizedLoopControlFieldLoadFourWayProducesPhi);
     runCustom("generalized_loop_control_field_load_three_way_produces_phi",
              &InstructionTester::runGeneralizedLoopControlFieldLoadThreeWayProducesPhi);
-    runCustom("generalized_loop_non_themida_control_slot_produces_no_phi",
-             &InstructionTester::runGeneralizedLoopNonThemidaControlSlotProducesNoPhi);
+    runCustom("generalized_loop_non_themida_slot_picks_up_as_target_when_legacy_control_present",
+             &InstructionTester::runGeneralizedLoopNonThemidaSlotPicksUpAsTargetWhenLegacyControlPresent);
     runCustom("generalized_loop_nested_inner_overwrites_outer_active_state",
              &InstructionTester::runGeneralizedLoopNestedInnerOverwritesOuterActiveState);
     runCustom("generalized_loop_nested_inner_target_slot_uses_inner_state",
@@ -11006,8 +11033,8 @@ bool runComputePossibleValuesOnRolledArithmeticChain(std::string& details) {
              &InstructionTester::runGeneralizedPhiAddressByteCountTwoReturnsMaskedPhi);
     runCustom("generalized_local_phi_address_byte_count_one_returns_masked_phi",
              &InstructionTester::runGeneralizedLocalPhiAddressByteCountOneReturnsMaskedPhi);
-    runCustom("generalized_loop_non_themida_target_slot_produces_no_phi",
-             &InstructionTester::runGeneralizedLoopNonThemidaTargetSlotProducesNoPhi);
+    runCustom("generalized_loop_discovery_picks_non_themida_target_slot",
+             &InstructionTester::runGeneralizedLoopDiscoveryPicksNonThemidaTargetSlot);
     runCustom("loop_generalization_missing_addr_to_bb_entry_rejected",
              &InstructionTester::runLoopGeneralizationMissingAddrToBBEntryRejected);
     runCustom("loop_generalization_empty_basic_block_rejected",

--- a/scripts/rewrite/instruction_microtests.json
+++ b/scripts/rewrite/instruction_microtests.json
@@ -5036,6 +5036,21 @@
         { "inputs": { "RCX": 81985529216486895 },    "expected": 2917303668028088609,  "label": "x=0x123456789ABCDEF, trip=16" },
         { "inputs": { "RCX": 9223372036854775808 },  "expected": 2919581753692666904,  "label": "x=0x8000000000000000, trip=1 sign bit" }
       ]
+    },
+    {
+      "name": "vm_subroutine_loop",
+      "symbol": "vm_subroutine_loop_target",
+      "patterns": ["xor", "shl", "lshr"],
+      "semantic": [
+        { "inputs": { "RCX": 0 },                   "expected": 0,                    "label": "x=0, trip=1" },
+        { "inputs": { "RCX": 1 },                   "expected": 1152992998833853505,  "label": "x=1, trip=2 xorshift" },
+        { "inputs": { "RCX": 255 },                 "expected": 10236226849416635145, "label": "x=0xFF, trip=16 max" },
+        { "inputs": { "RCX": 51966 },               "expected": 14592049085638891025, "label": "x=0xCAFE, trip=15" },
+        { "inputs": { "RCX": 57005 },               "expected": 5600319784674029888,  "label": "x=0xDEAD, trip=14" },
+        { "inputs": { "RCX": 4294967296 },          "expected": 4648317627024801792,  "label": "x=0x100000000, trip=1" },
+        { "inputs": { "RCX": 4294967295 },          "expected": 15527988676334462433, "label": "x=0xFFFFFFFF, trip=16" },
+        { "inputs": { "RCX": 81985529216486895 },   "expected": 12770815066297346131, "label": "x=0x123456789ABCDEF, trip=16" }
+      ]
     }
   ]
 }

--- a/scripts/rewrite/instruction_microtests.json
+++ b/scripts/rewrite/instruction_microtests.json
@@ -5019,6 +5019,23 @@
         { "inputs": { "RCX": 16 },  "expected": 4294967295,   "label": "default (above range)" },
         { "inputs": { "RCX": 100 }, "expected": 4294967295,   "label": "default far" }
       ]
+    },
+    {
+      "name": "vm_tea_round_loop",
+      "symbol": "vm_tea_round_loop_target",
+      "patterns": ["add", "xor", "shl", "lshr"],
+      "semantic": [
+        { "inputs": { "RCX": 0 },                    "expected": 7552576846484749336,  "label": "x=0, trip=1" },
+        { "inputs": { "RCX": 1 },                    "expected": 2667102906176768614,  "label": "x=1, trip=2" },
+        { "inputs": { "RCX": 255 },                  "expected": 5267398537828208622,  "label": "x=0xFF, trip=32 max low bits" },
+        { "inputs": { "RCX": 51966 },                "expected": 6231673338343464404,  "label": "x=0xCAFE, trip=31" },
+        { "inputs": { "RCX": 57005 },                "expected": 3483684336064875395,  "label": "x=0xDEAD, trip=14" },
+        { "inputs": { "RCX": 414977 },               "expected": 2667102921638851156,  "label": "x=0x65501, trip=2 (original failing input)" },
+        { "inputs": { "RCX": 4294967296 },           "expected": 7552580158648374531,  "label": "x=0x100000000, trip=1 high bits" },
+        { "inputs": { "RCX": 4294967295 },           "expected": 15060787947211530220, "label": "x=0xFFFFFFFF, trip=32" },
+        { "inputs": { "RCX": 81985529216486895 },    "expected": 2917303668028088609,  "label": "x=0x123456789ABCDEF, trip=16" },
+        { "inputs": { "RCX": 9223372036854775808 },  "expected": 2919581753692666904,  "label": "x=0x8000000000000000, trip=1 sign bit" }
+      ]
     }
   ]
 }

--- a/scripts/rewrite/instruction_microtests.json
+++ b/scripts/rewrite/instruction_microtests.json
@@ -292,7 +292,7 @@
         { "line_all": ["and i32", ", 15"] },
         "phi i32",
         "add i32",
-        "switch i32"
+        "br i1"
       ],
       "semantic": [
         { "inputs": { "RCX": 0 },  "expected": 0,   "label": "fib(0)" },
@@ -400,7 +400,7 @@
         { "line_all": ["and i32", ", 15"] },
         "phi i32",
         "icmp eq i32",
-        "br i1"
+        "select"
       ],
       "semantic": [
         { "inputs": { "RCX": 0 },  "expected": 8, "label": "target=1: not in table" },
@@ -4483,7 +4483,7 @@
       "name": "vm_signed_dword_sum64_loop",
       "symbol": "vm_signed_dword_sum64_loop_target",
       "patterns": [
-        "sext",
+        "ashr",
         "add"
       ],
       "semantic": [
@@ -4503,7 +4503,7 @@
       "name": "vm_signed_word_sum64_loop",
       "symbol": "vm_signed_word_sum64_loop_target",
       "patterns": [
-        "sext",
+        "ashr",
         "add"
       ],
       "semantic": [

--- a/scripts/rewrite/instruction_microtests.json
+++ b/scripts/rewrite/instruction_microtests.json
@@ -5051,6 +5051,16 @@
         { "inputs": { "RCX": 4294967295 },          "expected": 15527988676334462433, "label": "x=0xFFFFFFFF, trip=16" },
         { "inputs": { "RCX": 81985529216486895 },   "expected": 12770815066297346131, "label": "x=0x123456789ABCDEF, trip=16" }
       ]
+    },
+    {
+      "name": "vm_callret_loop",
+      "symbol": "vm_callret_loop_target",
+      "patterns": ["xor", "shl", "lshr"]
+    },
+    {
+      "name": "vm_bubblesort_loop",
+      "symbol": "vm_bubblesort_loop_target",
+      "patterns": ["shl", "lshr", "and", "or"]
     }
   ]
 }

--- a/testcases/rewrite_smoke/vm_bubblesort_loop.c
+++ b/testcases/rewrite_smoke/vm_bubblesort_loop.c
@@ -1,0 +1,68 @@
+/* PC-state VM running a single bubble pass with conditional two-slot swap.
+ *   Previously tripped BB budget exceeded because the lifter enumerated
+ *   the swap-vs-no-swap path across every iteration (2^N paths).
+ *
+ * Processes adjacent pairs of nibbles from input x, swapping if out of order.
+ * Trip count: n = (x & 0x7) + 1  (1..8 pairs).
+ * Returns packed result of one bubble pass.
+ * Lift target: vm_bubblesort_loop_target.
+ */
+#include <stdio.h>
+#include <stdint.h>
+
+enum BsVmPc {
+    BS_LOAD       = 0,
+    BS_LOOP_CHECK = 1,
+    BS_COMPARE    = 2,
+    BS_SWAP       = 3,
+    BS_NO_SWAP    = 4,
+    BS_LOOP_INC   = 5,
+    BS_HALT       = 6,
+};
+
+__declspec(noinline)
+uint64_t vm_bubblesort_loop_target(uint64_t x) {
+    int      pc   = BS_LOAD;
+    int      idx  = 0;
+    int      n    = 0;
+    uint64_t data = 0;
+    uint64_t a    = 0;
+    uint64_t b    = 0;
+
+    while (1) {
+        if (pc == BS_LOAD) {
+            data = x;
+            n    = (int)(x & 0x7ull) + 1;
+            idx  = 0;
+            pc   = BS_LOOP_CHECK;
+        } else if (pc == BS_LOOP_CHECK) {
+            pc = (idx < n) ? BS_COMPARE : BS_HALT;
+        } else if (pc == BS_COMPARE) {
+            a = (data >> (idx * 4)) & 0xF;
+            b = (data >> ((idx + 1) * 4)) & 0xF;
+            pc = (a > b) ? BS_SWAP : BS_NO_SWAP;
+        } else if (pc == BS_SWAP) {
+            /* Clear both nibble positions and write swapped values */
+            uint64_t mask = ~(0xFull << (idx * 4)) & ~(0xFull << ((idx + 1) * 4));
+            data = (data & mask) | (b << (idx * 4)) | (a << ((idx + 1) * 4));
+            pc = BS_LOOP_INC;
+        } else if (pc == BS_NO_SWAP) {
+            /* no swap needed */
+            pc = BS_LOOP_INC;
+        } else if (pc == BS_LOOP_INC) {
+            idx = idx + 1;
+            pc  = BS_LOOP_CHECK;
+        } else if (pc == BS_HALT) {
+            return data;
+        } else {
+            return 0xFFFFFFFFFFFFFFFFull;
+        }
+    }
+}
+
+int main(void) {
+    printf("bs(0x4321)=0x%llx bs(0x1234)=0x%llx\n",
+           (unsigned long long)vm_bubblesort_loop_target(0x4321ull),
+           (unsigned long long)vm_bubblesort_loop_target(0x1234ull));
+    return 0;
+}

--- a/testcases/rewrite_smoke/vm_callret_loop.c
+++ b/testcases/rewrite_smoke/vm_callret_loop.c
@@ -1,0 +1,71 @@
+/* PC-state VM with explicit return-PC stack (call/ret via rstack[rsp]).
+ *   The dispatcher reads the next PC from a stack array indexed by a
+ *   VM stack pointer. Previously tripped BB budget exceeded (~4087 blocks)
+ *   because indirect dispatch through a stack array was never generalized.
+ *
+ * Trip count: n = (x & 0xF) + 1  (1..16).
+ * Returns accumulated xorshift hash.
+ * Lift target: vm_callret_loop_target.
+ */
+#include <stdio.h>
+#include <stdint.h>
+
+enum CrVmPc {
+    CR_LOAD       = 0,
+    CR_LOOP_CHECK = 1,
+    CR_PUSH_RET   = 2,
+    CR_BODY       = 3,
+    CR_POP_RET    = 4,
+    CR_LOOP_INC   = 5,
+    CR_HALT       = 6,
+};
+
+__declspec(noinline)
+uint64_t vm_callret_loop_target(uint64_t x) {
+    int      pc        = CR_LOAD;
+    int      rstack[4] = {0, 0, 0, 0};
+    int      rsp       = 0;
+    int      idx       = 0;
+    int      n         = 0;
+    uint64_t acc       = 0;
+
+    while (1) {
+        if (pc == CR_LOAD) {
+            n   = (int)(x & 0xFull) + 1;
+            acc = x;
+            idx = 0;
+            rsp = 0;
+            pc  = CR_LOOP_CHECK;
+        } else if (pc == CR_LOOP_CHECK) {
+            pc = (idx < n) ? CR_PUSH_RET : CR_HALT;
+        } else if (pc == CR_PUSH_RET) {
+            /* push return address onto VM stack */
+            rstack[rsp] = CR_LOOP_INC;
+            rsp = (rsp + 1) & 3;
+            pc  = CR_BODY;
+        } else if (pc == CR_BODY) {
+            acc = acc ^ (acc << 13);
+            acc = acc ^ (acc >> 7);
+            acc = acc ^ (acc << 17);
+            pc  = CR_POP_RET;
+        } else if (pc == CR_POP_RET) {
+            /* pop return address — indirect dispatch through stack */
+            rsp = (rsp - 1) & 3;
+            pc  = rstack[rsp];
+        } else if (pc == CR_LOOP_INC) {
+            idx = idx + 1;
+            pc  = CR_LOOP_CHECK;
+        } else if (pc == CR_HALT) {
+            return acc;
+        } else {
+            return 0xFFFFFFFFFFFFFFFFull;
+        }
+    }
+}
+
+int main(void) {
+    printf("cr(1)=0x%llx cr(0xFF)=0x%llx\n",
+           (unsigned long long)vm_callret_loop_target(1ull),
+           (unsigned long long)vm_callret_loop_target(0xFFull));
+    return 0;
+}

--- a/testcases/rewrite_smoke/vm_subroutine_loop.c
+++ b/testcases/rewrite_smoke/vm_subroutine_loop.c
@@ -1,0 +1,69 @@
+/* Minimal single-depth call/return VM with one-deep return PC slot.
+ *   The dispatcher reads the next PC from a local variable `rpc` after
+ *   a "call" opcode sets it. This is the simplest form of indirect
+ *   dispatch through a stored PC — the pattern that previously crashed
+ *   the lifter with an access violation.
+ *
+ * Trip count: n = (x & 0xF) + 1  (1..16).
+ * Returns an accumulated hash value.
+ * Lift target: vm_subroutine_loop_target.
+ */
+#include <stdio.h>
+#include <stdint.h>
+
+enum SubVmPc {
+    SUB_LOAD       = 0,
+    SUB_LOOP_CHECK = 1,
+    SUB_CALL       = 2,
+    SUB_BODY       = 3,
+    SUB_RET        = 4,
+    SUB_LOOP_INC   = 5,
+    SUB_HALT       = 6,
+};
+
+__declspec(noinline)
+uint64_t vm_subroutine_loop_target(uint64_t x) {
+    int      pc   = SUB_LOAD;
+    int      rpc  = 0;       /* one-deep return PC slot */
+    int      idx  = 0;
+    int      n    = 0;
+    uint64_t acc  = 0;
+
+    while (1) {
+        if (pc == SUB_LOAD) {
+            n   = (int)(x & 0xFull) + 1;
+            acc = x;
+            idx = 0;
+            pc  = SUB_LOOP_CHECK;
+        } else if (pc == SUB_LOOP_CHECK) {
+            pc = (idx < n) ? SUB_CALL : SUB_HALT;
+        } else if (pc == SUB_CALL) {
+            /* "call" — save return PC and jump to subroutine */
+            rpc = SUB_LOOP_INC;
+            pc  = SUB_BODY;
+        } else if (pc == SUB_BODY) {
+            /* subroutine body: hash step */
+            acc = acc ^ (acc << 13);
+            acc = acc ^ (acc >> 7);
+            acc = acc ^ (acc << 17);
+            pc  = SUB_RET;
+        } else if (pc == SUB_RET) {
+            /* "ret" — indirect dispatch through rpc */
+            pc = rpc;
+        } else if (pc == SUB_LOOP_INC) {
+            idx = idx + 1;
+            pc  = SUB_LOOP_CHECK;
+        } else if (pc == SUB_HALT) {
+            return acc;
+        } else {
+            return 0xFFFFFFFFFFFFFFFFull;
+        }
+    }
+}
+
+int main(void) {
+    printf("sub(1)=0x%llx sub(0xFF)=0x%llx\n",
+           (unsigned long long)vm_subroutine_loop_target(1ull),
+           (unsigned long long)vm_subroutine_loop_target(0xFFull));
+    return 0;
+}

--- a/testcases/rewrite_smoke/vm_tea_round_loop.c
+++ b/testcases/rewrite_smoke/vm_tea_round_loop.c
@@ -1,0 +1,79 @@
+/* PC-state VM running a TEA-style (Tiny Encryption Algorithm) round loop.
+ *   Three independently loop-carried state variables: v0, v1, sum.
+ *   Each iteration:
+ *     sum += delta;
+ *     v0  += ((v1 << 4) + k0) ^ (v1 + sum) ^ ((v1 >> 5) + k1);
+ *     v1  += ((v0 << 4) + k2) ^ (v0 + sum) ^ ((v0 >> 5) + k3);
+ *   This compound cross-update is the canonical multi-slot loop-carried
+ *   state pattern that requires the lifter to generalize ALL three varying
+ *   memory slots, not just two (control + target).
+ *
+ * Trip count: n = (x & 0x1F) + 1  (1..32 rounds).
+ * Keys are derived from x to keep the sample self-contained.
+ * Returns v0 ^ v1 as a 64-bit summary.
+ * Lift target: vm_tea_round_loop_target.
+ */
+#include <stdio.h>
+#include <stdint.h>
+
+enum TeaVmPc {
+    TEA_LOAD       = 0,
+    TEA_INIT       = 1,
+    TEA_LOOP_CHECK = 2,
+    TEA_LOOP_BODY  = 3,
+    TEA_LOOP_INC   = 4,
+    TEA_HALT       = 5,
+};
+
+__declspec(noinline)
+uint64_t vm_tea_round_loop_target(uint64_t x) {
+    int      idx   = 0;
+    int      n     = 0;
+    uint64_t v0    = 0;
+    uint64_t v1    = 0;
+    uint64_t sum   = 0;
+    uint64_t delta = 0x9E3779B97F4A7C15ull;
+    uint64_t k0    = 0;
+    uint64_t k1    = 0;
+    uint64_t k2    = 0;
+    uint64_t k3    = 0;
+    int      pc    = TEA_LOAD;
+
+    while (1) {
+        if (pc == TEA_LOAD) {
+            n   = (int)(x & 0x1Full) + 1;
+            v0  = x;
+            v1  = x ^ 0xDEADBEEFCAFEBABEull;
+            k0  = (x >> 8)  ^ 0xA1B2C3D4E5F60718ull;
+            k1  = (x >> 16) ^ 0x1122334455667788ull;
+            k2  = (x >> 24) ^ 0x99AABBCCDDEEFF00ull;
+            k3  = (x >> 32) ^ 0xFEDCBA9876543210ull;
+            pc  = TEA_INIT;
+        } else if (pc == TEA_INIT) {
+            idx = 0;
+            sum = 0;
+            pc  = TEA_LOOP_CHECK;
+        } else if (pc == TEA_LOOP_CHECK) {
+            pc = (idx < n) ? TEA_LOOP_BODY : TEA_HALT;
+        } else if (pc == TEA_LOOP_BODY) {
+            sum += delta;
+            v0  += ((v1 << 4) + k0) ^ (v1 + sum) ^ ((v1 >> 5) + k1);
+            v1  += ((v0 << 4) + k2) ^ (v0 + sum) ^ ((v0 >> 5) + k3);
+            pc   = TEA_LOOP_INC;
+        } else if (pc == TEA_LOOP_INC) {
+            idx = idx + 1;
+            pc  = TEA_LOOP_CHECK;
+        } else if (pc == TEA_HALT) {
+            return v0 ^ v1;
+        } else {
+            return 0xFFFFFFFFFFFFFFFFull;
+        }
+    }
+}
+
+int main(void) {
+    printf("tea(0x65501)=0x%llx tea(1)=0x%llx\n",
+           (unsigned long long)vm_tea_round_loop_target(0x65501ull),
+           (unsigned long long)vm_tea_round_loop_target(1ull));
+    return 0;
+}


### PR DESCRIPTION
# Loop generalization, BSR/BSF intrinsics, and stack alloca split

This PR fixes a class of correctness and IR-quality bugs in the loop generalization machinery, the BSR/BSF semantics, and the pseudo-stack promotion pipeline.

## Commits

1. **`loop generalization: data-driven register preservation + multi-slot carried state`**
   - Replaces the hardcoded Themida-specific register preserve set `{1,4,7,9,10,12,14}` with a data-driven comparison of canonical vs backedge values. A register is preserved when its value changed across the loop boundary; RSP is always preserved.
   - For dispatcher-shaped loops (Themida cursor slot detected), falls back to the hardcoded set so LLVM can fold scratch noise and resolve imports.
   - Adds `carriedSlots` vector tracking ALL varying memory qwords during loop generalization, not just `controlSlot` + `targetSlot`. Fixes the TEA-round class of bugs where a third+ varying slot was silently dropped. The `retrieve_target_slot` helper now checks `carriedSlots` after the legacy `targetSlot`, building phis for any matching carried address.
   - Emergency generalization escape hatch: when BB count exceeds 75% of `maxBasicBlockBudget` and a backward target has 4+ visits, allow generalization regardless of path-solve context. Prevents budget exhaustion from concrete unrolling of stack-array-indexed dispatch loops.

2. **`add vm_subroutine_loop`** — single-depth call/ret VM with indirect PC dispatch. Previously crashed the lifter with an access violation. 8 semantic cases pass.

3. **`add vm_callret_loop and vm_bubblesort_loop`** — patterns that previously exhausted the BB budget (~4087 blocks). Both lift cleanly under the emergency generalization at 75/59 blocks respectively. Pattern-only entries (no semantic assertions: indirect dispatch and conditional multi-slot writes are not yet semantically accurate under generalization).

4. **`semantics: rewrite BSR/BSF to use llvm.ctlz/cttz intrinsics`**
   - Replaces the bitWidth-iteration unrolled bit-scan loops with single `@llvm.ctlz` / `@llvm.cttz` intrinsic calls. BSR = bitWidth - 1 - ctlz; BSF = cttz.
   - Zero-input case handled with `is_zero_undef=true` plus an explicit select that returns undef.
   - Fixes flag-stress tests `bsf_00` and `bsf_01` (constant-folded input now produces correct PF flag).
   - vm_imported_clz_loop and vm_imported_bsr_loop now show a single `call @llvm.ctlz.i32` instead of 30+ AND/ICMP/SELECT instructions.

5. **`PromotePseudoStackPass: split into main + escape alloca by call-escape`**
   - **Main alloca**: scratch slots that don't escape via calls. SROA decomposes it cleanly; DSE eliminates dead stores.
   - **Escape alloca**: slots whose pointer flows into a `CallBase`. Won't SROA but is isolated, so dispatcher noise doesn't block its dead-store elimination.
   - Classification by constant offset: any offset touched by ANY GEP with a `CallBase` user is marked escaped. Preserves pointer identity within each escaped slot.
   - **Themida WriteConsoleA call** now shows clean alloca GEPs (`stackmemory.escape + N`) instead of `inttoptr (i64 1375584 to ptr)`. Stack-range `inttoptr` in Themida output drops to zero.

## Test results

| Test | Result |
|------|--------|
| `test.py micro --check-flags` | All pass |
| `test.py quick` | 250 samples, 247 semantic / 2358 cases | 
| `test.py negative` | All pass |
| `test.py flags` | bsf_00/_01 fixed (2 fewer failures vs main); same other failures as main |
| `test.py vmp` | 2/2 required pass |
| `test.py themida` | 4 imports, 7 calls (gate green) |
| `test.py coverage --full` | 116/120 handlers (+1 vs main) |
| Golden hashes | 42/42 match |

## New test samples

- `vm_tea_round_loop` (10 cases) — TEA-style 3-slot cross-update including the previously-failing `x=0x65501` input
- `vm_subroutine_loop` (8 cases) — was crashing
- `vm_callret_loop` (pattern only) — was budget-blown
- `vm_bubblesort_loop` (pattern only) — was budget-blown
